### PR TITLE
Added missing semicolon to docker nginx config

### DIFF
--- a/deployment/docker/nginx.conf
+++ b/deployment/docker/nginx.conf
@@ -26,7 +26,7 @@ http {
 
 	access_log /var/log/nginx/access.log private;
 	error_log /var/log/nginx/error.log;
-	add_header Referrer-Policy same-origin
+	add_header Referrer-Policy same-origin;
 
 	gzip on;
 	gzip_disable "msie6";


### PR DESCRIPTION
...which results in docker container setup not starting properly.
You can see the log message setting up the container and entering
`docker exec -it --user root pretix.service cat /var/log/nginx/error.log`