### PR TITLE
Read payment details from MT940 NS tags too

### DIFF
--- a/src/pretix/plugins/banktransfer/mt940import.py
+++ b/src/pretix/plugins/banktransfer/mt940import.py
@@ -20,7 +20,7 @@ def parse(file):
         result.append({
             'reference': "\n".join([
                 t.data.get(f) for f in ('transaction_details', 'customer_reference', 'bank_reference',
-                                        'extra_details') if t.data.get(f, '')]),
+                                        'extra_details', 'non_swift_text') if t.data.get(f, '')]),
             'amount': str(round_decimal(t.data['amount'].amount)),
             'date': t.data['date'].isoformat()
         })

--- a/src/pretix/plugins/banktransfer/tasks.py
+++ b/src/pretix/plugins/banktransfer/tasks.py
@@ -84,7 +84,7 @@ def _get_unknown_transactions(event: Event, job: BankImportJob, data: list):
             amount = Decimal("0.00")
 
         trans = BankTransaction(event=event, import_job=job,
-                                payer=row['payer'],
+                                payer=row.get('payer', ''),
                                 reference=row['reference'],
                                 amount=amount,
                                 date=row['date'])

--- a/src/setup.py
+++ b/src/setup.py
@@ -97,7 +97,7 @@ setup(
         'redis==2.10.5',
         'stripe==1.22.*',
         'chardet>=2.3,<3',
-        'mt-940==3.2',
+        'mt-940==4.7',
         'django-i18nfield>=1.0.1',
         'vobject==0.9.*',
         'pycountry'


### PR DESCRIPTION
Payment details from raiffaisen.ch are only available in non-SWIFT (NS) tags. Thus added support for these tags in mt940. Now use the newer version and also parse these fields when available.