### PR TITLE
Add a count of elements to pagination elements

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/attendees/index.html
+++ b/src/pretix/control/templates/pretixcontrol/attendees/index.html
@@ -46,6 +46,7 @@
             <button class="btn btn-primary" type="submit">{% trans "Filter" %}</button>
         </form>
         </p>
+        {% include "pretixcontrol/pagination.html" %}
         <div class="table-responsive">
             <table class="table table-condensed table-hover">
                 <thead>

--- a/src/pretix/control/templates/pretixcontrol/events/index.html
+++ b/src/pretix/control/templates/pretixcontrol/events/index.html
@@ -33,6 +33,6 @@
             {% endfor %}
             </tbody>
         </table>
+        {% include "pretixcontrol/pagination.html" %}
     {% endif %}
-    {% include "pretixcontrol/pagination.html" %}
 {% endblock %}

--- a/src/pretix/control/templates/pretixcontrol/orders/index.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/index.html
@@ -56,6 +56,7 @@
             <button class="btn btn-primary" type="submit">{% trans "Filter" %}</button>
         </form>
         </p>
+        {% include "pretixcontrol/pagination.html" %}
         <div class="table-responsive">
             <table class="table table-condensed table-hover">
                 <thead>

--- a/src/pretix/control/templates/pretixcontrol/pagination.html
+++ b/src/pretix/control/templates/pretixcontrol/pagination.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% load urlreplace %}
-{% if is_paginated %}
-    <nav class="text-center">
-        <ul class="pagination">
+<nav class="text-center">
+    <ul class="pagination">
+        {% if is_paginated %}
             {% if page_obj.has_previous %}
                 <li>
                     <a href="?{% url_replace request 'page' page_obj.previous_page_number %}">
@@ -11,8 +11,8 @@
                 </li>
             {% endif %}
             <li class="page-current"><a>
-                {% blocktrans trimmed with page=page_obj.number of=page_obj.paginator.num_pages %}
-                    Page {{ page }} of {{ of }}
+                {% blocktrans trimmed with page=page_obj.number of=page_obj.paginator.num_pages count=page_obj.paginator.count %}
+                    Page {{ page }} of {{ of }} ({{ count }} elements)
                 {% endblocktrans %}
             </a></li>
             {% if page_obj.has_next %}
@@ -22,6 +22,14 @@
                     </a>
                 </li>
             {% endif %}
-        </ul>
-    </nav>
-{% endif %}
+        {% else %}
+        {% if page_obj.paginator.count > 1 %}
+                <li class="page-current"><a>
+                    {% blocktrans trimmed with count=page_obj.paginator.count %}
+                        {{ count }} elements
+                    {% endblocktrans %}
+                </a></li>
+            {% endif %}
+        {% endif %}
+    </ul>
+</nav>


### PR DESCRIPTION
Also, add a second, upper pagination element to orders and attendees
list sites as those tend to get long.