### PR TITLE
Improved documentation by adding missing requirements

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -17,6 +17,9 @@ External Dependencies
 * ``pyvenv`` for Python 3 (Debian package: ``python3-venv``)
 * ``libffi`` (Debian package: ``libffi-dev``)
 * ``libssl`` (Debian package: ``libssl-dev``)
+* ``libxml2`` (Debian package ``libxml2-dev``)
+* ``libxslt`` (Debian package ``libxslt1-dev``)
+* ``msgfmt`` (Debian package ``gettext``)
 * ``git``
 
 Your local python environment
@@ -77,7 +80,7 @@ and head to http://localhost:8000/
 
 As we did not implement an overall front page yet, you need to go directly to
 http://localhost:8000/control/ for the admin view or, if you imported the test
-data as suggested above, to the event page at http://localhost:8000/mrmcd/2015/
+data as suggested above, to the event page at http://localhost:8000/bigevents/2017/
 
 .. _`checksandtests`:
 


### PR DESCRIPTION
Improved documentation by adding some requirements that where needed to install from a clean Debian 8.6 installation.

Before the ```$ pip3 install -r requirements.txt -r requirements/dev.txt``` installation step would succeed I needed to add the following dependencies:
```$ sudo aptitude install libxml2-dev```
```$ sudo aptitude install libxslt1-dev```
The Error without the dependencies ended with:
```
    In file included from src/lxml/lxml.etree.c:515:0:
    src/lxml/includes/etree_defs.h:14:31: fatal error: libxml/xmlversion.h: No such file or directory
     #include "libxml/xmlversion.h"
                                   ^
    compilation terminated.
    Compile failed: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    creating tmp
    cc -I/usr/include/libxml2 -c /tmp/xmlXPathInitm_7rr3ky.c -o tmp/xmlXPathInitm_7rr3ky.o
    /tmp/xmlXPathInitm_7rr3ky.c:1:26: fatal error: libxml/xpath.h: No such file or directory
     #include "libxml/xpath.h"
                              ^
    compilation terminated.
    *********************************************************************************
    Could not find function xmlCheckVersion in library libxml2. Is libxml2 installed?
    *********************************************************************************
    error: command 'x86_64-linux-gnu-gcc' failed with exit status
```

In the "make localcompile" step I had to do
```$ sudo aptitude install gettext```
before it would succeed.

There was a reference to a demo event ("/mrmcd/2015/") it should probably be /bigevents/2017/ .