### PR TITLE
Allow products to be excluded from ticket-generation

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -163,6 +163,10 @@ DEFAULTS = {
         'default': 'False',
         'type': bool
     },
+    'ticket_download_nonadm': {
+        'default': 'True',
+        'type': bool
+    },
     'last_order_modification_date': {
         'default': None,
         'type': datetime

--- a/src/pretix/base/ticketoutput.py
+++ b/src/pretix/base/ticketoutput.py
@@ -54,11 +54,14 @@ class BaseTicketOutput:
 
         If you override this method, make sure that positions that are addons (i.e. ``addon_to``
         is set) are only outputted if the event setting ``ticket_download_addons`` is active.
+        Do the same for positions that are non-admission without ``ticket_download_nonadm`` active.
         """
         with tempfile.TemporaryDirectory() as d:
             with ZipFile(os.path.join(d, 'tmp.zip'), 'w') as zipf:
                 for pos in order.positions.all():
                     if pos.addon_to_id and not self.event.settings.ticket_download_addons:
+                        continue
+                    if not pos.item.admission and not self.event.settings.ticket_download_nonadm:
                         continue
                     fname, __, content = self.generate(pos)
                     zipf.writestr('{}-{}{}'.format(

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -624,6 +624,11 @@ class TicketSettingsForm(SettingsForm):
         required=False,
         widget=forms.CheckboxInput(attrs={'data-display-dependency': '#id_ticket_download'}),
     )
+    ticket_download_nonadm = forms.BooleanField(
+        label=_("Generate tickets for non-admission products"),
+        required=False,
+        widget=forms.CheckboxInput(attrs={'data-display-dependency': '#id_ticket_download'}),
+    )
 
     def prepare_fields(self):
         # See clean()

--- a/src/pretix/control/templates/pretixcontrol/event/tickets.html
+++ b/src/pretix/control/templates/pretixcontrol/event/tickets.html
@@ -10,6 +10,7 @@
             {% bootstrap_field form.ticket_download layout="horizontal" %}
             {% bootstrap_field form.ticket_download_date layout="horizontal" %}
             {% bootstrap_field form.ticket_download_addons layout="horizontal" %}
+            {% bootstrap_field form.ticket_download_nonadm layout="horizontal" %}
             {% for provider in providers %}
                 <div class="panel panel-default ticketoutput-panel">
                     <div class="panel-heading">

--- a/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
+++ b/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
@@ -93,6 +93,8 @@ class PdfTicketOutput(BaseTicketOutput):
         for op in order.positions.all():
             if op.addon_to_id and not self.event.settings.ticket_download_addons:
                 continue
+            if not op.item.admission and not self.event.settings.ticket_download_nonadm:
+                continue
             self._draw_page(p, op, order)
         p.save()
         outbuffer = self._render_with_background(buffer)

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load eventurl %}
 {% for line in cart.positions %}
-    <div class="row cart-row {% if download %}has-downloads{% endif %}">
+    <div class="row cart-row {% if download and line.item.admission|default:event.settings.ticket_download_nonadm %}has-downloads{% endif %}">
         <div class="product">
             {% if line.addon_to %}
                 <span class="addon-signifier">+</span>
@@ -33,7 +33,7 @@
             {% endif %}
         </div>
 
-        {% if download %}
+        {% if download and line.item.admission|default:event.settings.ticket_download_nonadm %}
             <div class="download-desktop">
                 {% if not line.addon_to or event.settings.ticket_download_addons %}
                     {% for b in download_buttons %}

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -544,6 +544,8 @@ class OrderDownload(EventViewMixin, OrderDetailMixin, View):
             return self.error(_('Ticket download is not (yet) enabled.'))
         if 'position' in kwargs and (self.order_position.addon_to and not self.request.event.settings.ticket_download_addons):
             return self.error(_('Ticket download is not enabled for add-on products.'))
+        if 'position' in kwargs and (not self.order_position.item.admission and not self.request.event.settings.ticket_download_nonadm):
+            return self.error(_('Ticket download is not enabled for non-admission products.'))
 
         if 'position' in kwargs:
             return self._download_position()


### PR DESCRIPTION
Per #456, allow products designated as non-admission to be excluded from ticket generation.

Includes the following:  
* Events setting `ticket_generation_nonadm` for generating tickets for non-admission products (defaults to true for backwards compatibility)  
* Logic to remove download button for non-relevant line items in order view  
* Error for non-admission items (if not allowed) in single ticket download and multi-ticket download.

Thanks to @raphaelm with https://github.com/pretix/pretix/issues/456#issuecomment-298421117 for assistance on what needed to be done here.
Closes #456.