### PR TITLE
Introduce a setting to show net prices

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -432,6 +432,10 @@ class AbstractPosition(models.Model):
             else:
                 q.answer = ""
 
+    @property
+    def net_price(self):
+        return self.price - self.tax_value
+
 
 class OrderPosition(AbstractPosition):
     """

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -7,10 +7,11 @@ from typing import List, Union
 
 from django.conf import settings
 from django.db import models
-from django.db.models import F
+from django.db.models import F, Sum
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.crypto import get_random_string
+from django.utils.functional import cached_property
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
@@ -214,6 +215,18 @@ class Order(LoggedModel):
                 self.payment_fee * (1 - 100 / (100 + self.payment_fee_tax_rate)))
         else:
             self.payment_fee_tax_value = Decimal('0.00')
+
+    @property
+    def payment_fee_net(self):
+        return self.payment_fee - self.payment_fee_tax_value
+
+    @cached_property
+    def tax_total(self):
+        return (self.positions.aggregate(s=Sum('tax_value'))['s'] or 0) + self.payment_fee_tax_value
+
+    @property
+    def net_total(self):
+        return self.total - self.tax_total
 
     @staticmethod
     def normalize_code(code):

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -9,6 +9,7 @@ from django.db.models import Q
 from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 
+from pretix.base.decimal import round_decimal
 from pretix.base.i18n import LazyLocaleException
 from pretix.base.models import (
     CartPosition, Event, Item, ItemVariation, Voucher,
@@ -143,6 +144,8 @@ class CartManager:
                 custom_price = Decimal(custom_price.replace(",", "."))
             if custom_price > 100000000:
                 return error_messages['price_too_high']
+            if self.event.settings.display_net_prices:
+                custom_price = round_decimal(custom_price * (100 + item.tax_rate) / 100)
             price = max(custom_price, price)
 
         return price

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -20,6 +20,10 @@ DEFAULTS = {
         'default': '10',
         'type': int
     },
+    'display_net_prices': {
+        'default': 'False',
+        'type': bool
+    },
     'attendee_names_asked': {
         'default': 'True',
         'type': bool

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -158,6 +158,12 @@ class EventSettingsForm(SettingsForm):
         help_text=_("Show item details before presale has started and after presale has ended"),
         required=False
     )
+    display_net_prices = forms.BooleanField(
+        label=_("Show net prices instead of gross prices in the product list (not recommended!)"),
+        help_text=_("Independent of your choice, the cart will show gross prices as this the price that needs to be "
+                    "paid"),
+        required=False
+    )
     presale_start_show_date = forms.BooleanField(
         label=_("Show start date"),
         help_text=_("Show the presale start date before presale has started."),

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -59,7 +59,7 @@ class OrderPositionChangeForm(forms.Form):
     price = forms.DecimalField(
         required=False,
         max_digits=10, decimal_places=2,
-        label=_('New price')
+        label=_('New price (gross)')
     )
     operation = forms.ChoiceField(
         required=False,

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -25,6 +25,7 @@
             {% bootstrap_field sform.contact_mail layout="horizontal" %}
             {% bootstrap_field sform.imprint_url layout="horizontal" %}
             {% bootstrap_field sform.show_quota_left layout="horizontal" %}
+            {% bootstrap_field sform.display_net_prices layout="horizontal" %}
         </fieldset>
         <fieldset>
             <legend>{% trans "Timeline" %}</legend>

--- a/src/pretix/control/templates/pretixcontrol/order/change.html
+++ b/src/pretix/control/templates/pretixcontrol/order/change.html
@@ -79,6 +79,9 @@
                                         {% if position.form.operation.value == "price" %}checked="checked"{% endif %}>
                                 {% trans "Change price to" %}
                                 {% bootstrap_field position.form.price layout='inline' %}
+                                {% if request.event.settings.display_net_prices %}
+                                    <em>{% trans "Enter a gross price including taxes." %}</em>
+                                {% endif %}
                             </label>
                         </div>
                         <div class="radio">

--- a/src/pretix/control/templates/pretixcontrol/order/index.html
+++ b/src/pretix/control/templates/pretixcontrol/order/index.html
@@ -189,12 +189,20 @@
                                 {% endif %}
                             </div>
                             <div class="col-md-3 col-xs-6 price">
-                                <strong>{{ event.currency }} {{ line.price|floatformat:2 }}</strong>
-                                {% if line.tax_rate %}
-                                    <br/>
-                                    <small>{% blocktrans trimmed with rate=line.tax_rate %}
+                                {% if event.settings.display_net_prices %}
+                                    <strong>{{ event.currency }} {{ line.net_price|floatformat:2 }}</strong>
+                                    {% if line.tax_rate %}
+                                        <br /><small>{% blocktrans trimmed with rate=line.tax_rate %}
+                                        <strong>plus</strong> {{ rate }}% taxes
+                                    {% endblocktrans %}</small>
+                                    {% endif %}
+                                {% else %}
+                                    <strong>{{ event.currency }} {{ line.price|floatformat:2 }}</strong>
+                                    {% if line.tax_rate %}
+                                        <br /><small>{% blocktrans trimmed with rate=line.tax_rate %}
                                         incl. {{ rate }}% taxes
                                     {% endblocktrans %}</small>
+                                    {% endif %}
                                 {% endif %}
                             </div>
                             <div class="clearfix"></div>
@@ -206,13 +214,43 @@
                                 <strong>{% trans "Payment method fee" %}</strong>
                             </div>
                             <div class="col-md-3 col-xs-6 col-md-offset-5 price">
-                                <strong>{{ event.currency }} {{ items.payment_fee|floatformat:2 }}</strong>
-                                {% if order.payment_fee_tax_rate %}
-                                    <br/>
-                                    <small>{% blocktrans trimmed with rate=order.payment_fee_tax_rate %}
-                                        incl. {{ rate }}% taxes
-                                    {% endblocktrans %}</small>
+                                {% if event.settings.display_net_prices %}
+                                    <strong>{{ event.currency }} {{ order.payment_fee_net|floatformat:2 }}</strong>
+                                    {% if order.payment_fee_tax_rate %}
+                                        <br/>
+                                        <small>{% blocktrans trimmed with rate=order.payment_fee_tax_rate %}
+                                            <strong>plus</strong> {{ rate }}% taxes
+                                        {% endblocktrans %}</small>
+                                    {% endif %}
+                                {% else %}
+                                    <strong>{{ event.currency }} {{ items.payment_fee|floatformat:2 }}</strong>
+                                    {% if order.payment_fee_tax_rate %}
+                                        <br/>
+                                        <small>{% blocktrans trimmed with rate=order.payment_fee_tax_rate %}
+                                            incl. {{ rate }}% taxes
+                                        {% endblocktrans %}</small>
+                                    {% endif %}
                                 {% endif %}
+                            </div>
+                            <div class="clearfix"></div>
+                        </div>
+                    {% endif %}
+                    {% if event.settings.display_net_prices %}
+                        <div class="row-fluid product-row total">
+                            <div class="col-md-4 col-xs-6">
+                                <strong>{% trans "Net total" %}</strong>
+                            </div>
+                            <div class="col-md-3 col-xs-6 col-md-offset-5 price">
+                                {{ event.currency }} {{ items.net_total|floatformat:2 }}
+                            </div>
+                            <div class="clearfix"></div>
+                        </div>
+                        <div class="row-fluid product-row">
+                            <div class="col-md-4 col-xs-6">
+                                <strong>{% trans "Taxes" %}</strong>
+                            </div>
+                            <div class="col-md-3 col-xs-6 col-md-offset-5 price">
+                                {{ event.currency }} {{ items.tax_total|floatformat:2 }}
                             </div>
                             <div class="clearfix"></div>
                         </div>

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -179,6 +179,8 @@ class OrderDetail(OrderView):
             'raw': cartpos,
             'total': self.object.total,
             'payment_fee': self.object.payment_fee,
+            'net_total': self.object.net_total,
+            'tax_total': self.object.tax_total,
         }
 
 

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -70,22 +70,35 @@
                         <input type="hidden" name="item_{{ line.item.id }}"
                                 value="1" />
                         <input type="hidden" name="price_{{ line.item.id }}"
-                                value="{{ line.price }}" />
+                                value="{% if event.settings.display_net_prices %}{{ line.net_price }}{% else %}{{ line.price }}{% endif %}" />
                     {% endif %}
                     <button class="btn btn-mini btn-link"><i class="fa fa-plus"></i></button>
                 </form>
                 {% endif %}
             </div>
             <div class="singleprice price">
-                {{ event.currency }} {{ line.price|floatformat:2 }}
+                {% if event.settings.display_net_prices %}
+                    {{ event.currency }} {{ line.net_price|floatformat:2 }}
+                {% else %}
+                    {{ event.currency }} {{ line.price|floatformat:2 }}
+                {% endif %}
             </div>
         {% endif %}
         <div class="totalprice price">
-            <strong>{{ event.currency }} {{ line.total|floatformat:2 }}</strong>
-            {% if line.tax_rate %}
-                <br /><small>{% blocktrans trimmed with rate=line.tax_rate %}
-                incl. {{ rate }}% taxes
-            {% endblocktrans %}</small>
+            {% if event.settings.display_net_prices %}
+                <strong>{{ event.currency }} {{ line.net_total|floatformat:2 }}</strong>
+                {% if line.tax_rate %}
+                    <br /><small>{% blocktrans trimmed with rate=line.tax_rate %}
+                    <strong>plus</strong> {{ rate }}% taxes
+                    {% endblocktrans %}</small>
+                {% endif %}
+            {% else %}
+                <strong>{{ event.currency }} {{ line.total|floatformat:2 }}</strong>
+                {% if line.tax_rate %}
+                    <br /><small>{% blocktrans trimmed with rate=line.tax_rate %}
+                    incl. {{ rate }}% taxes
+                    {% endblocktrans %}</small>
+                {% endif %}
             {% endif %}
         </div>
         {% if download %}
@@ -102,19 +115,48 @@
     </div>
 {% endfor %}
 {% if cart.payment_fee %}
-    {# TODO: Tax rate? #}
     <div class="row cart-row">
         <div class="col-md-4 col-xs-6">
             <strong>{% trans "Payment method fee" %}</strong>
         </div>
         <div class="col-md-3 col-xs-6 col-md-offset-5 price">
-            <strong>{{ event.currency }} {{ cart.payment_fee|floatformat:2 }}</strong>
-            {% if cart.payment_fee_tax_rate %}
-                <br/>
-                <small>{% blocktrans trimmed with rate=cart.payment_fee_tax_rate %}
-                    incl. {{ rate }}% taxes
-                {% endblocktrans %}</small>
+            {% if event.settings.display_net_prices %}
+                <strong>{{ event.currency }} {{ cart.payment_fee_net|floatformat:2 }}</strong>
+                {% if cart.payment_fee_tax_rate %}
+                    <br/>
+                    <small>{% blocktrans trimmed with rate=cart.payment_fee_tax_rate %}
+                        <strong>plus</strong> {{ rate }}% taxes
+                    {% endblocktrans %}</small>
+                {% endif %}
+            {% else %}
+                <strong>{{ event.currency }} {{ cart.payment_fee|floatformat:2 }}</strong>
+                {% if cart.payment_fee_tax_rate %}
+                    <br/>
+                    <small>{% blocktrans trimmed with rate=cart.payment_fee_tax_rate %}
+                        incl. {{ rate }}% taxes
+                    {% endblocktrans %}</small>
+                {% endif %}
             {% endif %}
+        </div>
+        <div class="clearfix"></div>
+    </div>
+{% endif %}
+{% if event.settings.display_net_prices %}
+    <div class="row cart-row total">
+        <div class="col-md-4 col-xs-6">
+            <strong>{% trans "Net total" %}</strong>
+        </div>
+        <div class="col-md-3 col-xs-6 col-md-offset-5 price">
+            {{ event.currency }} {{ cart.net_total|floatformat:2 }}
+        </div>
+        <div class="clearfix"></div>
+    </div>
+    <div class="row cart-row">
+        <div class="col-md-4 col-xs-6">
+            <strong>{% trans "Taxes" %}</strong>
+        </div>
+        <div class="col-md-3 col-xs-6 col-md-offset-5 price">
+            {{ event.currency }} {{ cart.tax_total|floatformat:2 }}
         </div>
         <div class="clearfix"></div>
     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -136,14 +136,18 @@
                                                         <span class="input-group-addon">{{ event.currency }}</span>
                                                         <input type="number" class="form-control input-item-price"
                                                                 placeholder="0"
-                                                                min="{{ var.price|stringformat:"0.2f" }}"
+                                                                min="{{ var.display_price|stringformat:"0.2f" }}"
                                                                 name="price_{{ item.id }}_{{ var.id }}"
-                                                                step="any" value="{{ var.price|stringformat:"0.2f" }}">
+                                                                step="any" value="{{ var.display_price|stringformat:"0.2f" }}">
                                                     </div>
                                                 {% else %}
-                                                    {{ event.currency }} {{ var.price|floatformat:2 }}
+                                                    {{ event.currency }} {{ var.display_price|floatformat:2 }}
                                                 {% endif %}
-                                                {% if item.tax_rate %}
+                                                {% if item.tax_rate and event.settings.display_net_prices %}
+                                                    <small>{% blocktrans trimmed with rate=item.tax_rate %}
+                                                        <strong>plus</strong> {{ rate }}% taxes
+                                                    {% endblocktrans %}</small>
+                                                {% elif item.tax_rate %}
                                                     <small>{% blocktrans trimmed with rate=item.tax_rate %}
                                                         incl. {{ rate }}% taxes
                                                     {% endblocktrans %}</small>
@@ -186,14 +190,18 @@
                                         <div class="input-group input-group-price">
                                             <span class="input-group-addon">{{ event.currency }}</span>
                                             <input type="number" class="form-control input-item-price" placeholder="0"
-                                                    min="{{ item.price|stringformat:"0.2f" }}"
+                                                    min="{{ item.display_price|stringformat:"0.2f" }}"
                                                     name="price_{{ item.id }}"
-                                                    step="any" value="{{ item.price|stringformat:"0.2f" }}">
+                                                    step="any" value="{{ item.display_price|stringformat:"0.2f" }}">
                                         </div>
                                     {% else %}
-                                        {{ event.currency }} {{ item.price|floatformat:2 }}
+                                        {{ event.currency }} {{ item.display_price|floatformat:2 }}
                                     {% endif %}
-                                    {% if item.tax_rate %}
+                                    {% if item.tax_rate and event.settings.display_net_prices %}
+                                        <small>{% blocktrans trimmed with rate=item.tax_rate %}
+                                            <strong>plus</strong> {{ rate }}% taxes
+                                        {% endblocktrans %}</small>
+                                    {% elif item.tax_rate %}
                                         <small>{% blocktrans trimmed with rate=item.tax_rate %}
                                             incl. {{ rate }}% taxes
                                         {% endblocktrans %}</small>

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -72,7 +72,11 @@
                                                 {% else %}
                                                     {{ event.currency }} {{ var.display_price|floatformat:2 }}
                                                 {% endif %}
-                                                {% if item.tax_rate %}
+                                                {% if item.tax_rate and event.settings.display_net_prices %}
+                                                    <small>{% blocktrans trimmed with rate=item.tax_rate %}
+                                                        <strong>plus</strong> {{ rate }}% taxes
+                                                    {% endblocktrans %}</small>
+                                                {% elif item.tax_rate %}
                                                     <small>{% blocktrans trimmed with rate=item.tax_rate %}
                                                         incl. {{ rate }}% taxes
                                                     {% endblocktrans %}</small>
@@ -126,7 +130,11 @@
                                     {% else %}
                                         {{ event.currency }} {{ item.price|floatformat:2 }}
                                     {% endif %}
-                                    {% if item.tax_rate %}
+                                    {% if item.tax_rate and event.settings.display_net_prices %}
+                                        <small>{% blocktrans trimmed with rate=item.tax_rate %}
+                                            <strong>plus</strong> {{ rate }}% taxes
+                                        {% endblocktrans %}</small>
+                                    {% elif item.tax_rate %}
                                         <small>{% blocktrans trimmed with rate=item.tax_rate %}
                                             incl. {{ rate }}% taxes
                                         {% endblocktrans %}</small>

--- a/src/pretix/presale/views/__init__.py
+++ b/src/pretix/presale/views/__init__.py
@@ -6,6 +6,7 @@ from django.db.models import Sum
 from django.utils.functional import cached_property
 from django.utils.timezone import now
 
+from pretix.base.decimal import round_decimal
 from pretix.base.models import CartPosition, OrderPosition
 from pretix.base.signals import register_payment_providers
 
@@ -44,10 +45,10 @@ class CartMixin:
             else:
                 i = pos.pk
             if downloads:
-                return i, pos.pk, 0, 0, 0, 0
+                return i, pos.pk, 0, 0, 0, 0,
             if answers and ((pos.item.admission and self.request.event.settings.attendee_names_asked)
                             or pos.item.questions.all()):
-                return i, pos.pk, 0, 0, 0, 0
+                return i, pos.pk, 0, 0, 0, 0,
             return 0, 0, pos.item_id, pos.variation_id, pos.price, (pos.voucher_id or 0)
 
         positions = []
@@ -56,15 +57,24 @@ class CartMixin:
             group = g[0]
             group.count = len(g)
             group.total = group.count * group.price
+            group.net_total = group.count * group.net_price
             group.has_questions = answers and k[0] != ""
             if answers:
                 group.cache_answers()
             positions.append(group)
 
         total = sum(p.total for p in positions)
+        net_total = sum(p.net_total for p in positions)
+        tax_total = sum(p.total - p.net_total for p in positions)
 
         payment_fee = payment_fee if payment_fee is not None else self.get_payment_fee(total)
-        payment_fee_tax_rate = payment_fee_tax_rate if payment_fee_tax_rate is not None else self.request.event.settings.tax_rate_default
+        payment_fee_tax_rate = round_decimal(payment_fee_tax_rate
+                                             if payment_fee_tax_rate is not None
+                                             else self.request.event.settings.tax_rate_default)
+        payment_fee_tax_value = round_decimal(payment_fee * (1 - 100 / (100 + payment_fee_tax_rate)))
+        payment_fee_net = payment_fee - payment_fee_tax_value
+        tax_total += payment_fee_tax_value
+        net_total += payment_fee_net
 
         try:
             first_expiry = min(p.expires for p in positions) if positions else now()
@@ -77,7 +87,10 @@ class CartMixin:
             'positions': positions,
             'raw': cartpos,
             'total': total + payment_fee,
+            'net_total': net_total,
+            'tax_total': tax_total,
             'payment_fee': payment_fee,
+            'payment_fee_net': payment_fee_net,
             'payment_fee_tax_rate': payment_fee_tax_rate,
             'answers': answers,
             'minutes_left': minutes_left,

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -63,6 +63,7 @@ def get_grouped_items(event):
                                  if item.cached_availability[1] is not None else sys.maxsize,
                                  int(event.settings.max_items_per_order))
             item.price = item.default_price
+            item.display_price = item.default_price_net if event.settings.display_net_prices else item.price
             display_add_to_cart = display_add_to_cart or item.order_max > 0
         else:
             for var in item.available_variations:
@@ -70,10 +71,11 @@ def get_grouped_items(event):
                 var.order_max = min(var.cached_availability[1]
                                     if var.cached_availability[1] is not None else sys.maxsize,
                                     int(event.settings.max_items_per_order))
+                var.display_price = var.net_price if event.settings.display_net_prices else var.price
                 display_add_to_cart = display_add_to_cart or var.order_max > 0
             if len(item.available_variations) > 0:
-                item.min_price = min([v.price for v in item.available_variations])
-                item.max_price = max([v.price for v in item.available_variations])
+                item.min_price = min([v.display_price for v in item.available_variations])
+                item.max_price = max([v.display_price for v in item.available_variations])
 
     items = [item for item in items if len(item.available_variations) > 0 or not item.has_variations]
     return items, display_add_to_cart


### PR DESCRIPTION
This shows net prices everywhere in the frontend, e.g. in the product list and in the cart:
![2017-02-21-180503_1164x457_scrot](https://cloud.githubusercontent.com/assets/64280/23175982/881fa78c-f861-11e6-97f8-505a3684189f.png)

- [x] backend
- [x] frontend