### PR TITLE
Fixed Module not found: pretix.celery_app error

### DIFF
--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -167,7 +167,7 @@ For background tasks we need a second service ``/etc/systemd/system/pretix-worke
     Group=pretix
     Environment="VIRTUAL_ENV=/var/pretix/venv"
     Environment="PATH=/var/pretix/venv/bin:/usr/local/bin:/usr/bin:/bin"
-    ExecStart=/var/pretix/venv/bin/celery -A pretix.celery_app worker -l info
+    ExecStart=/var/pretix/venv/bin/celery -A pretix.celery worker -l info
     WorkingDirectory=/var/pretix/source/src
     Restart=on-failure
 


### PR DESCRIPTION
While setting up the pretix background worker daemon I faced an python NameError which was caused by a missing pretix.celery_app module. Looking into source folder I noticed a celery.py module. I updated the parameter of celery to point to pretix.celery and it worked as expected.