### PR TITLE
Allow to pass prefix to generate_code, too

### DIFF
--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -20,9 +20,9 @@ def _generate_random_code(prefix=None):
     return get_random_string(length=settings.ENTROPY['voucher_code'], allowed_chars=charset)
 
 
-def generate_code():
+def generate_code(prefix=None):
     while True:
-        code = _generate_random_code()
+        code = _generate_random_code(prefix=prefix)
         if not Voucher.objects.filter(code=code).exists():
             return code
 


### PR DESCRIPTION
Useful in plugins if you don't want to replicate the uniqueness loop.