### PR TITLE
remove bundled code from github stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+src/static/fontawesome/* linguist-vendored
+src/static/lightbox/* linguist-vendored
+src/static/typeahead/* linguist-vendored
+src/static/moment/* linguist-vendored


### PR DESCRIPTION
Some external libraries that are bundled in this repository (fontawesome, lightbox, typeahead, moment.js) are not treated as vendored by the github stats. This can be fixed by adding a .gitattributes file. See [Linguist](https://github.com/github/linguist) for details.

Before change
```
50.79%  Python
29.35%  JavaScript
13.43%  HTML
6.23%   CSS
0.10%   Shell
0.08%   Nginx
0.02%   Makefile
```

After change:
```
74.76%  Python
19.77%  HTML
3.45%   CSS
1.74%   JavaScript
0.14%   Shell
0.12%   Nginx
0.03%   Makefile
```