### PR TITLE
Fix #130: Mark required question fields at checkout

### DIFF
--- a/src/pretix/presale/forms/checkout.py
+++ b/src/pretix/presale/forms/checkout.py
@@ -19,6 +19,7 @@ from pretix.presale.signals import contact_form_fields, question_form_fields
 
 
 class ContactForm(forms.Form):
+    required_css_class = 'required'
     email = forms.EmailField(label=_('E-mail'),
                              help_text=_('Make sure to enter a valid email address. We will send you an order '
                                          'confirmation including a link that you need in case you want to make '
@@ -48,6 +49,7 @@ class ContactForm(forms.Form):
 
 
 class InvoiceAddressForm(forms.ModelForm):
+    required_css_class = 'required'
 
     class Meta:
         model = InvoiceAddress
@@ -61,6 +63,7 @@ class InvoiceAddressForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.event = event = kwargs.pop('event')
         super().__init__(*args, **kwargs)
+        self.fields['name'].form_group_class = 'required'
         if not event.settings.invoice_address_vatid:
             del self.fields['vat_id']
         if not event.settings.invoice_address_required:

--- a/src/pretix/presale/forms/checkout.py
+++ b/src/pretix/presale/forms/checkout.py
@@ -118,6 +118,7 @@ class QuestionsForm(forms.Form):
     the attendee name for admission tickets, if the corresponding setting is enabled,
     as well as additional questions defined by the organizer.
     """
+    required_css_class = 'required'
 
     def __init__(self, *args, **kwargs):
         """

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
@@ -5,6 +5,11 @@
 {% block content %}
     <h2>{% trans "Checkout" %}</h2>
     <p>{% trans "Before we continue, we need you to answer some questions." %}</p>
+    <p class="required-legend">
+        {% blocktrans trimmed %}
+            You need to fill all fields that are marked with <span>*</span> to continue.
+        {% endblocktrans %}
+    </p>
     <form class="form-horizontal" method="post" enctype="multipart/form-data">
         {% csrf_token %}
         <div class="panel-group" id="questions_group">

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -34,6 +34,10 @@
   }
 }
 
+.required-legend span {
+  color: $brand-primary;
+  font-weight: bold;
+}
 .form-group.required .control-label:after {
   content: '*';
   color: $brand-primary

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -33,3 +33,8 @@
     @include box-shadow($shadow);
   }
 }
+
+.form-group.required .control-label:after {
+  content: '*';
+  color: $brand-primary
+}


### PR DESCRIPTION
This adds a new css class `required` to all form-groups that correspond to a required field. I then added a piece of CSS that adds a purple asterisk to the end of the labels in these fields.

![Screenshot](https://user-images.githubusercontent.com/5310424/28314276-2bdf1ed6-6bba-11e7-9443-bf736c435dec.PNG)
