### PR TITLE
Fixes Typos in the documentation

### DIFF
--- a/doc/development/api/restriction.rst
+++ b/doc/development/api/restriction.rst
@@ -66,12 +66,12 @@ It is sent out with several keyword arguments:
         keys and the ``PropertyValue`` objects are values. If an ``ItemVariation`` object 
         exists, it is available in the dictionary via the special key ``'variation'``. If
         the item does not have any properties, the list will contain exactly one empty
-        dictionary. Please not: this is *not* the list of all possible variations, this is
+        dictionary. Please note: this is *not* the list of all possible variations, this is
         only the list of all variations the frontend likes to determine the status for.
         Technically, you won't get ``dict`` objects but ``tixlbase.types.VariationDict`` 
         objects, which behave exactly the same but add some extra methods.
     ``context``
-        A yet-to-defined context object containing information about the user and the order
+        A yet-to-be-defined context object containing information about the user and the order
         process. This is required to implement coupon-systems or similar restrictions.
     ``cache``
         An object very similar to Django's own caching API (see tip below)

--- a/doc/development/concepts.rst
+++ b/doc/development/concepts.rst
@@ -95,8 +95,8 @@ to do nearly anything, there are a few obvious examples:
   a maximum number. You can use this either to stop selling tickets completely when your house
   is full or for creating limited 'VIP tickets'. We'll come to this again later.
 * A more advanced example is a restriction by user, for example reduced ticket prices for 
-  members who are members of a special group.
-* Arbitrary sophisticated features like coupon codes are also possible to be implemented using 
+  users who are members of a special group.
+* Arbitrary sophisticated features like coupon codes can also be implemented using 
   this feature.
 
 Any number of **restrictions** can be applied to the whole of a **item** or even to a specific 
@@ -139,7 +139,7 @@ special care in the implementation to never sell more tickets than allowed, even
 * The same quota can apply to multiple items and one item can be affected by multiple quotas, to
   enable both of the following features at the same time:
 
-  * You'll want to make sure you never have more then X people at your event, so you'll create a quota
+  * You'll want to make sure you never have more than X people at your event, so you'll create a quota
     applying to all ticket items.
   * You want to reduce the first Y tickets in price, so you'll create a restriction which is bound by
     a quota of Y and reduces the price.

--- a/doc/development/goals.rst
+++ b/doc/development/goals.rst
@@ -9,7 +9,7 @@ Technical goals
 * Python 3.4 features may be used, Python 3.2 is an absolute requirement
 * Use Django 1.7+
 * Be PEP-8 compliant
-* Be fully internationalization, unicode and timezone aware
+* Be fully internationalized, unicode and timezone aware
 * Use a fully documented and reproducible setup
 * Be fully tested by both unit and behaviour tests
 * Use LessCSS

--- a/doc/development/structure.rst
+++ b/doc/development/structure.rst
@@ -7,7 +7,7 @@ Python source code
 All the source code lives in ``src/``, which has several subdirectories.
 
 tixl/
-    This directory contains the basic Django settings and URL routing. It is
+    This directory contains the basic Django settings and URL routing.
 
 tixlbase/
     This is the django app containing all the models and methods which are

--- a/doc/development/style.rst
+++ b/doc/development/style.rst
@@ -35,7 +35,7 @@ LESS stylesheets
 
 * Indent your code with four spaces.
 * Make use of the nesting feature of LESS to put your code in logical groups, but avoid using 
-  more then three levels of nesting.
+  more than three levels of nesting.
 * Put spaces after ``:`` in declarations.
 * Put spaces before ``{`` in rulesets.
 * When grouping selectors, use one line per selector.


### PR DESCRIPTION
Fixed a few typos and some grammar errors.
Also removed the start of an unfinished sentence.
