### PR TITLE
Added missing requirement django-appconf

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 Django>=1.7
 pytz
+django-appconf
 django-bootstrap3
 django-compressor
 BeautifulSoup4


### PR DESCRIPTION
django-appconf is required to run 

```
  python manage syncdb
```
