### PR TITLE
fixed bug for same dates, added unit check for daterange

### DIFF
--- a/src/pretix/helpers/daterange.py
+++ b/src/pretix/helpers/daterange.py
@@ -6,12 +6,16 @@ def daterange(df, dt):
     lng = get_language()
 
     if lng.startswith("de"):
-        if df.year == dt.year and df.month == dt.month:
+        if df.year == dt.year and df.month == dt.month and df.day == dt.day:
+            return "{}".format(_date(df, "j. F Y"))
+        elif df.year == dt.year and df.month == dt.month:
             return "{}.–{}".format(_date(df, "j"), _date(dt, "j. F Y"))
         elif df.year == dt.year:
             return "{} – {}".format(_date(df, "j. F"), _date(dt, "j. F Y"))
     elif lng.startswith("en"):
-        if df.year == dt.year and df.month == dt.month:
+        if df.year == dt.year and df.month == dt.month and df.day == dt.day:
+            return "{}".format(_date(df, "N jS, Y"))
+        elif df.year == dt.year and df.month == dt.month:
             return "{} – {}".format(_date(df, "N jS"), _date(dt, "jS, Y"))
         elif df.year == dt.year:
             return "{} – {}".format(_date(df, "N jS"), _date(dt, "N jS, Y"))

--- a/src/tests/helpers/test_daterange.py
+++ b/src/tests/helpers/test_daterange.py
@@ -4,54 +4,54 @@ from pretix.helpers.daterange import daterange
 
 
 def test_same_day_german():
-    translation.activate('de')
-    df = date(2003, 2, 1)
-    assert daterange(df, df) == "1. Februar 2003"
+    with translation.override('de'):
+        df = date(2003, 2, 1)
+        assert daterange(df, df) == "1. Februar 2003"
 
 
 def test_same_day_english():
-    translation.activate('en')
-    df = date(2003, 2, 1)
-    assert daterange(df, df) == "Feb. 1st, 2003"
+    with translation.override('en'):
+        df = date(2003, 2, 1)
+        assert daterange(df, df) == "Feb. 1st, 2003"
 
 
 def test_same_month_german():
-    translation.activate('de')
-    df = date(2003, 2, 1)
-    dt = date(2003, 2, 3)
-    assert daterange(df, dt) == "1.–3. Februar 2003"
+    with translation.override('de'):
+        df = date(2003, 2, 1)
+        dt = date(2003, 2, 3)
+        assert daterange(df, dt) == "1.–3. Februar 2003"
 
 
 def test_same_month_english():
-    translation.activate('en')
-    df = date(2003, 2, 1)
-    dt = date(2003, 2, 3)
-    assert daterange(df, dt) == "Feb. 1st – 3rd, 2003"
+    with translation.override('en'):
+        df = date(2003, 2, 1)
+        dt = date(2003, 2, 3)
+        assert daterange(df, dt) == "Feb. 1st – 3rd, 2003"
 
 
 def test_same_year_german():
-    translation.activate('de')
-    df = date(2003, 2, 1)
-    dt = date(2003, 4, 3)
-    assert daterange(df, dt) == "1. Februar – 3. April 2003"
+    with translation.override('de'):
+        df = date(2003, 2, 1)
+        dt = date(2003, 4, 3)
+        assert daterange(df, dt) == "1. Februar – 3. April 2003"
 
 
 def test_same_year_english():
-    translation.activate('en')
-    df = date(2003, 2, 1)
-    dt = date(2003, 4, 3)
-    assert daterange(df, dt) == "Feb. 1st – April 3rd, 2003"
+    with translation.override('en'):
+        df = date(2003, 2, 1)
+        dt = date(2003, 4, 3)
+        assert daterange(df, dt) == "Feb. 1st – April 3rd, 2003"
 
 
 def test_different_dates_german():
-    translation.activate('de')
-    df = date(2003, 2, 1)
-    dt = date(2005, 4, 3)
-    assert daterange(df, dt) == "1. Februar 2003 – 3. April 2005"
+    with translation.override('de'):
+        df = date(2003, 2, 1)
+        dt = date(2005, 4, 3)
+        assert daterange(df, dt) == "1. Februar 2003 – 3. April 2005"
 
 
 def test_different_dates_english():
-    translation.activate('en')
-    df = date(2003, 2, 1)
-    dt = date(2005, 4, 3)
-    assert daterange(df, dt) == "Feb. 1, 2003 – April 3, 2005"
+    with translation.override('en'):
+        df = date(2003, 2, 1)
+        dt = date(2005, 4, 3)
+        assert daterange(df, dt) == "Feb. 1, 2003 – April 3, 2005"

--- a/src/tests/helpers/test_daterange.py
+++ b/src/tests/helpers/test_daterange.py
@@ -1,0 +1,57 @@
+from datetime import date
+from django.utils import translation
+from pretix.helpers.daterange import daterange
+
+
+def test_same_day_german():
+    translation.activate('de')
+    df = date(2003, 2, 1)
+    assert daterange(df, df) == "1. Februar 2003"
+
+
+def test_same_day_english():
+    translation.activate('en')
+    df = date(2003, 2, 1)
+    assert daterange(df, df) == "Feb. 1st, 2003"
+
+
+def test_same_month_german():
+    translation.activate('de')
+    df = date(2003, 2, 1)
+    dt = date(2003, 2, 3)
+    assert daterange(df, dt) == "1.–3. Februar 2003"
+
+
+def test_same_month_english():
+    translation.activate('en')
+    df = date(2003, 2, 1)
+    dt = date(2003, 2, 3)
+    assert daterange(df, dt) == "Feb. 1st – 3rd, 2003"
+
+
+def test_same_year_german():
+    translation.activate('de')
+    df = date(2003, 2, 1)
+    dt = date(2003, 4, 3)
+    assert daterange(df, dt) == "1. Februar – 3. April 2003"
+
+
+def test_same_year_english():
+    translation.activate('en')
+    df = date(2003, 2, 1)
+    dt = date(2003, 4, 3)
+    assert daterange(df, dt) == "Feb. 1st – April 3rd, 2003"
+
+
+def test_different_dates_german():
+    translation.activate('de')
+    df = date(2003, 2, 1)
+    dt = date(2005, 4, 3)
+    assert daterange(df, dt) == "1. Februar 2003 – 3. April 2005"
+
+
+def test_different_dates_english():
+    translation.activate('en')
+    df = date(2003, 2, 1)
+    dt = date(2005, 4, 3)
+    assert daterange(df, dt) == "Feb. 1, 2003 – April 3, 2005"


### PR DESCRIPTION
Hey,

in this commit I fixed a bug in `daterange.py`. `daterange(df,dt)` now does what it should if the two dates are equal: It returns the string for one day.
I also added a (probably _slightly_ overkill) unit test.

Cheers
Marvin