### PR TITLE
[WIP] Fixes bug in voucher generation for items with variations

### DIFF
--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -68,7 +68,15 @@ class VoucherForm(I18nModelForm):
                 avail = self.instance.variation.check_quotas()
             else:
                 self.instance.variation = None
-                avail = self.instance.item.check_quotas()
+                variations = self.instance.item.variations.all()
+                if variations:
+                    available, count = zip(*[v.check_quotas() for v in variations])
+                    avail = (
+                        Quota.AVAILABILITY_OK if Quota.AVAILABILITY_OK in available else None,
+                        sum(filter(None, count))
+                    )
+                else:
+                    avail = self.instance.item.check_quotas()
             self.instance.quota = None
         else:
             self.instance.quota = Quota.objects.get(pk=quotaid, event=self.instance.event)


### PR DESCRIPTION
Bug was for voucher generation to fail when an item with variations was
chosen.
In items with variations, vouchers will be generated if at least one
variation is still available and the sum of available items is larger
than the amount of vouchers being generated.

It would maybe be worth consideration to make this the implementation of
Item.check_quotas for items with variations.

Refs #170.