### PR TITLE
Reactivate voucher on cancelled orders (#165)

### DIFF
--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from .base import LoggedModel
 from .event import Event
 from .items import Item, ItemVariation, Quota
-from .orders import CartPosition, OrderPosition
+from .orders import CartPosition, Order, OrderPosition
 
 
 def generate_code():

--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -162,10 +162,12 @@ class Voucher(LoggedModel):
 
     def is_ordered(self) -> int:
         """
-        Returns whether an order position exists that uses this voucher.
+        Returns whether a non-canceled order position exists that uses this voucher.
         """
         return OrderPosition.objects.filter(
             voucher=self
+        ).exclude(
+            order__status=Order.STATUS_CANCELLED
         ).exists()
 
     def is_in_cart(self) -> int:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -142,7 +142,7 @@ def cancel_order(order, user=None):
     if isinstance(user, int):
         user = User.objects.get(pk=user)
     with order.event.lock():
-        if order.status not in (Order.STATUS_PENDING, Order.STATUS_EXPIRED):
+        if order.status != Order.STATUS_PENDING:
             raise OrderError(_('You cannot cancel this order.'))
         order.status = Order.STATUS_CANCELLED
         order.save()

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -152,6 +152,11 @@ def cancel_order(order, user=None):
     if i:
         generate_cancellation(i)
 
+    for position in order.positions.all():
+        if position.voucher:
+            position.voucher.redeemed = False
+            position.voucher.save()
+
     return order
 
 

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -295,7 +295,7 @@ class OrderCancel(EventViewMixin, OrderDetailMixin, TemplateView):
         self.kwargs = kwargs
         if not self.order:
             raise Http404(_('Unknown order code or not authorized to access this order.'))
-        if self.order.status not in (Order.STATUS_PENDING, Order.STATUS_EXPIRED) or not self.order.can_user_cancel:
+        if self.order.status != Order.STATUS_PENDING or not self.order.can_user_cancel:
             messages.error(request, _('You cannot cancel this order.'))
             return redirect(self.get_order_url())
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
As discussed in #165, I added a second commit disallowing cancelling expired orders to avoid weird edge cases (and because it makes sense). Supersedes/continues #183.