### PR TITLE
fix #428: ignore timezone when saving event

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -5,7 +5,7 @@ from django.core.validators import RegexValidator
 from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import ugettext_lazy as _
 from i18nfield.forms import I18nFormField, I18nTextarea
-from pytz import common_timezones
+from pytz import common_timezones, timezone
 
 from pretix.base.forms import I18nModelForm, SettingsForm
 from pretix.base.models import Event, Organizer
@@ -80,6 +80,18 @@ class EventWizardBasicsForm(I18nModelForm):
             raise ValidationError({
                 'locale': _('Your default locale must also be enabled for your event (see box above).')
             })
+        if data['timezone'] not in common_timezones:
+            raise ValidationError({
+                'timezone': _('Your default locale must be specified.')
+            })
+
+        # change timezone
+        zone = timezone(data['timezone'])
+        data['date_from'] = zone.localize(data['date_from'].replace(tzinfo=None))
+        data['date_to'] = zone.localize(data['date_to'].replace(tzinfo=None))
+        data['presale_start'] = zone.localize(data['presale_start'].replace(tzinfo=None))
+        data['presale_end'] = zone.localize(data['presale_end'].replace(tzinfo=None))
+
         return data
 
     def clean_slug(self):

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -80,17 +80,17 @@ class EventWizardBasicsForm(I18nModelForm):
             raise ValidationError({
                 'locale': _('Your default locale must also be enabled for your event (see box above).')
             })
-        if data['timezone'] not in common_timezones:
+        if data.get('timezone') not in common_timezones:
             raise ValidationError({
                 'timezone': _('Your default locale must be specified.')
             })
 
         # change timezone
-        zone = timezone(data['timezone'])
-        data['date_from'] = self.reset_timezone(zone, data['date_from'])
-        data['date_to'] = self.reset_timezone(zone, data['date_to'])
-        data['presale_start'] = self.reset_timezone(zone, data['presale_start'])
-        data['presale_end'] = self.reset_timezone(zone, data['presale_end'])
+        zone = timezone(data.get('timezone'))
+        data['date_from'] = self.reset_timezone(zone, data.get('date_from'))
+        data['date_to'] = self.reset_timezone(zone, data.get('date_to'))
+        data['presale_start'] = self.reset_timezone(zone, data.get('presale_start'))
+        data['presale_end'] = self.reset_timezone(zone, data.get('presale_end'))
         return data
 
     @staticmethod

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -87,12 +87,15 @@ class EventWizardBasicsForm(I18nModelForm):
 
         # change timezone
         zone = timezone(data['timezone'])
-        data['date_from'] = zone.localize(data['date_from'].replace(tzinfo=None))
-        data['date_to'] = zone.localize(data['date_to'].replace(tzinfo=None))
-        data['presale_start'] = zone.localize(data['presale_start'].replace(tzinfo=None))
-        data['presale_end'] = zone.localize(data['presale_end'].replace(tzinfo=None))
-
+        data['date_from'] = self.reset_timezone(zone, data['date_from'])
+        data['date_to'] = self.reset_timezone(zone, data['date_to'])
+        data['presale_start'] = self.reset_timezone(zone, data['presale_start'])
+        data['presale_end'] = self.reset_timezone(zone, data['presale_end'])
         return data
+
+    @staticmethod
+    def reset_timezone(tz, dt):
+        return tz.localize(dt.replace(tzinfo=None)) if dt is not None else None
 
     def clean_slug(self):
         slug = self.cleaned_data['slug']

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -1,7 +1,9 @@
 import datetime
 from decimal import Decimal
 
+import pytz
 from i18nfield.strings import LazyI18nString
+from pytz import timezone
 from tests.base import SoupTest, extract_form_fields
 
 from pretix.base.models import (
@@ -45,7 +47,6 @@ class EventsTest(SoupTest):
         doc = self.get_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug))
         doc.select("[name=date_to]")[0]['value'] = "2013-12-30 17:00:00"
         doc.select("[name=settings-max_items_per_order]")[0]['value'] = "12"
-        print(extract_form_fields(doc.select('.container-fluid form')[0]))
 
         doc = self.post_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug),
                             extract_form_fields(doc.select('.container-fluid form')[0]))
@@ -60,7 +61,6 @@ class EventsTest(SoupTest):
         doc.select("[name=settings-timezone]")[0]['value'] = "Asia/Tokyo"
         doc.find('option', {"value": "Asia/Tokyo"})['selected'] = 'selected'
         doc.find('option', {"value": "UTC"}).attrs.pop('selected')
-        print(extract_form_fields(doc.select('.container-fluid form')[0]))
 
         doc = self.post_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug),
                             extract_form_fields(doc.select('.container-fluid form')[0]))
@@ -69,6 +69,11 @@ class EventsTest(SoupTest):
         assert doc.select("[name=date_to]")[0]['value'] == "2013-12-30 17:00:00"
         assert doc.find('option', {"value": "Asia/Tokyo"})['selected'] == "selected"
         assert doc.select("[name=settings-max_items_per_order]")[0]['value'] == "12"
+
+        self.event1.refresh_from_db()
+        # Asia/Tokyo -> GMT+9
+        assert self.event1.date_to.strftime('%Y-%m-%d %H:%M:%S') == "2013-12-30 08:00:00"
+        assert self.event1.settings.timezone == 'Asia/Tokyo'
 
     def test_plugins(self):
         doc = self.get_doc('/control/event/%s/%s/settings/plugins' % (self.orga1.slug, self.event1.slug))
@@ -312,4 +317,72 @@ class EventsTest(SoupTest):
         assert ev.currency == 'EUR'
         assert ev.settings.timezone == 'Europe/Berlin'
         assert ev.organizer == self.orga1
+        assert ev.location == LazyI18nString({'de': 'Hamburg', 'en': 'Hamburg'})
         assert EventPermission.objects.filter(event=ev, user=self.user).exists()
+
+        berlin_tz = timezone('Europe/Berlin')
+        assert ev.date_from == berlin_tz.localize(datetime.datetime(2016, 12, 27, 10, 0, 0)).astimezone(pytz.utc)
+        assert ev.date_to == berlin_tz.localize(datetime.datetime(2016, 12, 30, 19, 0, 0)).astimezone(pytz.utc)
+        assert ev.presale_start == berlin_tz.localize(datetime.datetime(2016, 11, 1, 10, 0, 0)).astimezone(pytz.utc)
+        assert ev.presale_end == berlin_tz.localize(datetime.datetime(2016, 11, 30, 18, 0, 0)).astimezone(pytz.utc)
+
+    def test_create_event_only_date_from(self):
+        # date_to, presale_start & presale_end are optional fields
+        self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'foundation',
+            'foundation-organizer': self.orga1.pk,
+            'foundation-locales': 'en'
+        })
+        self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'basics',
+            'basics-name_0': '33C3',
+            'basics-slug': '33c3',
+            'basics-date_from': '2016-12-27 10:00:00',
+            'basics-date_to': '',
+            'basics-location_0': 'Hamburg',
+            'basics-currency': 'EUR',
+            'basics-locale': 'en',
+            'basics-timezone': 'UTC',
+            'basics-presale_start': '',
+            'basics-presale_end': '',
+        })
+        self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'copy',
+            'copy-copy_from_event': ''
+        })
+
+        ev = Event.objects.get(slug='33c3')
+        assert ev.name == LazyI18nString({'en': '33C3'})
+        assert ev.settings.locales == ['en']
+        assert ev.settings.locale == 'en'
+        assert ev.currency == 'EUR'
+        assert ev.settings.timezone == 'UTC'
+        assert ev.organizer == self.orga1
+        assert ev.location == LazyI18nString({'en': 'Hamburg'})
+        assert EventPermission.objects.filter(event=ev, user=self.user).exists()
+        assert ev.date_from == datetime.datetime(2016, 12, 27, 10, 0, 0, tzinfo=pytz.utc)
+        assert ev.date_to is None
+        assert ev.presale_start is None
+        assert ev.presale_end is None
+
+    def test_create_event_missing_date_from(self):
+        # date_from is mandatory
+        self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'foundation',
+            'foundation-organizer': self.orga1.pk,
+            'foundation-locales': 'en'
+        })
+        doc = self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'basics',
+            'basics-name_0': '33C3',
+            'basics-slug': '33c3',
+            'basics-date_from': '',
+            'basics-date_to': '2016-12-30 19:00:00',
+            'basics-location_0': 'Hamburg',
+            'basics-currency': 'EUR',
+            'basics-locale': 'en',
+            'basics-timezone': 'Europe/Berlin',
+            'basics-presale_start': '2016-11-20 11:00:00',
+            'basics-presale_end': '2016-11-24 18:00:00',
+        })
+        assert doc.select(".alert-danger")

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -53,6 +53,23 @@ class EventsTest(SoupTest):
         assert doc.select("[name=date_to]")[0]['value'] == "2013-12-30 17:00:00"
         assert doc.select("[name=settings-max_items_per_order]")[0]['value'] == "12"
 
+    def test_settings_timezone(self):
+        doc = self.get_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug))
+        doc.select("[name=date_to]")[0]['value'] = "2013-12-30 17:00:00"
+        doc.select("[name=settings-max_items_per_order]")[0]['value'] = "12"
+        doc.select("[name=settings-timezone]")[0]['value'] = "Asia/Tokyo"
+        doc.find('option', {"value": "Asia/Tokyo"})['selected'] = 'selected'
+        doc.find('option', {"value": "UTC"}).attrs.pop('selected')
+        print(extract_form_fields(doc.select('.container-fluid form')[0]))
+
+        doc = self.post_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug),
+                            extract_form_fields(doc.select('.container-fluid form')[0]))
+        assert len(doc.select(".alert-success")) > 0
+        # date_to should not be changed even though the timezone is changed
+        assert doc.select("[name=date_to]")[0]['value'] == "2013-12-30 17:00:00"
+        assert doc.find('option', {"value": "Asia/Tokyo"})['selected'] == "selected"
+        assert doc.select("[name=settings-max_items_per_order]")[0]['value'] == "12"
+
     def test_plugins(self):
         doc = self.get_doc('/control/event/%s/%s/settings/plugins' % (self.orga1.slug, self.event1.slug))
         self.assertIn("PayPal", doc.select(".form-plugins")[0].text)


### PR DESCRIPTION
Hi, this is the PR for fixing #428 .

**event creation**
This has been fixed by adding timezone to date related values in `clean` method in `EventWizardBasicsForm`.

**event update**
I still have no idea how I can fix it. (Sorry I'm pretty new to django..)
>From the top of my head, I would go neither for option 1 nor for option 2. EventWizard and EventUpdate are views, which are rather to high-level for this kind of thing and Event is a model which is rather to low-level for this. In my opinion, the golden middle road would be the forms involved, which are EventWizardBasicsForm and EventUpdateForm. We could do it in the save() methods there but I think an even better way might be the clean() method in Django's validation cycle.

@raphaelm I just learnt the django's validation cycle you mentioned in the comment from #428. Thanks! 👍 👍  However, I am wondering whether we can use the same technique in event update.
Since `timezone` is stored in `EventSettingsForm` while `date_to` (as well as the other 3 fields) are stored in `EventUpdateForm`, I can't use (more like I don't know how to use... ) the timezone to update all 4 fields in `clean` method. Since `EventUpdate` view is the bridge between the two forms, should I also change part of the logic there?