### PR TITLE
Fix incompatibility with sqlparse and debug-toolbar

### DIFF
--- a/src/requirements/dev.txt
+++ b/src/requirements/dev.txt
@@ -1,5 +1,5 @@
 django-debug-toolbar==1.5
-sqlparse==0.1.19  # not yet supported by django-debug-toolbar 1.4
+sqlparse==0.2.1  # pinned due to difficulties with django-debug-toolbar
 # Testing requirements
 pep8==1.5.7  # exact requirement by flake8 2.4.0
 pyflakes==1.1.0  # later version causes problems currently


### PR DESCRIPTION
Thanks to @flaviabastos for reporting this in #259.
I think the issue is solved by higher versions of sqlparse in general,
but without further testing, version pinning is probably the safest
option.

Tested both with python 3.4 and 3.5, fixes the issue successfully.