### PR TITLE
Add documentation for voucher tags

### DIFF
--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -48,6 +48,8 @@ class Voucher(LoggedModel):
     :type quota: Quota
     :param comment: An internal comment that will only be visible to staff, and never displayed to the user
     :type comment: str
+	:param tag: Use this field to group multiple vouchers together. If you enter the same value for multiple vouchers, you can get statistics on how many of them have been redeemed etc.
+	:type tag: str
 
     Various constraints apply:
 


### PR DESCRIPTION
Voucher tags were not documented in the help text at the beginning
of the voucher class.
Related to #228