### PR TITLE
Log emails sent with sendmail plugin #307

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -8,4 +8,3 @@ dist/
 *.egg-info/
 *.bak
 static/jsi18n/
-

--- a/src/pretix/base/models/log.py
+++ b/src/pretix/base/models/log.py
@@ -1,3 +1,4 @@
+import json
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -124,3 +125,7 @@ class LogEntry(models.Model):
             return a_text
         else:
             return ''
+
+    @cached_property
+    def parsed_data(self):
+        return json.loads(self.data)

--- a/src/pretix/control/templates/pretixcontrol/event/base.html
+++ b/src/pretix/control/templates/pretixcontrol/event/base.html
@@ -98,12 +98,28 @@
     {% endif %}
     {% for nav in nav_event %}
         <li>
-            <a href="{{ nav.url }}" {% if nav.active %}class="active"{% endif %}>
+            <a href="{{ nav.url }}" {% if nav.active %}class="active"{% endif %}
+            {% if nav.children %}class="has-children"{% endif %}>
                 {% if nav.icon %}
                     <i class="fa fa-{{ nav.icon }} fa-fw"></i>
                 {% endif %}
                 {{ nav.label }}
             </a>
+            {% if nav.children %}
+                <a href="#" class="arrow">
+                    <span class="fa arrow"></span>
+                </a>
+                <ul class="nav nav-second-level">
+                {% for item in nav.children %}
+                    <li>
+                        <a href="{{ item.url }}"
+                        {% if item.active %}class="active"{% endif %}>
+                            {{ item.label }}
+                        </a>
+                    </li>
+                {% endfor %}
+                </ul>
+            {% endif %}
         </li>
     {% endfor %}
 {% endblock %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -16,31 +16,17 @@
                         {% if log.display %}
                             <br/><span class="fa fa-comment-o"></span> {{ log.display }}
                         {% endif %}
-                    </p>
-                    <p>
-                        <strong>Email address:</strong> {{ log.parsed_data.recipients }}
-                    </p>
-                    <p>
-                        <strong>Subject:</strong>
-                    </p>
-                    <p>
-                        {% for key,value in log.parsed_data.subject.items %}
-                            <p>
-                                {{ key }}: {{ value }}
-                            </p>
+                        <br/><span class="fa fa-shopping-cart"></span> {% trans "Sent to orders:" %}
+                        {% for status in log.parsed_data.sendto %}
+                            {{ status }}{% if forloop.revcounter > 1 %},{% endif %}
                         {% endfor %}
                     </p>
                     <p>
-                        <strong>Email content:</strong>
-                    </p>
-                    <p>
-                        {% for key,value in log.parsed_data.message.items %}
+                        {% for locale, value in log.pdata.locales.items %}
                             <p>
-                                {{ key }}:
+                                <strong>[{{ locale }}] {% trans "Subject:" %} {{ value.subject }}</strong>
                             </p>
-                            <p>
-                                {{ value|linebreaksbr }}
-                            </p>
+                            <pre>{{ value.message|linebreaksbr }}</pre>
                         {% endfor %}
                     </p>
                 </li>

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -1,0 +1,51 @@
+{% extends "pretixcontrol/event/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% block title %}{% trans "Send out emails" %}{% endblock %}
+{% block content %}
+    <h1>{% trans "Email history" %}</h1>
+    <div>
+        <ul class="list-group">
+            {% for log in logs %}
+                <li class="list-group-item logentry">
+                    <p class="meta">
+                        <span class="fa fa-clock-o"></span> {{ log.datetime|date:"SHORT_DATETIME_FORMAT" }}
+                        {% if log.user %}
+                            <br/><span class="fa fa-user"></span> {{ log.user.get_full_name }}
+                        {% endif %}
+                        {% if log.display %}
+                            <br/><span class="fa fa-comment-o"></span> {{ log.display }}
+                        {% endif %}
+                    </p>
+                    <p>
+                        <strong>Email address:</strong> {{ log.parsed_data.recipients }}
+                    </p>
+                    <p>
+                        <strong>Subject:</strong>
+                    </p>
+                    <p>
+                        {% for key,value in log.parsed_data.subject.items %}
+                            <p>
+                                {{ key }}: {{ value }}
+                            </p>
+                        {% endfor %}
+                    </p>
+                    <p>
+                        <strong>Email content:</strong>
+                    </p>
+                    <p>
+                        {% for key,value in log.parsed_data.message.items %}
+                            <p>
+                                {{ key }}:
+                            </p>
+                            <p>
+                                {{ value|linebreaksbr }}
+                            </p>
+                        {% endfor %}
+                    </p>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% include "pretixcontrol/pagination.html" %}
+{% endblock %}

--- a/src/pretix/plugins/sendmail/urls.py
+++ b/src/pretix/plugins/sendmail/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/', views.SenderView.as_view(),
+    url(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/$', views.SenderView.as_view(),
         name='send'),
+    url(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/sendmail/history/', views.EmailHistoryView.as_view(), name='history')
 ]

--- a/src/tests/control/test_items.py
+++ b/src/tests/control/test_items.py
@@ -236,6 +236,7 @@ class QuotaTest(ItemFormTest):
         form_data['size'] = '350'
         doc = self.post_doc('/control/event/%s/%s/quotas/%s/change' % (self.orga1.slug, self.event1.slug, c.id),
                             form_data)
+        doc = self.get_doc('/control/event/%s/%s/quotas/' % (self.orga1.slug, self.event1.slug))
         self.assertIn("350", doc.select("#page-wrapper table")[0].text)
         self.assertNotIn("500", doc.select("#page-wrapper table")[0].text)
         assert Quota.objects.get(id=c.id).size == 350


### PR DESCRIPTION
This logs to the database emails sent with sendmail plugin and displays them in the control backend
Also adds support to second-level nav to plugins

As I previously mentioned, I'm confused about *event*-level and *order*-level logs so I don't know if I am logging/displaying the right thing (probably not). I appreciate feedback. 
I'm displaying raw (uggly) data but 1- I wasn't sure I had the right thing and 2- I didn't know how to display it prettier. 

I didn't remove the code for the new Model either. Let me know if it needs to go. 