### PR TITLE
Fix #516 -- Prevent gaps in plugin list

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/plugins.html
+++ b/src/pretix/control/templates/pretixcontrol/event/plugins.html
@@ -11,7 +11,7 @@
 					{% trans "Your changes have been saved." %}
 				</div>
 			{% endif %}
-            <div class="row">
+            <div class="row row-plugins">
                 {% for plugin in plugins %}
                     <div class="col-md-6 col-sm-12">
                         <div class="panel panel-{% if plugin.app.compatibility_errors %}warning{% elif plugin.module in plugins_active %}success{% else %}default{% endif %}">

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -351,3 +351,21 @@ body.loading #wrapper {
     padding: 6px 10px;
     color: white !important;
 }
+
+@media (min-width: $screen-md-min) {
+    .row-plugins {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .row-plugins > [class*=col] {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .row-plugins > [class*=col] > .panel {
+        height: 100%
+    }
+}
+
+


### PR DESCRIPTION
Use flexbox to fix misalignment when column height is imbalanced.