### PR TITLE
Fix false success message on sendmail plugin

### DIFF
--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -45,57 +45,56 @@ class SenderView(EventPermissionRequiredMixin, FormView):
         if not orders:
             messages.error(self.request, _('There are no orders matching this selection.'))
             return self.get(self.request, *self.args, **self.kwargs)
-        else:
-            for o in orders:
-                if self.request.POST.get("action") == "preview":
-                    for l in self.request.event.settings.locales:
-                        with language(l):
-                            self.output[l] = []
-                            self.output[l].append(_('Subject: {subject}').format(subject=form.cleaned_data['subject'].localize(l)))
-                            message = form.cleaned_data['message'].localize(l)
-                            preview_text = message.format(
-                                order='ORDER1234',
-                                event=self.request.event.name,
-                                order_date=date_format(now(), 'SHORT_DATE_FORMAT'),
-                                due_date=date_format(now() + timedelta(days=7), 'SHORT_DATE_FORMAT'),
-                                order_url=build_absolute_uri(self.request.event, 'presale:event.order', kwargs={
-                                    'order': 'ORDER1234',
-                                    'secret': 'longrandomsecretabcdef123456'
-                                }))
-                            self.output[l].append(preview_text)
-                    return self.get(self.request, *self.args, **self.kwargs)
-                else:
-                    try:
-                        with language(o.locale):
-                            mail(o.email, form.cleaned_data['subject'], form.cleaned_data['message'],
-                                 {
-                                     'event': o.event,
-                                     'order': o.code,
-                                     'order_date': date_format(o.datetime.astimezone(tz), 'SHORT_DATETIME_FORMAT'),
-                                     'due_date': date_format(o.expires, 'SHORT_DATE_FORMAT'),
-                                     'order_url': build_absolute_uri(o.event, 'presale:event.order', kwargs={
-                                         'order': o.code,
-                                         'secret': o.secret
-                                     })},
-                                 self.request.event, locale=o.locale, order=o)
-                            o.log_action(
-                                'pretix.plugins.sendmail.order.email.sent',
-                                user=self.request.user,
-                                data={
-                                    'subject': form.cleaned_data['subject'],
-                                    'message': form.cleaned_data['message'],
-                                    'recipient': o.email
-                                }
-                            )
-                    except SendMailException:
-                        failures.append(o.email)
-            self.request.event.log_action('pretix.plugins.sendmail.sent',
-                                          user=self.request.user,
-                                          data=dict(form.cleaned_data))
-            if failures:
-                messages.error(self.request, _('Failed to send mails to the following users: {}'.format(' '.join(failures))))
+        for o in orders:
+            if self.request.POST.get("action") == "preview":
+                for l in self.request.event.settings.locales:
+                    with language(l):
+                        self.output[l] = []
+                        self.output[l].append(_('Subject: {subject}').format(subject=form.cleaned_data['subject'].localize(l)))
+                        message = form.cleaned_data['message'].localize(l)
+                        preview_text = message.format(
+                            order='ORDER1234',
+                            event=self.request.event.name,
+                            order_date=date_format(now(), 'SHORT_DATE_FORMAT'),
+                            due_date=date_format(now() + timedelta(days=7), 'SHORT_DATE_FORMAT'),
+                            order_url=build_absolute_uri(self.request.event, 'presale:event.order', kwargs={
+                                'order': 'ORDER1234',
+                                'secret': 'longrandomsecretabcdef123456'
+                            }))
+                        self.output[l].append(preview_text)
+                return self.get(self.request, *self.args, **self.kwargs)
             else:
-                messages.success(self.request, _('Your message has been queued to be sent to the selected users.'))
+                try:
+                    with language(o.locale):
+                        mail(o.email, form.cleaned_data['subject'], form.cleaned_data['message'],
+                             {
+                                 'event': o.event,
+                                 'order': o.code,
+                                 'order_date': date_format(o.datetime.astimezone(tz), 'SHORT_DATETIME_FORMAT'),
+                                 'due_date': date_format(o.expires, 'SHORT_DATE_FORMAT'),
+                                 'order_url': build_absolute_uri(o.event, 'presale:event.order', kwargs={
+                                     'order': o.code,
+                                     'secret': o.secret
+                                 })},
+                             self.request.event, locale=o.locale, order=o)
+                        o.log_action(
+                            'pretix.plugins.sendmail.order.email.sent',
+                            user=self.request.user,
+                            data={
+                                'subject': form.cleaned_data['subject'],
+                                'message': form.cleaned_data['message'],
+                                'recipient': o.email
+                            }
+                        )
+                except SendMailException:
+                    failures.append(o.email)
+        self.request.event.log_action('pretix.plugins.sendmail.sent',
+                                      user=self.request.user,
+                                      data=dict(form.cleaned_data))
+        if failures:
+            messages.error(self.request, _('Failed to send mails to the following users: {}'.format(' '.join(failures))))
+        else:
+            messages.success(self.request, _('Your message has been queued to be sent to the selected users.'))
 
         return redirect(
             'plugins:sendmail:send',


### PR DESCRIPTION
This fixes issue #409

Add check to confirm if there are no orders with that status. In this case, display error message and keep form populated. Doesn't log any info.