### PR TITLE
Tilt Ordered/Paid Statistics Labels in order to show them all

### DIFF
--- a/src/pretix/plugins/statistics/static/pretixplugins/statistics/statistics.js
+++ b/src/pretix/plugins/statistics/static/pretixplugins/statistics/statistics.js
@@ -31,6 +31,7 @@ $(function () {
         ykeys: ['ordered', 'paid'],
         labels: [gettext('Placed orders'), gettext('Paid orders')],
         barColors: ['#000099', '#009900'],
-        resize: true
+        resize: true,
+        xLabelAngle: 60
     });
 });


### PR DESCRIPTION
Alternative would be to set xLabelMargin to something low - but this
would just cause new problems with very, very long names.