### PR TITLE
added missing spaces in DE and DE_informal

### DIFF
--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -4928,7 +4928,7 @@ msgid ""
 msgstr ""
 "Bitte wählen Sie die Produkte oder Produktvariationen aus, auf die dieses "
 "Kontingent wirken soll. Wenn Sie ein Produkt zu zwei Kontingenten "
-"hinzufügen, wird es nur verkauft, wenn <strong>beide</strong>Kontingente "
+"hinzufügen, wird es nur verkauft, wenn <strong>beide</strong> Kontingente "
 "noch übrige Kapazität haben."
 
 #: pretix/control/templates/pretixcontrol/items/quotas.html:7

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -4932,7 +4932,7 @@ msgid ""
 msgstr ""
 "Bitte wähle die Produkte oder Produktvariationen aus, auf die dieses "
 "Kontingent wirken soll. Wenn du ein Produkt zu zwei Kontingenten hinzufügen, "
-"wird es nur verkauft, wenn <strong>beide</strong>Kontingente noch übrige "
+"wird es nur verkauft, wenn <strong>beide</strong> Kontingente noch übrige "
 "Kapazität haben."
 
 #: pretix/control/templates/pretixcontrol/items/quotas.html:7


### PR DESCRIPTION
There was a space missing in de and de_informal in the description for the quota edit.

Hopefully this is the right way to send you guys my edit.

Best regards.