### PR TITLE
Added configurable text for organizer page

### DIFF
--- a/src/pretix/base/templatetags/rich_text.py
+++ b/src/pretix/base/templatetags/rich_text.py
@@ -47,6 +47,7 @@ def rich_text(text: str, **kwargs):
     """
     Processes markdown and cleans HTML in a text input.
     """
+    text = str(text)
     body_md = bleach.linkify(bleach.clean(
         markdown.markdown(text),
         tags=ALLOWED_TAGS,

--- a/src/pretix/control/forms/organizer.py
+++ b/src/pretix/control/forms/organizer.py
@@ -1,6 +1,8 @@
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
+from i18nfield.forms import I18nFormField, I18nTextarea
 
 from pretix.base.forms import I18nModelForm, SettingsForm
 from pretix.base.models import Organizer, Team
@@ -102,6 +104,20 @@ class TeamForm(forms.ModelForm):
 
 
 class OrganizerSettingsForm(SettingsForm):
+
+    locales = forms.MultipleChoiceField(
+        choices=settings.LANGUAGES,
+        label=_("Use languages"),
+        widget=forms.CheckboxSelectMultiple,
+        help_text=_('Choose all languages that your organizer homepage should be available in.')
+    )
+
+    organizer_homepage_text = I18nFormField(
+        label=_('Homepage text'),
+        required=False,
+        widget=I18nTextarea,
+        help_text=_('This will be displayed on the organizer homepage.')
+    )
 
     organizer_logo_image = ExtFileField(
         label=_('Logo image'),

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -18,7 +18,9 @@
         <fieldset>
             <legend>{% trans "Display settings" %}</legend>
             {% bootstrap_form_errors sform %}
+            {% bootstrap_field sform.locales layout="horizontal" %}
             {% bootstrap_field sform.organizer_logo_image layout="horizontal" %}
+            {% bootstrap_field sform.organizer_homepage_text layout="horizontal" %}
         </fieldset>
         <div class="form-group submit-group">
             <button type="submit" class="btn btn-primary btn-save">

--- a/src/pretix/presale/context.py
+++ b/src/pretix/presale/context.py
@@ -56,6 +56,7 @@ def contextprocessor(request):
 
     if hasattr(request, 'organizer'):
         ctx['organizer_logo'] = request.organizer.settings.get('organizer_logo_image', as_type=str, default='')[7:]
+        ctx['organizer_homepage_text'] = request.organizer.settings.get('organizer_homepage_text', as_type=LazyI18nString)
         ctx['organizer'] = request.organizer
 
     ctx['html_head'] = "".join(_html_head)

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -1,8 +1,14 @@
 {% extends "pretixpresale/organizers/base.html" %}
 {% load i18n %}
+{% load rich_text %}
 {% load eventurl %}
 {% block title %}{% trans "Event list" %}{% endblock %}
 {% block content %}
+    <div>
+	{% if organizer_homepage_text %}
+                {{ organizer_homepage_text | rich_text }}
+	{% endif %}
+    </div>	
     {% if "old" in request.GET %}
         <h3>Past events</h3>
         <p>


### PR DESCRIPTION
This PR adds a configurable text that can be displayed under an organizer's name on the corresponding page. Things to follow in near future:

- organizers might be given language options (overwritten by events' language options) allowing language selection at an organizer's front end page
- unit tests will be added after some more work on the organizer page
- `rich_text` filter tag should recognize single newlines