### PR TITLE
Export an item's tax_rate in the JSON export

### DIFF
--- a/src/pretix/base/exporters/json.py
+++ b/src/pretix/base/exporters/json.py
@@ -32,6 +32,7 @@ class JSONExporter(BaseExporter):
                         'name': str(item.name),
                         'category': item.category_id,
                         'price': item.default_price,
+                        'tax_rate': item.tax_rate,
                         'admission': item.admission,
                         'active': item.active,
                         'variations': [


### PR DESCRIPTION
This might be required for various depending services; knowing a price without the included tax isn't useful in a lot of places.