### PR TITLE
Pass request's user when refunding (for logging)

### DIFF
--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -221,7 +221,7 @@ class Paypal(BasePaymentProvider):
             payment_info = None
 
         if not payment_info:
-            mark_order_refunded(order)
+            mark_order_refunded(order, user=request.user)
             messages.warning(request, _('We were unable to transfer the money back automatically. '
                                         'Please get in touch with the customer and transfer it back manually.'))
             return
@@ -239,7 +239,7 @@ class Paypal(BasePaymentProvider):
                                         'Please get in touch with the customer and transfer it back manually.'))
         else:
             sale = paypalrestsdk.Payment.find(payment_info['id'])
-            order = mark_order_refunded(order)
+            order = mark_order_refunded(order, user=request.user)
             order.payment_info = json.dumps(sale.to_dict())
             order.save()
 

--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -202,10 +202,10 @@ class Stripe(BasePaymentProvider):
                                       'support if the problem persists.'))
             logger.error('Stripe error: %s' % str(err))
         except stripe.error.StripeError:
-            mark_order_refunded(order)
+            mark_order_refunded(order, user=request.user)
             messages.warning(request, _('We were unable to transfer the money back automatically. '
                                         'Please get in touch with the customer and transfer it back manually.'))
         else:
-            order = mark_order_refunded(order)
+            order = mark_order_refunded(order, user=request.user)
             order.payment_info = str(ch)
             order.save()

--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -55,6 +55,6 @@ def webhook(request, *args, **kwargs):
     order.log_action('pretix.plugins.stripe.event', data=event_json)
 
     if order.status == Order.STATUS_PAID and (charge['refunds']['total_count'] or charge['dispute']):
-        mark_order_refunded(order)
+        mark_order_refunded(order, user=None)
 
     return HttpResponse(status=200)


### PR DESCRIPTION
Except when triggered by a webhook. Closes #275