### PR TITLE
Correct wrong module name for Postgres in example configs

### DIFF
--- a/doc/admin/installation/docker_smallscale.rst
+++ b/doc/admin/installation/docker_smallscale.rst
@@ -111,7 +111,7 @@ Fill the configuration file ``/etc/pretix/pretix.cfg`` with the following conten
     datadir=/data
 
     [database]
-    ; Replace mysql with psycopg2 for PostgreSQL
+    ; Replace mysql with postgresql_psycopg2 for PostgreSQL
     backend=mysql
     name=pretix
     user=pretix

--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -82,7 +82,7 @@ Fill the configuration file ``/etc/pretix/pretix.cfg`` with the following conten
     datadir=/var/pretix/data
 
     [database]
-    ; Replace mysql with psycopg2 for PostgreSQL
+    ; Replace mysql with postgresql_psycopg2 for PostgreSQL
     backend=mysql
     name=pretix
     user=pretix


### PR DESCRIPTION
The example configs list `psycopg2` as the name for the Django postgres database module, but it's actually `postgresql_psycopg2`: https://github.com/django/django/tree/master/django/db/backends/postgresql_psycopg2