### PR TITLE
Marked webfonts as binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,13 @@ src/static/typeahead/* linguist-vendored
 src/static/moment/* linguist-vendored
 src/static/datetimepicker/* linguist-vendored
 src/static/charts/* linguist-vendored
+
+# Denote all files that are truly binary and should not be modified.
+*.eot binary
+*.otf binary
+*.ttf binary
+*.woff binary
+*.zip binary
+*.png binary
+*.gif binary
+*.jpg binary


### PR DESCRIPTION
`.gitattributes` is used in the cloning process for, among other things, determining if a file is text, and needs to have line-endings converted. Doing this to the binary webfont files will cause issues with using them.
When merged, fixes #486.