### PR TITLE
Add message explaining invoice address updating process (#195)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/order_modify.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order_modify.html
@@ -12,6 +12,12 @@
         {% csrf_token %}
         <div class="panel-group" id="questions_accordion">
             {% if event.settings.invoice_address_asked %}
+                <div class="alert alert-info">
+                    {% blocktrans trimmed %}
+                        Modifying your invoice address will not automatically generate a new invoice.
+                        Please contact us if you need a new invoice.
+                    {% endblocktrans %}
+                </div>
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h4 class="panel-title">

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -264,6 +264,10 @@ class OrderModify(EventViewMixin, OrderDetailMixin, QuestionsViewMixin, Template
             return self.get(request, *args, **kwargs)
         self.invoice_form.save()
         self.order.log_action('pretix.event.order.modified')
+        if self.invoice_form.has_changed():
+            success_message = ('Your invoice address has been updated. Please contact us if you need us '
+                               'to regenerate your invoice.')
+            messages.success(self.request, _(success_message))
         return redirect(self.get_order_url())
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Adds messages both pre- and post-update explaining to the user that the
invoice itself will not be automatically regenerated and that support
interaction is required for this step. Might reduce user frustration. (re: #195)

What this doesn't do

 - it will display "please contact us at None" if no contact email is configured
 - it doesn't display the email as mailto: link

I wasn't sure how to do *both* of these things idiomatically while using translation. Any help appreciated.