### PR TITLE
add basic instrumentation possibilities to pretix

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -174,6 +174,20 @@ Example::
     .. WARNING:: Never set this to ``True`` in production!
 
 
+Metrics
+-------
+
+If you want to fetch internally collected prometheus-style metrics you need to configure the credentials for the
+metrics endpoint and enable it::
+
+    [metrics]
+    enabled=true
+    user=your_user
+    passphrase=mysupersecretpassphrase
+
+Currently, metrics-collection requires a redis server to be available.
+
+
 Memcached
 ---------
 
@@ -187,6 +201,25 @@ You can use an existing memcached server as pretix's caching backend::
 
 If no memcached is configured, pretix will use Django's built-in local-memory caching method.
 
+Redis
+-----
+
+If a redis server is configured, pretix can use it for locking, caching and session storage
+to speed up various operations::
+
+    [redis]
+    location=redis://127.0.0.1:6379/1
+    sessions=false
+
+``location``
+    The location of redis, as a URL of the form ``redis://[:password]@localhost:6379/0``
+    or ``unix://[:password]@/path/to/socket.sock?db=0``
+
+``session``
+    When this is set to ``True``, redis will be used as the session storage.
+
+If redis is not configured, pretix will store sessions and locks in the database. If memcached
+is configured, memcached will be used for caching instead of redis.
 
 Redis
 -----

--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -201,25 +201,6 @@ You can use an existing memcached server as pretix's caching backend::
 
 If no memcached is configured, pretix will use Django's built-in local-memory caching method.
 
-Redis
------
-
-If a redis server is configured, pretix can use it for locking, caching and session storage
-to speed up various operations::
-
-    [redis]
-    location=redis://127.0.0.1:6379/1
-    sessions=false
-
-``location``
-    The location of redis, as a URL of the form ``redis://[:password]@localhost:6379/0``
-    or ``unix://[:password]@/path/to/socket.sock?db=0``
-
-``session``
-    When this is set to ``True``, redis will be used as the session storage.
-
-If redis is not configured, pretix will store sessions and locks in the database. If memcached
-is configured, memcached will be used for caching instead of redis.
 
 Redis
 -----

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -20,14 +20,11 @@ class Metric(object):
         self.help = helpstring
         self.labelnames = labelnames
 
-
     def __repr__(self):
         return self.name + "{" + ",".join(self.labelnames) + "}"
 
-
     def __str__(self):
         return self.__repr__()
-
 
     def _check_label_consistency(self, labelset):
         """
@@ -43,7 +40,6 @@ class Metric(object):
         if len(labelset) != len(self.labelnames):
             raise MetricsError("Unknown label used.")
 
-
     def _construct_metric_identifier(self, metricname, labelset=None):
         """
         Constructs the scrapable metricname usable in the output format.
@@ -57,14 +53,12 @@ class Metric(object):
 
             return metricname[:-1] + "}"
 
-
     def _inc_in_redis(self, key, amount):
         """
         Increments given key in Redis.
         """
         rkey = ns_prefix + key  # effective key for redis
         r.incrby(rkey, amount)
-
 
     def _set_in_redis(self, key, value):
         """
@@ -109,7 +103,6 @@ class Gauge(Metric):
         fullmetric = self._construct_metric_identifier(self.name, kwargs)
         self._set_in_redis(fullmetric, value)
 
-
     def inc(self, amount=1, **kwargs):
         """
         Increments Gauge by given amount for the labelset specified in kwargs.
@@ -122,7 +115,6 @@ class Gauge(Metric):
         fullmetric = self._construct_metric_identifier(self.name, kwargs)
         self._inc_in_redis(fullmetric, amount)
 
-
     def dec(self, amount=1, **kwargs):
         """
         Decrements Gauge by given amount for the labelset specified in kwargs.
@@ -132,9 +124,8 @@ class Gauge(Metric):
 
         self._check_label_consistency(self.labelnames, kwargs)
 
-        fullmetric = self._construct_metric_identifier(name, kwargs)
-        self._inc_in_redis(fullmetric, -1*amount)
-
+        fullmetric = self._construct_metric_identifier(self.name, kwargs)
+        self._inc_in_redis(fullmetric, amount * -1)
 
 
 def metrics_scrapable_textformat():
@@ -151,8 +142,6 @@ def metrics_scrapable_textformat():
         output.append(output_key + " " + str(value))
 
     return "\n".join(output)
-
-
 
 """
 Provided metrics

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -124,23 +124,23 @@ class Gauge(Metric):
         self._inc_in_redis(fullmetric, amount * -1)
 
 
-def metrics_textformat():
+def metric_values():
     """
     Produces the scrapable textformat to be presented to the monitoring system
     """
     if not settings.HAS_REDIS:
         return ""
 
-    output = []
+    metrics = {}
 
     for key in redis.scan_iter(match=REDIS_KEY_PREFIX + "*"):
         dkey = key.decode("utf-8")
         _, _, output_key = dkey.split("_", 2)
         value = float(redis.get(dkey).decode("utf-8"))
 
-        output.append(output_key + " " + str(value))
+        metrics[output_key] = value
 
-    return "\n".join(output)
+    return metrics
 
 
 """

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -6,151 +6,151 @@ r = redis.Redis(host=redishost, port=redisport)
 
 
 class MetricsError(Exception):
-	def __init__(self, msg):
-		self.msg = msg
+    def __init__(self, msg):
+        self.msg = msg
 
 
 class Metric(object):
-	"""
-	Base Metrics Object
-	"""
+    """
+    Base Metrics Object
+    """
 
-	def __init__(self, name, helpstring, labelnames=[]):
-		self.name = name
-		self.help = helpstring
-		self.labelnames = labelnames
-
-
-	def __repr__(self):
-		return self.name + "{" + ",".join(self.labelnames) + "}"
+    def __init__(self, name, helpstring, labelnames=[]):
+        self.name = name
+        self.help = helpstring
+        self.labelnames = labelnames
 
 
-	def __str__(self):
-		return self.__repr__()
+    def __repr__(self):
+        return self.name + "{" + ",".join(self.labelnames) + "}"
 
 
-	def _check_label_consistency(self, labelset):
-		"""
-		Checks if the given labelset provides exactly the labels that are required.
-		"""
-
-		# test if every required label is provided
-		for labelname in self.labelnames:
-			if labelname not in labelset:
-				raise MetricsError("Label {0} not specified.".format(labelname))
-
-		# now test if no further labels are required
-		if len(labelset) != len(self.labelnames):
-			raise MetricsError("Unknown label used.")
+    def __str__(self):
+        return self.__repr__()
 
 
-	def _construct_metric_identifier(self, metricname, labelset=None):
-		"""
-		Constructs the scrapable metricname usable in the output format.
-		"""
-		if not labelset:
-			return metricname
-		else:
-			metricname += "{"
-			for labelname in self.labelnames:
-				metricname += '{0}="{1}",'.format(labelname, labelset[labelname])
+    def _check_label_consistency(self, labelset):
+        """
+        Checks if the given labelset provides exactly the labels that are required.
+        """
 
-			return metricname[:-1] + "}"
+        # test if every required label is provided
+        for labelname in self.labelnames:
+            if labelname not in labelset:
+                raise MetricsError("Label {0} not specified.".format(labelname))
 
-
-	def _inc_in_redis(self, key, amount):
-		"""
-		Increments given key in Redis.
-		"""
-		rkey = ns_prefix + key  # effective key for redis
-		r.incrby(rkey, amount)
+        # now test if no further labels are required
+        if len(labelset) != len(self.labelnames):
+            raise MetricsError("Unknown label used.")
 
 
-	def _set_in_redis(self, key, value):
-		"""
-		Sets given key in Redis.
-		"""
-		rkey = ns_prefix + key  # effective key for redis
-		r.set(rkey, value)
+    def _construct_metric_identifier(self, metricname, labelset=None):
+        """
+        Constructs the scrapable metricname usable in the output format.
+        """
+        if not labelset:
+            return metricname
+        else:
+            metricname += "{"
+            for labelname in self.labelnames:
+                metricname += '{0}="{1}",'.format(labelname, labelset[labelname])
+
+            return metricname[:-1] + "}"
+
+
+    def _inc_in_redis(self, key, amount):
+        """
+        Increments given key in Redis.
+        """
+        rkey = ns_prefix + key  # effective key for redis
+        r.incrby(rkey, amount)
+
+
+    def _set_in_redis(self, key, value):
+        """
+        Sets given key in Redis.
+        """
+        rkey = ns_prefix + key  # effective key for redis
+        r.set(rkey, value)
 
 
 class Counter(Metric):
-	"""
-	Counter Metric Object
-	Counters can only be increased, they can neither be set to a specific value
-	nor decreased.
-	"""
+    """
+    Counter Metric Object
+    Counters can only be increased, they can neither be set to a specific value
+    nor decreased.
+    """
 
-	def inc(self, amount=1, **kwargs):
-		"""
-		Increments Counter by given amount for the labelset specified in kwargs.
-		"""
-		if amount < 0:
-			raise MetricsError("Counter cannot be decreased.")
+    def inc(self, amount=1, **kwargs):
+        """
+        Increments Counter by given amount for the labelset specified in kwargs.
+        """
+        if amount < 0:
+            raise MetricsError("Counter cannot be decreased.")
 
-		self._check_label_consistency(kwargs)
+        self._check_label_consistency(kwargs)
 
-		fullmetric = self._construct_metric_identifier(self.name, kwargs)
-		self._inc_in_redis(fullmetric, amount)
+        fullmetric = self._construct_metric_identifier(self.name, kwargs)
+        self._inc_in_redis(fullmetric, amount)
 
 
 class Gauge(Metric):
-	"""
-	Gauge Metric Object
-	Gauges can be set to a specific value, increased and decreased.
-	"""
+    """
+    Gauge Metric Object
+    Gauges can be set to a specific value, increased and decreased.
+    """
 
-	def set(self, value=1, **kwargs):
-		"""
-		Sets Gauge to a specific value for the labelset specified in kwargs.
-		"""
-		self._check_label_consistency(kwargs)
+    def set(self, value=1, **kwargs):
+        """
+        Sets Gauge to a specific value for the labelset specified in kwargs.
+        """
+        self._check_label_consistency(kwargs)
 
-		fullmetric = self._construct_metric_identifier(self.name, kwargs)
-		self._set_in_redis(fullmetric, value)
-
-
-	def inc(self, amount=1, **kwargs):
-		"""
-		Increments Gauge by given amount for the labelset specified in kwargs.
-		"""
-		if amount < 0:
-			raise MetricsError("Amount must be greater than zero. Otherwise use dec().")
-
-		self._check_label_consistency(kwargs)
-
-		fullmetric = self._construct_metric_identifier(self.name, kwargs)
-		self._inc_in_redis(fullmetric, amount)
+        fullmetric = self._construct_metric_identifier(self.name, kwargs)
+        self._set_in_redis(fullmetric, value)
 
 
-	def dec(self, amount=1, **kwargs):
-		"""
-		Decrements Gauge by given amount for the labelset specified in kwargs.
-		"""
-		if amount < 0:
-			raise MetricsError("Amount must be greater than zero. Otherwise use inc().")
+    def inc(self, amount=1, **kwargs):
+        """
+        Increments Gauge by given amount for the labelset specified in kwargs.
+        """
+        if amount < 0:
+            raise MetricsError("Amount must be greater than zero. Otherwise use dec().")
 
-		self._check_label_consistency(self.labelnames, kwargs)
+        self._check_label_consistency(kwargs)
 
-		fullmetric = self._construct_metric_identifier(name, kwargs)
-		self._inc_in_redis(fullmetric, -1*amount)
+        fullmetric = self._construct_metric_identifier(self.name, kwargs)
+        self._inc_in_redis(fullmetric, amount)
+
+
+    def dec(self, amount=1, **kwargs):
+        """
+        Decrements Gauge by given amount for the labelset specified in kwargs.
+        """
+        if amount < 0:
+            raise MetricsError("Amount must be greater than zero. Otherwise use inc().")
+
+        self._check_label_consistency(self.labelnames, kwargs)
+
+        fullmetric = self._construct_metric_identifier(name, kwargs)
+        self._inc_in_redis(fullmetric, -1*amount)
 
 
 
 def metrics_scrapable_textformat():
-	"""
-	Produces the scrapable textformat to be presented to the monitoring system
-	"""
-	output = []
+    """
+    Produces the scrapable textformat to be presented to the monitoring system
+    """
+    output = []
 
-	for key in r.scan_iter(match=ns_prefix + "*"):
-		dkey = key.decode("utf-8")
-		_, _, output_key = dkey.split("_", 2)
-		value = float(r.get(dkey).decode("utf-8"))
+    for key in r.scan_iter(match=ns_prefix + "*"):
+        dkey = key.decode("utf-8")
+        _, _, output_key = dkey.split("_", 2)
+        value = float(r.get(dkey).decode("utf-8"))
 
-		output.append(output_key + " " + str(value))
+        output.append(output_key + " " + str(value))
 
-	return "\n".join(output)
+    return "\n".join(output)
 
 
 

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -5,7 +5,7 @@ if settings.HAS_REDIS:
 
 REDIS_KEY_PREFIX = "pretix_metrics_"
 
-r = django_redis.get_redis_connection("redis")
+redis = django_redis.get_redis_connection("redis")
 
 
 class MetricsError(Exception):
@@ -60,14 +60,14 @@ class Metric(object):
         Increments given key in Redis.
         """
         rkey = REDIS_KEY_PREFIX + key
-        r.incrbyfloat(rkey, amount)
+        redis.incrbyfloat(rkey, amount)
 
     def _set_in_redis(self, key, value):
         """
         Sets given key in Redis.
         """
         rkey = REDIS_KEY_PREFIX + key
-        r.set(rkey, value)
+        redis.set(rkey, value)
 
 
 class Counter(Metric):

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -1,0 +1,161 @@
+import redis
+
+ns_prefix = "pretix_metrics_"
+
+r = redis.Redis(host=redishost, port=redisport)
+
+
+class MetricsError(Exception):
+	def __init__(self, msg):
+		self.msg = msg
+
+
+class Metric(object):
+	"""
+	Base Metrics Object
+	"""
+
+	def __init__(self, name, helpstring, labelnames=[]):
+		self.name = name
+		self.help = helpstring
+		self.labelnames = labelnames
+
+
+	def __repr__(self):
+		return self.name + "{" + ",".join(self.labelnames) + "}"
+
+
+	def __str__(self):
+		return self.__repr__()
+
+
+	def _check_label_consistency(self, labelset):
+		"""
+		Checks if the given labelset provides exactly the labels that are required.
+		"""
+
+		# test if every required label is provided
+		for labelname in self.labelnames:
+			if labelname not in labelset:
+				raise MetricsError("Label {0} not specified.".format(labelname))
+
+		# now test if no further labels are required
+		if len(labelset) != len(self.labelnames):
+			raise MetricsError("Unknown label used.")
+
+
+	def _construct_metric_identifier(self, metricname, labelset=None):
+		"""
+		Constructs the scrapable metricname usable in the output format.
+		"""
+		if not labelset:
+			return metricname
+		else:
+			metricname += "{"
+			for labelname in self.labelnames:
+				metricname += '{0}="{1}",'.format(labelname, labelset[labelname])
+
+			return metricname[:-1] + "}"
+
+
+	def _inc_in_redis(self, key, amount):
+		"""
+		Increments given key in Redis.
+		"""
+		rkey = ns_prefix + key  # effective key for redis
+		r.incrby(rkey, amount)
+
+
+	def _set_in_redis(self, key, value):
+		"""
+		Sets given key in Redis.
+		"""
+		rkey = ns_prefix + key  # effective key for redis
+		r.set(rkey, value)
+
+
+class Counter(Metric):
+	"""
+	Counter Metric Object
+	Counters can only be increased, they can neither be set to a specific value
+	nor decreased.
+	"""
+
+	def inc(self, amount=1, **kwargs):
+		"""
+		Increments Counter by given amount for the labelset specified in kwargs.
+		"""
+		if amount < 0:
+			raise MetricsError("Counter cannot be decreased.")
+
+		self._check_label_consistency(kwargs)
+
+		fullmetric = self._construct_metric_identifier(self.name, kwargs)
+		self._inc_in_redis(fullmetric, amount)
+
+
+class Gauge(Metric):
+	"""
+	Gauge Metric Object
+	Gauges can be set to a specific value, increased and decreased.
+	"""
+
+	def set(self, value=1, **kwargs):
+		"""
+		Sets Gauge to a specific value for the labelset specified in kwargs.
+		"""
+		self._check_label_consistency(kwargs)
+
+		fullmetric = self._construct_metric_identifier(self.name, kwargs)
+		self._set_in_redis(fullmetric, value)
+
+
+	def inc(self, amount=1, **kwargs):
+		"""
+		Increments Gauge by given amount for the labelset specified in kwargs.
+		"""
+		if amount < 0:
+			raise MetricsError("Amount must be greater than zero. Otherwise use dec().")
+
+		self._check_label_consistency(kwargs)
+
+		fullmetric = self._construct_metric_identifier(self.name, kwargs)
+		self._inc_in_redis(fullmetric, amount)
+
+
+	def dec(self, amount=1, **kwargs):
+		"""
+		Decrements Gauge by given amount for the labelset specified in kwargs.
+		"""
+		if amount < 0:
+			raise MetricsError("Amount must be greater than zero. Otherwise use inc().")
+
+		self._check_label_consistency(self.labelnames, kwargs)
+
+		fullmetric = self._construct_metric_identifier(name, kwargs)
+		self._inc_in_redis(fullmetric, -1*amount)
+
+
+
+def metrics_scrapable_textformat():
+	"""
+	Produces the scrapable textformat to be presented to the monitoring system
+	"""
+	output = []
+
+	for key in r.scan_iter(match=ns_prefix + "*"):
+		dkey = key.decode("utf-8")
+		_, _, output_key = dkey.split("_", 2)
+		value = float(r.get(dkey).decode("utf-8"))
+
+		output.append(output_key + " " + str(value))
+
+	return "\n".join(output)
+
+
+
+"""
+Provided metrics
+"""
+http_requests_total = Counter("http_requests_total", "Total number of HTTP requests made.", ["code", "handler", "method"])
+# usage: http_requests_total.inc(code="200", handler="/foo", method="GET")

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -2,14 +2,9 @@ from django.conf import settings
 
 if settings.HAS_REDIS:
     import django_redis
+    redis = django_redis.get_redis_connection("redis")
 
 REDIS_KEY_PREFIX = "pretix_metrics_"
-
-redis = django_redis.get_redis_connection("redis")
-
-
-class MetricsError(Exception):
-    pass
 
 
 class Metric(object):
@@ -33,14 +28,11 @@ class Metric(object):
         # test if every required label is provided
         for labelname in self.labelnames:
             if labelname not in labelset:
-                raise MetricsError("Label {0} not specified.".format(labelname))
+                raise ValueError("Label {0} not specified.".format(labelname))
 
         # now test if no further labels are required
         if len(labelset) != len(self.labelnames):
-            s1 = set(labelset)
-            s2 = set(labelnames)
-            diff = s1.difference(s2)
-            raise MetricsError("Unknown labels used: {}".format(", ".join(diff)))
+            raise ValueError("Unknown labels used: {}".format(", ".join(set(labelset) - set(self.labelnames))))
 
     def _construct_metric_identifier(self, metricname, labelset=None):
         """
@@ -60,14 +52,16 @@ class Metric(object):
         Increments given key in Redis.
         """
         rkey = REDIS_KEY_PREFIX + key
-        redis.incrbyfloat(rkey, amount)
+        if settings.HAS_REDIS:
+            redis.incrbyfloat(rkey, amount)
 
     def _set_in_redis(self, key, value):
         """
         Sets given key in Redis.
         """
         rkey = REDIS_KEY_PREFIX + key
-        redis.set(rkey, value)
+        if settings.HAS_REDIS:
+            redis.set(rkey, value)
 
 
 class Counter(Metric):
@@ -82,7 +76,7 @@ class Counter(Metric):
         Increments Counter by given amount for the labelset specified in kwargs.
         """
         if amount < 0:
-            raise MetricsError("Counter cannot be increased by negative values.")
+            raise ValueError("Counter cannot be increased by negative values.")
 
         self._check_label_consistency(kwargs)
 
@@ -110,7 +104,7 @@ class Gauge(Metric):
         Increments Gauge by given amount for the labelset specified in kwargs.
         """
         if amount < 0:
-            raise MetricsError("Amount must be greater than zero. Otherwise use dec().")
+            raise ValueError("Amount must be greater than zero. Otherwise use dec().")
 
         self._check_label_consistency(kwargs)
 
@@ -122,7 +116,7 @@ class Gauge(Metric):
         Decrements Gauge by given amount for the labelset specified in kwargs.
         """
         if amount < 0:
-            raise MetricsError("Amount must be greater than zero. Otherwise use inc().")
+            raise ValueError("Amount must be greater than zero. Otherwise use inc().")
 
         self._check_label_consistency(self.labelnames, kwargs)
 
@@ -134,26 +128,19 @@ def metrics_textformat():
     """
     Produces the scrapable textformat to be presented to the monitoring system
     """
+    if not settings.HAS_REDIS:
+        return ""
+
     output = []
 
-    for key in r.scan_iter(match=REDIS_KEY_PREFIX + "*"):
+    for key in redis.scan_iter(match=REDIS_KEY_PREFIX + "*"):
         dkey = key.decode("utf-8")
         _, _, output_key = dkey.split("_", 2)
-        value = float(r.get(dkey).decode("utf-8"))
+        value = float(redis.get(dkey).decode("utf-8"))
 
         output.append(output_key + " " + str(value))
 
     return "\n".join(output)
-
-
-if not settings.HAS_REDIS:
-    # noop everything
-    class Counter(object):
-        def inc(): pass
-    class Gauge(object):
-        def inc(): pass
-        def dec(): pass
-    def metrics_textformat(): pass
 
 
 """

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -20,32 +20,32 @@ class Metric(object):
     def __repr__(self):
         return self.name + "{" + ",".join(self.labelnames) + "}"
 
-    def _check_label_consistency(self, labelset):
+    def _check_label_consistency(self, labels):
         """
-        Checks if the given labelset provides exactly the labels that are required.
+        Checks if the given labels provides exactly the labels that are required.
         """
 
         # test if every required label is provided
         for labelname in self.labelnames:
-            if labelname not in labelset:
+            if labelname not in labels:
                 raise ValueError("Label {0} not specified.".format(labelname))
 
         # now test if no further labels are required
-        if len(labelset) != len(self.labelnames):
-            raise ValueError("Unknown labels used: {}".format(", ".join(set(labelset) - set(self.labelnames))))
+        if len(labels) != len(self.labelnames):
+            raise ValueError("Unknown labels used: {}".format(", ".join(set(labels) - set(self.labelnames))))
 
-    def _construct_metric_identifier(self, metricname, labelset=None):
+    def _construct_metric_identifier(self, metricname, labels=None):
         """
         Constructs the scrapable metricname usable in the output format.
         """
-        if not labelset:
+        if not labels:
             return metricname
         else:
-            labels = []
+            named_labels = []
             for labelname in self.labelnames:
-                labels.append('{}="{}",'.format(labelname, labelset[labelname]))
+                named_labels.append('{}="{}",'.format(labelname, labels[labelname]))
 
-            return metricname + "{" + ",".join(labels) + "}"
+            return metricname + "{" + ",".join(named_labels) + "}"
 
     def _inc_in_redis(self, key, amount):
         """
@@ -73,7 +73,7 @@ class Counter(Metric):
 
     def inc(self, amount=1, **kwargs):
         """
-        Increments Counter by given amount for the labelset specified in kwargs.
+        Increments Counter by given amount for the labels specified in kwargs.
         """
         if amount < 0:
             raise ValueError("Counter cannot be increased by negative values.")
@@ -92,7 +92,7 @@ class Gauge(Metric):
 
     def set(self, value=1, **kwargs):
         """
-        Sets Gauge to a specific value for the labelset specified in kwargs.
+        Sets Gauge to a specific value for the labels specified in kwargs.
         """
         self._check_label_consistency(kwargs)
 
@@ -101,7 +101,7 @@ class Gauge(Metric):
 
     def inc(self, amount=1, **kwargs):
         """
-        Increments Gauge by given amount for the labelset specified in kwargs.
+        Increments Gauge by given amount for the labels specified in kwargs.
         """
         if amount < 0:
             raise ValueError("Amount must be greater than zero. Otherwise use dec().")
@@ -113,7 +113,7 @@ class Gauge(Metric):
 
     def dec(self, amount=1, **kwargs):
         """
-        Decrements Gauge by given amount for the labelset specified in kwargs.
+        Decrements Gauge by given amount for the labels specified in kwargs.
         """
         if amount < 0:
             raise ValueError("Amount must be greater than zero. Otherwise use inc().")

--- a/src/pretix/base/metrics.py
+++ b/src/pretix/base/metrics.py
@@ -118,7 +118,7 @@ class Gauge(Metric):
         if amount < 0:
             raise ValueError("Amount must be greater than zero. Otherwise use inc().")
 
-        self._check_label_consistency(self.labelnames, kwargs)
+        self._check_label_consistency(kwargs)
 
         fullmetric = self._construct_metric_identifier(self.name, kwargs)
         self._inc_in_redis(fullmetric, amount * -1)

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -3,31 +3,31 @@ from django.http import HttpResponse
 from .. import metrics
 
 
-def unauthedResponse():
+def unauthed_response():
     content = "<html><title>Forbidden</title><body>You are not authorized to view this page.</body></html>"
-    unauthedResponse = HttpResponse(content, mimetype="text/html")
-    unauthedResponse["WWW-Authenticate"] = 'Basic realm="metrics"'
-    unauthedResponse.status_code = 401
+    response = HttpResponse(content, mimetype="text/html")
+    response["WWW-Authenticate"] = 'Basic realm="metrics"'
+    response.status_code = 401
 
 
 def serve_metrics(request):
     if not settings.METRICS_ENABLED:
-        return unauthedResponse()
+        return unauthed_response()
 
     # check if the user is properly authorized:
     if "HTTP_AUTHORIZATION" not in request.META:
-        return unauthedResponse()
+        return unauthed_response()
 
     method, credentials = request.META["HTTP_AUTHORIZATION"].split(" ", 1)
     if method.lower() != "basic":
-        return unauthedResponse()
+        return unauthed_response()
 
     user, passphrase = credentials.strip().decode("base64").split(":", 1)
 
     if user != settings.METRICS_USER:
-        return unauthedResponse()
+        return unauthed_response()
     if passphrase != settings.METRICS_PASSPHRASE:
-        return unauthedResponse()
+        return unauthed_response()
 
     # ok, the request passed the authentication-barrier, let's hand out the metrics:
     m = metrics.metric_values()

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -1,8 +1,28 @@
+from django.conf import settings
 from http import HttpResponse
 from .. import metrics
 
+unauthedResponse = HttpResponse("<html><title>Forbidden</title><body>You are not authorized to view this page.</body></html>", mimetype="text/html")
+unauthedResponse["WWW-Authenticate"] = 'Basic realm="metrics"'
+unauthedResponse.status_code = 401
 
 def serve_metrics(request):
+    # first check if the user is properly authorized:
+    if not request.META.has_key("HTTP_AUTHORIZATION"):
+        return unauthedResponse
+
+    method, credentials = request.META["HTTP_AUTHORIZATION"].split(" ", 1)
+    if method.lower() != "basic":
+        return unauthedResponse
+
+    user, passphrase = credentials.strip().decode("base64").split(":", 1)
+
+    if user != settings.METRICS_USER:
+        return unauthedResponse
+    if passphrase != settings.METRICS_PASSPHRASE:
+        return unauthedResponse
+
+    # ok, the request passed the authentication-barrier, let's hand out the metrics:
     m = metrics.metric_values()
 
     output = []

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -1,0 +1,14 @@
+from http import HttpResponse
+from .. import metrics
+
+
+def serve_metrics(request):
+    m = metrics.metric_values()
+
+    output = []
+    for metric, value in m:
+        output.append("{} {}".format(metric, str(value)))
+
+    content = "\n".join(output)
+
+    return HttpResponse(content)

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -8,6 +8,7 @@ def unauthed_response():
     response = HttpResponse(content, mimetype="text/html")
     response["WWW-Authenticate"] = 'Basic realm="metrics"'
     response.status_code = 401
+    return response
 
 
 def serve_metrics(request):

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.http import HttpResponse
+
 from .. import metrics
 
 

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -6,7 +6,7 @@ from .. import metrics
 
 def unauthed_response():
     content = "<html><title>Forbidden</title><body>You are not authorized to view this page.</body></html>"
-    response = HttpResponse(content, mimetype="text/html")
+    response = HttpResponse(content, content_type="text/html")
     response["WWW-Authenticate"] = 'Basic realm="metrics"'
     response.status_code = 401
     return response

--- a/src/pretix/base/views/metrics.py
+++ b/src/pretix/base/views/metrics.py
@@ -6,9 +6,10 @@ unauthedResponse = HttpResponse("<html><title>Forbidden</title><body>You are not
 unauthedResponse["WWW-Authenticate"] = 'Basic realm="metrics"'
 unauthedResponse.status_code = 401
 
+
 def serve_metrics(request):
     # first check if the user is properly authorized:
-    if not request.META.has_key("HTTP_AUTHORIZATION"):
+    if "HTTP_AUTHORIZATION" not in request.META:
         return unauthedResponse
 
     method, credentials = request.META["HTTP_AUTHORIZATION"].split(" ", 1)

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -89,6 +89,10 @@ EMAIL_SUBJECT_PREFIX = '[pretix] '
 
 ADMINS = [('Admin', n) for n in config.get('mail', 'admins', fallback='').split(",") if n]
 
+METRICS_ENABLED = config.get('metrics', 'enabled', fallback=False)
+METRICS_USER = config.get('metrics', 'user', fallback="metrics")
+METRICS_PASSPHRASE = config.get('metrics', 'passphrase', fallback="")
+
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/src/pretix/urls.py
+++ b/src/pretix/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import include, url
 import pretix.control.urls
 import pretix.presale.urls
 
-from .base.views import cachedfiles, health, js_catalog, redirect, metrics
+from .base.views import cachedfiles, health, js_catalog, metrics, redirect
 
 base_patterns = [
     url(r'^download/(?P<id>[^/]+)/$', cachedfiles.DownloadView.as_view(),

--- a/src/pretix/urls.py
+++ b/src/pretix/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import include, url
 import pretix.control.urls
 import pretix.presale.urls
 
-from .base.views import cachedfiles, health, js_catalog, redirect
+from .base.views import cachedfiles, health, js_catalog, redirect, metrics
 
 base_patterns = [
     url(r'^download/(?P<id>[^/]+)/$', cachedfiles.DownloadView.as_view(),
@@ -13,6 +13,8 @@ base_patterns = [
         name='healthcheck'),
     url(r'^redirect/$', redirect.redir_view, name='redirect'),
     url(r'^jsi18n/(?P<lang>[a-zA-Z-_]+)/$', js_catalog.js_catalog, name='javascript-catalog'),
+    url(r'^metrics$', metrics.serve_metrics,
+        name='metrics'),
 ]
 
 control_patterns = [

--- a/src/tests/base/test_metrics.py
+++ b/src/tests/base/test_metrics.py
@@ -6,7 +6,7 @@ from pretix.base import metrics
 from pretix.base.views import metrics as metricsview
 
 
-class fakeRedis(object):
+class FakeRedis(object):
 
     def __init__(self):
         self.storage = {}
@@ -28,7 +28,7 @@ class fakeRedis(object):
 @override_settings(HAS_REDIS=True)
 def test_counter(monkeypatch):
 
-    fake_redis = fakeRedis()
+    fake_redis = FakeRedis()
 
     monkeypatch.setattr(metrics, "redis", fake_redis, raising=False)
 
@@ -36,11 +36,11 @@ def test_counter(monkeypatch):
     fullname_GET  = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "GET"})
     fullname_POST = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "POST"})
     metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 1
+    assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 1
     metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 2
+    assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 2
     metrics.http_requests_total.inc(7, code="200", handler="/foo", method="GET")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 9
+    assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 9
     metrics.http_requests_total.inc(7, code="200", handler="/foo", method="POST")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 9
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_POST] == 7
+    assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 9
+    assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_POST] == 7

--- a/src/tests/base/test_metrics.py
+++ b/src/tests/base/test_metrics.py
@@ -1,0 +1,41 @@
+# pytest
+
+from django.test import override_settings
+
+from pretix.base import metrics
+
+
+class fake_redis(object):
+
+    def __init__(self):
+        self.storage = {}
+
+    def incrbyfloat(self, rkey, amount):
+        if rkey in self.storage:
+            self.storage[rkey] += amount
+        else:
+            self.set(rkey, amount)
+
+    def set(self, rkey, value):
+        self.storage[rkey] = value
+
+    def get(self, rkey):
+        # bytes-conversion here for emulating redis behavior without making incr too hard
+        return bytes(self.storage[rkey], encoding='utf-8')
+
+
+@override_settings(HAS_REDIS=True)
+def test_counter(monkeypatch):
+
+    local_fake_redis = fake_redis()
+
+    monkeypatch.setattr(metrics, "redis", local_fake_redis, raising=False)
+
+    # now test
+    fullname = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "GET"})
+    metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname] == 1
+    metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname] == 2
+    metrics.http_requests_total.inc(7, code="200", handler="/foo", method="GET")
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname] == 9

--- a/src/tests/base/test_metrics.py
+++ b/src/tests/base/test_metrics.py
@@ -35,7 +35,7 @@ def test_counter(monkeypatch):
     monkeypatch.setattr(metrics, "redis", fake_redis, raising=False)
 
     # now test
-    fullname_GET  = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "GET"})
+    fullname_GET = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "GET"})
     fullname_POST = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "POST"})
     metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
     assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 1
@@ -48,7 +48,7 @@ def test_counter(monkeypatch):
     assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_POST] == 7
 
 
-@override_settings(HAS_REDIS=True,METRICS_USER="foo",METRICS_PASSPHRASE="bar")
+@override_settings(HAS_REDIS=True, METRICS_USER="foo", METRICS_PASSPHRASE="bar")
 def test_metrics_view(monkeypatch, client):
 
     fake_redis = FakeRedis()

--- a/src/tests/base/test_metrics.py
+++ b/src/tests/base/test_metrics.py
@@ -119,6 +119,7 @@ def test_gauge(monkeypatch):
     assert fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_dimless] == 20
 
 
+@pytest.mark.django_db
 @override_settings(HAS_REDIS=True, METRICS_USER="foo", METRICS_PASSPHRASE="bar")
 def test_metrics_view(monkeypatch, client):
 

--- a/src/tests/base/test_metrics.py
+++ b/src/tests/base/test_metrics.py
@@ -3,9 +3,10 @@
 from django.test import override_settings
 
 from pretix.base import metrics
+from pretix.base.views import metrics as metricsview
 
 
-class fake_redis(object):
+class fakeRedis(object):
 
     def __init__(self):
         self.storage = {}
@@ -27,15 +28,19 @@ class fake_redis(object):
 @override_settings(HAS_REDIS=True)
 def test_counter(monkeypatch):
 
-    local_fake_redis = fake_redis()
+    fake_redis = fakeRedis()
 
-    monkeypatch.setattr(metrics, "redis", local_fake_redis, raising=False)
+    monkeypatch.setattr(metrics, "redis", fake_redis, raising=False)
 
     # now test
-    fullname = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "GET"})
+    fullname_GET  = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "GET"})
+    fullname_POST = metrics.http_requests_total._construct_metric_identifier('http_requests_total', {"code": "200", "handler": "/foo", "method": "POST"})
     metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname] == 1
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 1
     metrics.http_requests_total.inc(code="200", handler="/foo", method="GET")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname] == 2
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 2
     metrics.http_requests_total.inc(7, code="200", handler="/foo", method="GET")
-    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname] == 9
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 9
+    metrics.http_requests_total.inc(7, code="200", handler="/foo", method="POST")
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_GET] == 9
+    assert local_fake_redis.storage[metrics.REDIS_KEY_PREFIX + fullname_POST] == 7


### PR DESCRIPTION
This PR adds the necessary datatypes to provide prometheus-like instrumentation natively to pretix.

Currently supported by this PR are Counters and Gauges.
