### PR TITLE
Order Bankimports by their job's date

### DIFF
--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -215,6 +215,8 @@ class ImportView(EventPermissionRequiredMixin, ListView):
             q = self.request.GET.get('search')
             qs = qs.filter(
                 Q(payer__icontains=q) | Q(reference__icontains=q) | Q(comment__icontains=q)
+            ).order_by(
+                '-import_job__created'
             )
 
         return qs


### PR DESCRIPTION
Leads to having the most recent unresolved transfers on top instead of
in between.