### PR TITLE
Change signature-delimiter for e-mails

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -74,7 +74,7 @@ def mail(email: str, subject: str, template: str,
             if prefix:
                 subject = "[%s] %s" % (prefix, subject)
 
-            body += "\r\n\r\n----\r\n"
+            body += "\r\n\r\n-- \r\n"
             body += _(
                 "You are receiving this email because you placed an order for {event}."
             ).format(event=event.name)


### PR DESCRIPTION
`"-- "` on a single line as a signature-delimiter is noticed by a lot of mail programs out there as an actual signature separator and the text below may be marked that way, e.g. is greyed out a little in Mozilla Thunderbird.

This change should leverage that behavior for e-mails sent by pretix.