### PR TITLE
Change event currency to use a choice attribute

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -26,6 +26,7 @@ from .auth import User
 from .organizer import Organizer
 from .settings import EventSetting
 
+
 class Event(LoggedModel):
     """
     This model represents an event. An event is anything you can buy
@@ -80,8 +81,8 @@ class Event(LoggedModel):
     live = models.BooleanField(default=False, verbose_name=_("Shop is live"))
     permitted = models.ManyToManyField(User, through='EventPermission',
                                        related_name="events", )
-    CURRENCY_CHOICES = [(settings.CURRENCIES[i].alpha_3, settings.CURRENCIES[i].alpha_3 + " - " + settings.CURRENCIES[i].name)\
-            for i in range(0, len(settings.CURRENCIES))]
+    CURRENCY_CHOICES = [(settings.CURRENCIES[i].alpha_3, settings.CURRENCIES[i].alpha_3 + " - " + settings.CURRENCIES[i].name)
+                        for i in range(0, len(settings.CURRENCIES))]
     currency = models.CharField(max_length=10,
                                 verbose_name=_("Default currency"),
                                 choices=CURRENCY_CHOICES,

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -26,7 +26,6 @@ from .auth import User
 from .organizer import Organizer
 from .settings import EventSetting
 
-
 class Event(LoggedModel):
     """
     This model represents an event. An event is anything you can buy
@@ -81,8 +80,11 @@ class Event(LoggedModel):
     live = models.BooleanField(default=False, verbose_name=_("Shop is live"))
     permitted = models.ManyToManyField(User, through='EventPermission',
                                        related_name="events", )
+    CURRENCY_CHOICES = [(settings.CURRENCIES[i].alpha_3, settings.CURRENCIES[i].alpha_3 + " - " + settings.CURRENCIES[i].name)\
+            for i in range(0, len(settings.CURRENCIES))]
     currency = models.CharField(max_length=10,
                                 verbose_name=_("Default currency"),
+                                choices=CURRENCY_CHOICES,
                                 default=settings.DEFAULT_CURRENCY)
     date_from = models.DateTimeField(verbose_name=_("Event start time"))
     date_to = models.DateTimeField(null=True, blank=True,

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -59,6 +59,7 @@ class Event(LoggedModel):
     """
 
     settings_namespace = 'event'
+    CURRENCY_CHOICES = [(c.alpha_3, c.alpha_3 + " - " + c.name) for c in settings.CURRENCIES]
     organizer = models.ForeignKey(Organizer, related_name="events", on_delete=models.PROTECT)
     name = I18nCharField(
         max_length=200,
@@ -81,8 +82,6 @@ class Event(LoggedModel):
     live = models.BooleanField(default=False, verbose_name=_("Shop is live"))
     permitted = models.ManyToManyField(User, through='EventPermission',
                                        related_name="events", )
-    CURRENCY_CHOICES = [(settings.CURRENCIES[i].alpha_3, settings.CURRENCIES[i].alpha_3 + " - " + settings.CURRENCIES[i].name)
-                        for i in range(0, len(settings.CURRENCIES))]
     currency = models.CharField(max_length=10,
                                 verbose_name=_("Default currency"),
                                 choices=CURRENCY_CHOICES,

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import sys
+from pycountry import currencies
 
 import django.conf.locale
 from django.contrib.messages import constants as messages  # NOQA
@@ -85,6 +86,7 @@ PRETIX_PLUGINS_DEFAULT = config.get('pretix', 'plugins_default',
                                     fallback='pretix.plugins.sendmail,pretix.plugins.statistics')
 
 DEFAULT_CURRENCY = config.get('pretix', 'currency', fallback='EUR')
+CURRENCIES = list(currencies)
 
 ALLOWED_HOSTS = ['*']
 

--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -37,3 +37,4 @@ pycparser==2.13  # https://github.com/eliben/pycparser/issues/147
 chardet>=2.3,<3
 mt-940==3.2
 vobject==0.9.*
+pycountry

--- a/src/setup.py
+++ b/src/setup.py
@@ -98,7 +98,8 @@ setup(
         'chardet>=2.3,<3',
         'mt-940==3.2',
         'django-i18nfield',
-        'vobject==0.9.*'
+        'vobject==0.9.*',
+        'pycountry'
     ],
     extras_require={
         'dev': [

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -430,4 +430,3 @@ class EventsTest(SoupTest):
             'basics-presale_end': '2016-11-30 18:00:00',
         })
         assert doc.select(".alert-danger")
-

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -386,3 +386,48 @@ class EventsTest(SoupTest):
             'basics-presale_end': '2016-11-24 18:00:00',
         })
         assert doc.select(".alert-danger")
+
+    def test_create_event_currency_symbol(self):
+        doc = self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'foundation',
+            'foundation-organizer': self.orga1.pk,
+            'foundation-locales': 'en'
+        })
+
+        doc = self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'basics',
+            'basics-name_0': '33C3',
+            'basics-slug': '31c4',
+            'basics-date_from': '2016-12-27 10:00:00',
+            'basics-date_to': '2016-12-30 19:00:00',
+            'basics-location_0': 'Hamburg',
+            'basics-currency': '$',
+            'basics-locale': 'en',
+            'basics-timezone': 'Europe/Berlin',
+            'basics-presale_start': '2016-11-01 10:00:00',
+            'basics-presale_end': '2016-11-30 18:00:00',
+        })
+        assert doc.select(".alert-danger")
+
+    def test_create_event_non_iso_currency(self):
+        doc = self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'foundation',
+            'foundation-organizer': self.orga1.pk,
+            'foundation-locales': 'en'
+        })
+
+        doc = self.post_doc('/control/events/add', {
+            'event_wizard-current_step': 'basics',
+            'basics-name_0': '33C3',
+            'basics-slug': '31c5',
+            'basics-date_from': '2016-12-27 10:00:00',
+            'basics-date_to': '2016-12-30 19:00:00',
+            'basics-location_0': 'Hamburg',
+            'basics-currency': 'ASD',
+            'basics-locale': 'en',
+            'basics-timezone': 'Europe/Berlin',
+            'basics-presale_start': '2016-11-01 10:00:00',
+            'basics-presale_end': '2016-11-30 18:00:00',
+        })
+        assert doc.select(".alert-danger")
+


### PR DESCRIPTION
Fixes #446 

Uses a choice attribute so the event currency will be a 3 character ISO currency. Also, adds pycountry to the requirements which provide the list of countries and currencies. 