### PR TITLE
Unify spelling of 'canceled' - #187

### DIFF
--- a/doc/development/implementation/logging.rst
+++ b/doc/development/implementation/logging.rst
@@ -16,7 +16,7 @@ We recommend all relevant models to inherit from ``LoggedModel`` as it simplifie
 
 To actually log an action, you can just call the ``log_action`` method on your object::
 
-   order.log_action('pretix.event.order.cancelled', user=user, data={})
+   order.log_action('pretix.event.order.canceled', user=user, data={})
 
 The positional ``action`` argument should represent the type of action and should be globally unique, we
 recomment do prefix it with your packagename, e.g. ``paypal.payment.rejected``. The ``user`` argument is
@@ -75,7 +75,7 @@ implementation could look like::
         plains = {
             'pretix.event.order.paid': _('The order has been marked as paid.'),
             'pretix.event.order.refunded': _('The order has been refunded.'),
-            'pretix.event.order.cancelled': _('The order has been cancelled.'),
+            'pretix.event.order.canceled': _('The order has been canceled.'),
             ...
         }
         if logentry.action_type in plains:

--- a/doc/images/order_states.puml
+++ b/doc/images/order_states.puml
@@ -3,16 +3,16 @@
 Pending: Order is expecting payment\nOrder reduces quotas
 Expired: Payment period is over\nOrder does not affect quotas
 Paid: Order was successful\nOrder reduces quotas
-Cancelled: Order has been cancelled\nOrder does not affect quotas
+Canceled: Order has been canceled\nOrder does not affect quotas
 Refunded: Order has been refunded\nOrder does not affect quotas
 
 [*] --> Pending: customer\nplaces order
 Pending --> Paid: successful payment
 Pending --> Expired: automatically\nor manually\non admin action
 Expired --> Paid: if payment is received\nonly if quota left
-Expired --> Cancelled
+Expired --> Canceled
 Paid --> Refunded: manually on\nadmin action\nor if an external\npayment provider\nnotifies about a\npayment refund
-Pending --> Cancelled: on admin or\ncustomer action
+Pending --> Canceled: on admin or\ncustomer action
 Paid -> Pending: manually on admin action
 
 @enduml

--- a/src/pretix/base/models/invoices.py
+++ b/src/pretix/base/models/invoices.py
@@ -29,7 +29,7 @@ class Invoice(models.Model):
     :type invoice_no: int
     :param is_cancellation: Whether or not this is a cancellation instead of an invoice
     :type is_cancellation: bool
-    :param refers: A link to another invoice this invoice refers to, e.g. the cancelled invoice in a cancellation
+    :param refers: A link to another invoice this invoice refers to, e.g. the canceled invoice in a cancellation
     :type refers: Invoice
     :param invoice_from: The sender address
     :type invoice_from: str

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -107,7 +107,7 @@ class Item(LoggedModel):
     :type require_voucher: bool
     :param hide_without_voucher: If set to ``True``, this item is only visible and available when a voucher is used.
     :type hide_without_voucher: bool
-    :param allow_cancel: If set to ``False``, an order with this product can not be cancelled by the user.
+    :param allow_cancel: If set to ``False``, an order with this product can not be canceled by the user.
     :type allow_cancel: bool
     """
 
@@ -192,10 +192,10 @@ class Item(LoggedModel):
                     'code that is specifically tied to this product (and not via a quota).')
     )
     allow_cancel = models.BooleanField(
-        verbose_name=_('Allow product to be cancelled'),
+        verbose_name=_('Allow product to be canceled'),
         default=True,
-        help_text=_('If you deactivate this, an order including this product might not be cancelled by the user. '
-                    'It may still be cancelled by you.')
+        help_text=_('If you deactivate this, an order including this product might not be canceled by the user. '
+                    'It may still be canceled by you.')
     )
 
     class Meta:

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -30,7 +30,7 @@ class Order(LoggedModel):
     An order is created when a user clicks 'buy' on his cart. It holds
     several OrderPositions and is connected to a user. It has an
     expiration date: If items run out of capacity, orders which are over
-    their expiration date might be cancelled.
+    their expiration date might be canceled.
 
     An order -- like all objects -- has an ID, which is globally unique,
     but also a code, which is shorter and easier to memorize, but only
@@ -45,7 +45,7 @@ class Order(LoggedModel):
         * ``STATUS_PENDING``
         * ``STATUS_PAID``
         * ``STATUS_EXPIRED``
-        * ``STATUS_CANCELLED``
+        * ``STATUS_CANCELED``
         * ``STATUS_REFUNDED``
 
     :param event: The event this order belongs to
@@ -81,13 +81,13 @@ class Order(LoggedModel):
     STATUS_PENDING = "n"
     STATUS_PAID = "p"
     STATUS_EXPIRED = "e"
-    STATUS_CANCELLED = "c"
+    STATUS_CANCELED = "c"
     STATUS_REFUNDED = "r"
     STATUS_CHOICE = (
         (STATUS_PENDING, _("pending")),
         (STATUS_PAID, _("paid")),
         (STATUS_EXPIRED, _("expired")),
-        (STATUS_CANCELLED, _("cancelled")),
+        (STATUS_CANCELED, _("canceled")),
         (STATUS_REFUNDED, _("refunded"))
     )
 

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -150,10 +150,10 @@ def cancel_order(order, user=None):
     with order.event.lock():
         if order.status != Order.STATUS_PENDING:
             raise OrderError(_('You cannot cancel this order.'))
-        order.status = Order.STATUS_CANCELLED
+        order.status = Order.STATUS_CANCELED
         order.save()
 
-    order.log_action('pretix.event.order.cancelled', user=user)
+    order.log_action('pretix.event.order.canceled', user=user)
     i = order.invoices.filter(is_cancellation=False).last()
     if i:
         generate_cancellation(i)

--- a/src/pretix/base/services/stats.py
+++ b/src/pretix/base/services/stats.py
@@ -41,10 +41,10 @@ def order_overview(event: Event) -> Tuple[List[Tuple[ItemCategory, List[Item]]],
                   .values('item', 'variation')
                   .annotate(cnt=Count('id'), price=Sum('price')).order_by())
     }
-    num_cancelled = {
+    num_canceled = {
         (p['item'], p['variation']): (p['cnt'], p['price'])
         for p in (OrderPosition.objects
-                  .filter(order__event=event, order__status=Order.STATUS_CANCELLED)
+                  .filter(order__event=event, order__status=Order.STATUS_CANCELED)
                   .values('item', 'variation')
                   .annotate(cnt=Count('id'), price=Sum('price')).order_by())
     }
@@ -79,18 +79,18 @@ def order_overview(event: Event) -> Tuple[List[Tuple[ItemCategory, List[Item]]],
                 variid = var.id
                 var.num_total = num_total.get((item.id, variid), (0, 0))
                 var.num_pending = num_pending.get((item.id, variid), (0, 0))
-                var.num_cancelled = num_cancelled.get((item.id, variid), (0, 0))
+                var.num_canceled = num_canceled.get((item.id, variid), (0, 0))
                 var.num_refunded = num_refunded.get((item.id, variid), (0, 0))
                 var.num_paid = num_paid.get((item.id, variid), (0, 0))
             item.num_total = tuplesum(var.num_total for var in item.all_variations)
             item.num_pending = tuplesum(var.num_pending for var in item.all_variations)
-            item.num_cancelled = tuplesum(var.num_cancelled for var in item.all_variations)
+            item.num_canceled = tuplesum(var.num_canceled for var in item.all_variations)
             item.num_refunded = tuplesum(var.num_refunded for var in item.all_variations)
             item.num_paid = tuplesum(var.num_paid for var in item.all_variations)
         else:
             item.num_total = num_total.get((item.id, None), (0, 0))
             item.num_pending = num_pending.get((item.id, None), (0, 0))
-            item.num_cancelled = num_cancelled.get((item.id, None), (0, 0))
+            item.num_canceled = num_canceled.get((item.id, None), (0, 0))
             item.num_refunded = num_refunded.get((item.id, None), (0, 0))
             item.num_paid = num_paid.get((item.id, None), (0, 0))
 
@@ -112,7 +112,7 @@ def order_overview(event: Event) -> Tuple[List[Tuple[ItemCategory, List[Item]]],
         c[0].num_total = tuplesum(item.num_total for item in c[1])
         print(c[1], c[0].num_total, [item.num_total for item in c[1]])
         c[0].num_pending = tuplesum(item.num_pending for item in c[1])
-        c[0].num_cancelled = tuplesum(item.num_cancelled for item in c[1])
+        c[0].num_canceled = tuplesum(item.num_canceled for item in c[1])
         c[0].num_refunded = tuplesum(item.num_refunded for item in c[1])
         c[0].num_paid = tuplesum(item.num_paid for item in c[1])
 
@@ -127,10 +127,10 @@ def order_overview(event: Event) -> Tuple[List[Tuple[ItemCategory, List[Item]]],
                   .values('payment_provider')
                   .annotate(cnt=Count('id'), payment_fee=Sum('payment_fee')).order_by())
     }
-    num_cancelled = {
+    num_canceled = {
         o['payment_provider']: (o['cnt'], o['payment_fee'])
         for o in (Order.objects
-                  .filter(event=event, status=Order.STATUS_CANCELLED)
+                  .filter(event=event, status=Order.STATUS_CANCELED)
                   .values('payment_provider')
                   .annotate(cnt=Count('id'), payment_fee=Sum('payment_fee')).order_by())
     }
@@ -168,14 +168,14 @@ def order_overview(event: Event) -> Tuple[List[Tuple[ItemCategory, List[Item]]],
         ppobj.provider = provider
         ppobj.has_variations = False
         ppobj.num_total = total
-        ppobj.num_cancelled = num_cancelled.get(pprov, (0, 0))
+        ppobj.num_canceled = num_canceled.get(pprov, (0, 0))
         ppobj.num_refunded = num_refunded.get(pprov, (0, 0))
         ppobj.num_pending = num_pending.get(pprov, (0, 0))
         ppobj.num_paid = num_paid.get(pprov, (0, 0))
         payment_items.append(ppobj)
 
     payment_cat_obj.num_total = (Dontsum(''), sum(i.num_total[1] for i in payment_items))
-    payment_cat_obj.num_cancelled = (Dontsum(''), sum(i.num_cancelled[1] for i in payment_items))
+    payment_cat_obj.num_canceled = (Dontsum(''), sum(i.num_canceled[1] for i in payment_items))
     payment_cat_obj.num_refunded = (Dontsum(''), sum(i.num_refunded[1] for i in payment_items))
     payment_cat_obj.num_pending = (Dontsum(''), sum(i.num_pending[1] for i in payment_items))
     payment_cat_obj.num_paid = (Dontsum(''), sum(i.num_paid[1] for i in payment_items))
@@ -186,7 +186,7 @@ def order_overview(event: Event) -> Tuple[List[Tuple[ItemCategory, List[Item]]],
     total = {
         'num_total': tuplesum(c.num_total for c, i in items_by_category),
         'num_pending': tuplesum(c.num_pending for c, i in items_by_category),
-        'num_cancelled': tuplesum(c.num_cancelled for c, i in items_by_category),
+        'num_canceled': tuplesum(c.num_canceled for c, i in items_by_category),
         'num_refunded': tuplesum(c.num_refunded for c, i in items_by_category),
         'num_paid': tuplesum(c.num_paid for c, i in items_by_category)
     }

--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -53,7 +53,7 @@ def pretixcontrol_logentry_display(sender: Event, logentry: LogEntry, **kwargs):
         'pretix.event.order.expired': _('The order has been marked as expired.'),
         'pretix.event.order.paid': _('The order has been marked as paid.'),
         'pretix.event.order.refunded': _('The order has been refunded.'),
-        'pretix.event.order.cancelled': _('The order has been cancelled.'),
+        'pretix.event.order.canceled': _('The order has been canceled.'),
         'pretix.event.order.placed': _('The order has been created.'),
         'pretix.event.order.invoice.generated': _('The invoice has been generated.'),
         'pretix.event.order.invoice.regenerated': _('The invoice has been regenerated.'),

--- a/src/pretix/control/templates/pretixcontrol/attendees/index.html
+++ b/src/pretix/control/templates/pretixcontrol/attendees/index.html
@@ -31,7 +31,7 @@
                 <option value="p" {% if request.GET.status == "p" %}selected="selected"{% endif %}>{% trans "Paid" %}</option>
                 <option value="n" {% if request.GET.status == "n" %}selected="selected"{% endif %}>{% trans "Pending" %}</option>
                 <option value="e" {% if request.GET.status == "e" %}selected="selected"{% endif %}>{% trans "Pending (expired)" %}</option>
-                <option value="c" {% if request.GET.status == "c" %}selected="selected"{% endif %}>{% trans "Cancelled" %}</option>
+                <option value="c" {% if request.GET.status == "c" %}selected="selected"{% endif %}>{% trans "Canceled" %}</option>
                 <option value="r" {% if request.GET.status == "r" %}selected="selected"{% endif %}>{% trans "Refunded" %}</option>
             </select>
             <select name="item" class="form-control">

--- a/src/pretix/control/templates/pretixcontrol/items/question.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question.html
@@ -21,7 +21,7 @@
                 <option value="o" {% if request.GET.status == "o" %}selected="selected"{% endif %}>{% trans "Pending (overdue)" %}</option>
                 <option value="e" {% if request.GET.status == "e" %}selected="selected"{% endif %}>{% trans "Expired" %}</option>
                 <option value="ne" {% if request.GET.status == "ne" %}selected="selected"{% endif %}>{% trans "Pending or expired" %}</option>
-                <option value="c" {% if request.GET.status == "c" %}selected="selected"{% endif %}>{% trans "Cancelled" %}</option>
+                <option value="c" {% if request.GET.status == "c" %}selected="selected"{% endif %}>{% trans "Canceled" %}</option>
                 <option value="r" {% if request.GET.status == "r" %}selected="selected"{% endif %}>{% trans "Refunded" %}</option>
             </select>
             <select name="item" class="form-control">

--- a/src/pretix/control/templates/pretixcontrol/orders/fragment_order_status.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/fragment_order_status.html
@@ -7,7 +7,7 @@
 {% elif order.status == "e" %} {# expired #}
     <span class="label label-danger {{ class }}">{% trans "Expired" %}</span>
 {% elif order.status == "c" %}
-    <span class="label label-danger {{ class }}">{% trans "Cancelled" %}</span>
+    <span class="label label-danger {{ class }}">{% trans "Canceled" %}</span>
 {% elif order.status == "r" %}
     <span class="label label-danger {{ class }}">{% trans "Refunded" %}</span>
 {% endif %}

--- a/src/pretix/control/templates/pretixcontrol/orders/index.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/index.html
@@ -42,7 +42,7 @@
                 <option value="o" {% if request.GET.status == "o" %}selected="selected"{% endif %}>{% trans "Pending (overdue)" %}</option>
                 <option value="e" {% if request.GET.status == "e" %}selected="selected"{% endif %}>{% trans "Expired" %}</option>
                 <option value="ne" {% if request.GET.status == "ne" %}selected="selected"{% endif %}>{% trans "Pending or expired" %}</option>
-                <option value="c" {% if request.GET.status == "c" %}selected="selected"{% endif %}>{% trans "Cancelled" %}</option>
+                <option value="c" {% if request.GET.status == "c" %}selected="selected"{% endif %}>{% trans "Canceled" %}</option>
                 <option value="r" {% if request.GET.status == "r" %}selected="selected"{% endif %}>{% trans "Refunded" %}</option>
             </select>
             <select name="item" class="form-control">

--- a/src/pretix/control/templates/pretixcontrol/orders/overview.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/overview.html
@@ -19,7 +19,7 @@
                     <th>{% trans "Product" %}</th>
                     <th>{% trans "Total (pending or paid)" %}</th>
                     <th>{% trans "Payment pending" %}</th>
-                    <th>{% trans "Cancelled" %}</th>
+                    <th>{% trans "Canceled" %}</th>
                     <th>{% trans "Refunded" %}</th>
                     <th>{% trans "Paid" %}</th>
                 </tr>
@@ -31,7 +31,7 @@
                             <th>{{ tup.0.name }}</th>
                             <th>{{ tup.0.num_total|togglesum }}</th>
                             <th>{{ tup.0.num_pending|togglesum }}</th>
-                            <th>{{ tup.0.num_cancelled|togglesum }}</th>
+                            <th>{{ tup.0.num_canceled|togglesum }}</th>
                             <th>{{ tup.0.num_refunded|togglesum }}</th>
                             <th>{{ tup.0.num_paid|togglesum }}</th>
                         </tr>
@@ -51,7 +51,7 @@
                             </td>
                             <td>
                                 <a href="{{ listurl }}?item={{ item.id }}&amp;status=c&amp;provider={{ item.provider }}">
-                                    {{ item.num_cancelled|togglesum }}
+                                    {{ item.num_canceled|togglesum }}
                                 </a>
                             </td>
                             <td>
@@ -71,7 +71,7 @@
                                     <td>{{ var }}</td>
                                     <td>{{ var.num_total|togglesum }}</td>
                                     <td>{{ var.num_pending|togglesum }}</td>
-                                    <td>{{ var.num_cancelled|togglesum }}</td>
+                                    <td>{{ var.num_canceled|togglesum }}</td>
                                     <td>{{ var.num_refunded|togglesum }}</td>
                                     <td>{{ var.num_paid|togglesum }}</td>
                                 </tr>
@@ -85,7 +85,7 @@
                     <th>{% trans "Total" %}</th>
                     <th>{{ total.num_total|togglesum }}</th>
                     <th>{{ total.num_pending|togglesum }}</th>
-                    <th>{{ total.num_cancelled|togglesum }}</th>
+                    <th>{{ total.num_canceled|togglesum }}</th>
                     <th>{{ total.num_refunded|togglesum }}</th>
                     <th>{{ total.num_paid|togglesum }}</th>
                 </tr>

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -236,7 +236,7 @@ class OrderTransition(OrderView):
                 messages.success(self.request, _('The order has been marked as paid.'))
         elif self.order.status == Order.STATUS_PENDING and to == 'c':
             cancel_order(self.order, user=self.request.user)
-            messages.success(self.request, _('The order has been cancelled.'))
+            messages.success(self.request, _('The order has been canceled.'))
         elif self.order.status == Order.STATUS_PAID and to == 'n':
             self.order.status = Order.STATUS_PENDING
             self.order.payment_manual = True

--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -505,13 +505,13 @@ msgstr ""
 "Kontingent."
 
 #: pretix/base/models/items.py:195
-msgid "Allow product to be cancelled"
+msgid "Allow product to be canceled"
 msgstr "Erlaube Stornierungen"
 
 #: pretix/base/models/items.py:197
 msgid ""
 "If you deactivate this, an order including this product might not be "
-"cancelled by the user. It may still be cancelled by you."
+"canceled by the user. It may still be canceled by you."
 msgstr ""
 "Wenn Sie dies deaktivieren, kann eine Bestellung die dieses Produkt enthält "
 "nicht vom Kunden storniert werden. Sie kann immer noch von Ihnen storniert "
@@ -657,7 +657,7 @@ msgid "expired"
 msgstr "abgelaufen"
 
 #: pretix/base/models/orders.py:90
-msgid "cancelled"
+msgid "canceled"
 msgstr "storniert"
 
 #: pretix/base/models/orders.py:91
@@ -2349,7 +2349,7 @@ msgstr "Die Bestellung wurde zurückerstattet."
 
 #: pretix/control/logdisplay.py:56 pretix/control/views/orders.py:239
 #: pretix/presale/views/order.py:456
-msgid "The order has been cancelled."
+msgid "The order has been canceled."
 msgstr "Die Bestellung wurde storniert."
 
 #: pretix/control/logdisplay.py:57
@@ -2463,7 +2463,7 @@ msgstr "ausstehend (abgelaufen)"
 #: pretix/control/templates/pretixcontrol/orders/overview.html:22
 #: pretix/plugins/reports/exporters.py:152
 #: pretix/presale/templates/pretixpresale/event/fragment_order_status.html:10
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "storniert"
 
 #: pretix/control/templates/pretixcontrol/attendees/index.html:35
@@ -4222,7 +4222,7 @@ msgstr "Die Bestellung wurde bereits zurückerstattet."
 
 #: pretix/plugins/banktransfer/tasks.py:39
 #: pretix/plugins/banktransfer/views.py:60
-msgid "The order has already been cancelled."
+msgid "The order has already been canceled."
 msgstr "Die Rechnung wurde bereits storniert."
 
 #: pretix/plugins/banktransfer/tasks.py:42
@@ -4668,7 +4668,7 @@ msgstr ""
 "kontaktieren Sie uns, falls dies mehr als ein paar Stunden dauert."
 
 #: pretix/plugins/paypal/views.py:39
-msgid "It looks like you cancelled the PayPal payment"
+msgid "It looks like you canceled the PayPal payment"
 msgstr "Die PayPal-Zahlung wurde abgebrochen"
 
 #: pretix/plugins/pretixdroid/__init__.py:10
@@ -5761,7 +5761,7 @@ msgstr "Deutsch (Du)"
 #~ msgid "Found wrong amount. Expected: %s"
 #~ msgstr "Falscher Betrag. Erwartet: %s"
 
-#~ msgid "Order has been cancelled"
+#~ msgid "Order has been canceled"
 #~ msgstr "Bestellung wurde storniert"
 
 #~ msgid "Order has been refunded"

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -505,13 +505,13 @@ msgstr ""
 "Kontingent."
 
 #: pretix/base/models/items.py:195
-msgid "Allow product to be cancelled"
+msgid "Allow product to be canceled"
 msgstr "Erlaube Stornierungen"
 
 #: pretix/base/models/items.py:197
 msgid ""
 "If you deactivate this, an order including this product might not be "
-"cancelled by the user. It may still be cancelled by you."
+"canceled by the user. It may still be canceled by you."
 msgstr ""
 "Wenn du dies deaktivierst, kann eine Bestellung die dieses Produkt enthält "
 "nicht vom Kunden storniert werden. Sie kann immer noch von dir storniert "
@@ -657,7 +657,7 @@ msgid "expired"
 msgstr "abgelaufen"
 
 #: pretix/base/models/orders.py:90
-msgid "cancelled"
+msgid "canceled"
 msgstr "storniert"
 
 #: pretix/base/models/orders.py:91
@@ -2343,7 +2343,7 @@ msgstr "Die Bestellung wurde zurückerstattet."
 
 #: pretix/control/logdisplay.py:56 pretix/control/views/orders.py:239
 #: pretix/presale/views/order.py:456
-msgid "The order has been cancelled."
+msgid "The order has been canceled."
 msgstr "Die Bestellung wurde storniert."
 
 #: pretix/control/logdisplay.py:57
@@ -2455,7 +2455,7 @@ msgstr "ausstehend (abgelaufen)"
 #: pretix/control/templates/pretixcontrol/orders/overview.html:22
 #: pretix/plugins/reports/exporters.py:152
 #: pretix/presale/templates/pretixpresale/event/fragment_order_status.html:10
-msgid "Cancelled"
+msgid "Canceled"
 msgstr "storniert"
 
 #: pretix/control/templates/pretixcontrol/attendees/index.html:35
@@ -4208,7 +4208,7 @@ msgstr "Die Bestellung wurde bereits zurückerstattet."
 
 #: pretix/plugins/banktransfer/tasks.py:39
 #: pretix/plugins/banktransfer/views.py:60
-msgid "The order has already been cancelled."
+msgid "The order has already been canceled."
 msgstr "Die Rechnung wurde bereits storniert."
 
 #: pretix/plugins/banktransfer/tasks.py:42
@@ -4654,7 +4654,7 @@ msgstr ""
 "kontaktiere uns, falls dies mehr als ein paar Stunden dauert."
 
 #: pretix/plugins/paypal/views.py:39
-msgid "It looks like you cancelled the PayPal payment"
+msgid "It looks like you canceled the PayPal payment"
 msgstr "Die PayPal-Zahlung wurde abgebrochen"
 
 #: pretix/plugins/pretixdroid/__init__.py:10
@@ -5742,7 +5742,7 @@ msgstr "Deutsch (Du)"
 #~ msgid "Found wrong amount. Expected: %s"
 #~ msgstr "Falscher Betrag. Erwartet: %s"
 
-#~ msgid "Order has been cancelled"
+#~ msgid "Order has been canceled"
 #~ msgstr "Bestellung wurde storniert"
 
 #~ msgid "Order has been refunded"

--- a/src/pretix/plugins/banktransfer/tasks.py
+++ b/src/pretix/plugins/banktransfer/tasks.py
@@ -34,9 +34,9 @@ def _handle_transaction(event: Event, trans: BankTransaction, code: str):
     elif trans.order.status == Order.STATUS_REFUNDED:
         trans.state = BankTransaction.STATE_ERROR
         trans.message = ugettext_noop('The order has already been refunded.')
-    elif trans.order.status == Order.STATUS_CANCELLED:
+    elif trans.order.status == Order.STATUS_CANCELED:
         trans.state = BankTransaction.STATE_ERROR
-        trans.message = ugettext_noop('The order has already been cancelled.')
+        trans.message = ugettext_noop('The order has already been canceled.')
     elif trans.amount != trans.order.total:
         trans.state = BankTransaction.STATE_INVALID
         trans.message = ugettext_noop('The transaction amount is incorrect.')

--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -54,10 +54,10 @@ class ActionView(EventPermissionRequiredMixin, View):
                 'status': 'error',
                 'message': _('The order has already been refunded.')
             })
-        elif trans.order.status == Order.STATUS_CANCELLED:
+        elif trans.order.status == Order.STATUS_CANCELED:
             return JsonResponse({
                 'status': 'error',
-                'message': _('The order has already been cancelled.')
+                'message': _('The order has already been canceled.')
             })
 
         try:

--- a/src/pretix/plugins/paypal/views.py
+++ b/src/pretix/plugins/paypal/views.py
@@ -36,7 +36,7 @@ def success(request, organizer=None, event=None):
 
 
 def abort(request, organizer=None, event=None):
-    messages.error(request, _('It looks like you cancelled the PayPal payment'))
+    messages.error(request, _('It looks like you canceled the PayPal payment'))
     try:
         event = Event.objects.get(id=request.session['payment_paypal_event'])
         return redirect(eventreverse(event, 'presale:event.checkout', kwargs={'step': 'payment'}))

--- a/src/pretix/plugins/reports/exporters.py
+++ b/src/pretix/plugins/reports/exporters.py
@@ -149,7 +149,7 @@ class OverviewReport(Report):
         ]
         tdata = [
             [
-                _('Product'), _('Total (pending or paid)'), '', _('Pending'), '', _('Cancelled'), '', _('Refunded'), '',
+                _('Product'), _('Total (pending or paid)'), '', _('Pending'), '', _('Canceled'), '', _('Refunded'), '',
                 _('Paid'), ''
             ],
             [
@@ -171,7 +171,7 @@ class OverviewReport(Report):
                     tup[0].name,
                     str(tup[0].num_total[0]), str(tup[0].num_total[1]),
                     str(tup[0].num_pending[0]), str(tup[0].num_pending[1]),
-                    str(tup[0].num_cancelled[0]), str(tup[0].num_cancelled[1]),
+                    str(tup[0].num_canceled[0]), str(tup[0].num_canceled[1]),
                     str(tup[0].num_refunded[0]), str(tup[0].num_refunded[1]),
                     str(tup[0].num_paid[0]), str(tup[0].num_paid[1])
                 ])
@@ -180,7 +180,7 @@ class OverviewReport(Report):
                     "     " + str(item.name),
                     str(item.num_total[0]), str(item.num_total[1]),
                     str(item.num_pending[0]), str(item.num_pending[1]),
-                    str(item.num_cancelled[0]), str(item.num_cancelled[1]),
+                    str(item.num_canceled[0]), str(item.num_canceled[1]),
                     str(item.num_refunded[0]), str(item.num_refunded[1]),
                     str(item.num_paid[0]), str(item.num_paid[1])
                 ])
@@ -190,7 +190,7 @@ class OverviewReport(Report):
                             "          " + str(var),
                             str(var.num_total[0]), str(var.num_total[1]),
                             str(var.num_pending[0]), str(var.num_pending[1]),
-                            str(var.num_cancelled[0]), str(var.num_cancelled[1]),
+                            str(var.num_canceled[0]), str(var.num_canceled[1]),
                             str(var.num_refunded[0]), str(var.num_refunded[1]),
                             str(var.num_paid[0]), str(var.num_paid[1])
                         ])
@@ -199,7 +199,7 @@ class OverviewReport(Report):
             _("Total"),
             str(total['num_total'][0]), str(total['num_total'][1]),
             str(total['num_pending'][0]), str(total['num_pending'][1]),
-            str(total['num_cancelled'][0]), str(total['num_cancelled'][1]),
+            str(total['num_canceled'][0]), str(total['num_canceled'][1]),
             str(total['num_refunded'][0]), str(total['num_refunded'][1]),
             str(total['num_paid'][0]), str(total['num_paid'][1])
         ])

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_order_status.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_order_status.html
@@ -7,7 +7,7 @@
 {% elif order.status == "e" %}
     <span class="label label-danger {{ class }}">{% trans "Expired" %}</span>
 {% elif order.status == "c" %}
-    <span class="label label-danger {{ class }}">{% trans "Cancelled" %}</span>
+    <span class="label label-danger {{ class }}">{% trans "Canceled" %}</span>
 {% elif order.status == "r" %}
     <span class="label label-danger {{ class }}">{% trans "Refunded" %}</span>
 {% endif %}

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -453,7 +453,7 @@ class OrderCancelDo(EventViewMixin, OrderDetailMixin, AsyncAction, View):
         return ctx
 
     def get_success_message(self, value):
-        return _('The order has been cancelled.')
+        return _('The order has been canceled.')
 
     def get_error_message(self, exception):
         if isinstance(exception, dict) and exception['exc_type'] == 'OrderError':

--- a/src/tests/control/test_orders.py
+++ b/src/tests/control/test_orders.py
@@ -159,22 +159,22 @@ def test_order_transition_to_paid_expired_quota_left(client, env):
 @pytest.mark.django_db
 @pytest.mark.parametrize("process", [
     # (Old status, new status, success expected)
-    (Order.STATUS_CANCELLED, Order.STATUS_PAID, False),
-    (Order.STATUS_CANCELLED, Order.STATUS_PENDING, False),
-    (Order.STATUS_CANCELLED, Order.STATUS_REFUNDED, False),
-    (Order.STATUS_CANCELLED, Order.STATUS_EXPIRED, False),
+    (Order.STATUS_CANCELED, Order.STATUS_PAID, False),
+    (Order.STATUS_CANCELED, Order.STATUS_PENDING, False),
+    (Order.STATUS_CANCELED, Order.STATUS_REFUNDED, False),
+    (Order.STATUS_CANCELED, Order.STATUS_EXPIRED, False),
 
     (Order.STATUS_PAID, Order.STATUS_PENDING, True),
-    (Order.STATUS_PAID, Order.STATUS_CANCELLED, False),
+    (Order.STATUS_PAID, Order.STATUS_CANCELED, False),
     (Order.STATUS_PAID, Order.STATUS_REFUNDED, True),
     (Order.STATUS_PAID, Order.STATUS_EXPIRED, False),
 
-    (Order.STATUS_PENDING, Order.STATUS_CANCELLED, True),
+    (Order.STATUS_PENDING, Order.STATUS_CANCELED, True),
     (Order.STATUS_PENDING, Order.STATUS_PAID, True),
     (Order.STATUS_PENDING, Order.STATUS_REFUNDED, False),
     (Order.STATUS_PENDING, Order.STATUS_EXPIRED, True),
 
-    (Order.STATUS_REFUNDED, Order.STATUS_CANCELLED, False),
+    (Order.STATUS_REFUNDED, Order.STATUS_CANCELED, False),
     (Order.STATUS_REFUNDED, Order.STATUS_PAID, False),
     (Order.STATUS_REFUNDED, Order.STATUS_PENDING, False),
     (Order.STATUS_REFUNDED, Order.STATUS_EXPIRED, False),

--- a/src/tests/plugins/banktransfer/test_import.py
+++ b/src/tests/plugins/banktransfer/test_import.py
@@ -30,13 +30,13 @@ def env():
     )
     o2 = Order.objects.create(
         code='6789Z', event=event,
-        status=Order.STATUS_CANCELLED,
+        status=Order.STATUS_CANCELED,
         datetime=now(), expires=now() + timedelta(days=10),
         total=23, payment_provider='banktransfer'
     )
     Order.objects.create(
         code='GS89Z', event=event,
-        status=Order.STATUS_CANCELLED,
+        status=Order.STATUS_CANCELED,
         datetime=now(), expires=now() + timedelta(days=10),
         total=23, payment_provider='banktransfer'
     )
@@ -113,7 +113,7 @@ def test_check_amount(env, job):
 
 
 @pytest.mark.django_db
-def test_ignore_cancelled(env, job):
+def test_ignore_canceled(env, job):
     process_banktransfers(env[0].pk, job, [{
         'payer': 'Karla Kundin',
         'reference': 'Bestellung DUMMY6789Z',
@@ -121,7 +121,7 @@ def test_ignore_cancelled(env, job):
         'amount': '23.00'
     }])
     env[3].refresh_from_db()
-    assert env[3].status == Order.STATUS_CANCELLED
+    assert env[3].status == Order.STATUS_CANCELED
 
 
 @pytest.mark.django_db

--- a/src/tests/presale/test_orders.py
+++ b/src/tests/presale/test_orders.py
@@ -262,7 +262,7 @@ class OrdersTest(TestCase):
                                                       self.order.secret),
                              target_status_code=200)
         self.order.refresh_from_db()
-        assert self.order.status == Order.STATUS_CANCELLED
+        assert self.order.status == Order.STATUS_CANCELED
 
     def test_orders_cancel_forbidden(self):
         self.event.settings.set('cancel_allow_user', False)


### PR DESCRIPTION
Switching 'cancelled' (double 'L') to 'canceled' (single 'L') across all files.

#187

I skipped all `src/pretix/base/migrations/*` files (I understand that these files are overwritten when new migrations are done, but I'm not sure about this :confused: ). Please let me know if they need to be included.
