### PR TITLE
fix for #454 - made email field required on admin user settings page

### DIFF
--- a/src/pretix/base/forms/user.py
+++ b/src/pretix/base/forms/user.py
@@ -48,6 +48,7 @@ class UserSettingsForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')
         super().__init__(*args, **kwargs)
+        self.fields['email'].required = True
 
     def clean_old_pw(self):
         old_pw = self.cleaned_data.get('old_pw')


### PR DESCRIPTION
This is a fix for issue #454.

The email field has now been set to required on the admin user account settings page.