### PR TITLE
Include some missing security headers

### DIFF
--- a/deployment/docker/nginx.conf
+++ b/deployment/docker/nginx.conf
@@ -22,9 +22,11 @@ http {
 
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
+	add_header X-Content-Type-Options nosniff;
 
 	access_log /var/log/nginx/access.log private;
 	error_log /var/log/nginx/error.log;
+	add_header Referrer-Policy same-origin
 
 	gzip on;
 	gzip_disable "msie6";

--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -213,6 +213,9 @@ The following snippet is an example on how to configure a nginx proxy for pretix
         ssl_certificate /path/to/cert.chain.pem;
         ssl_certificate_key /path/to/key.pem;
 
+        add_header Referrer-Options same-origin;
+        add_header X-Content-Type-Options nosniff;
+
         location / {
             proxy_pass http://localhost:8345/;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This change adds the following security headers:
* X-Content-Type-Options to prevent content type sniffing
* Referrer-Policy to prevent leaking referrer information when navigating away from the instance