### PR TITLE
Make mail() raise an exception on obvious failures

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -102,6 +102,19 @@ for example::
     flake8 --ignore=E123,E128,F403,F401,N802,W503 .
 
 
+Working with mails
+^^^^^^^^^^^^^^^^^^
+If you want to test anything regarding emails in your development setup, we recommend
+starting Python's debugging SMTP server in a separate shell and configuring pretix to use it.
+Every email will then be printed to the debugging SMTP server's stdout.
+
+Add this to your ``src/pretix.cfg``::
+
+    [mail]
+    port = 1025
+
+Then execute ``python -m smtpd -n -c DebuggingServer localhost:1025``.
+
 
 Working with the documentation
 ------------------------------

--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -44,8 +44,8 @@ def mail(email: str, subject: str, template: str,
 
     :param locale: The locale to be used while evaluating the subject and the template
 
-    :return: ``False`` on obvious, immediate failures, ``True`` otherwise. ``True`` does not necessarily mean that
-        the email has been sent, just that it has been queued by the email backend.
+    :raises Exception: on obvious, immediate failures. Not raising an exception does not necessarily mean that the
+        email has been sent, just that it has been queued by the email backend.
     """
     with language(locale):
         if isinstance(template, LazyI18nString):
@@ -90,10 +90,9 @@ def mail_send(to: str, subject: str, body: str, sender: str, event: int=None) ->
 
     try:
         backend.send_messages([email])
-        return True
     except Exception:
         logger.exception('Error sending email')
-        return False
+        raise
 
 
 if settings.HAS_CELERY and settings.EMAIL_BACKEND != 'django.core.mail.outbox':


### PR DESCRIPTION
As per #164 

Can be either committed as-is, or I could add error-handling to all `mail()` calls. Not sure how useful this would be, especially since mail errors will be logged regardless. I probably should at least do this for the sendmail plugin?