### PR TITLE
throw exception if PRETIX_CONFIG_FILE can not be opened

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -14,7 +14,7 @@ from . import __version__
 
 config = configparser.RawConfigParser()
 if 'PRETIX_CONFIG_FILE' in os.environ:
-    config.read([os.environ.get('PRETIX_CONFIG_FILE')], encoding='utf-8')
+    config.read_file(open(os.environ.get('PRETIX_CONFIG_FILE'), encoding='utf-8'))
 else:
     config.read(['/etc/pretix/pretix.cfg', os.path.expanduser('~/.pretix.cfg'), 'pretix.cfg'],
                 encoding='utf-8')


### PR DESCRIPTION
If the environment variable PRETIX_CONFIG_FILE is set but the file can not be read because it does not exists or permission is denied, pretix just runs with default settings. When setting up a new installation this can be confusing and difficult to debug.

I think it is safe to assume that someone who sets PRETIX_CONFIG_FILE aims to point it at a readable file, so raising with a more understandable exception is expected or at least helpful. Otherwise, the user will usually get a DisallowedHost exception because the [pretix]url config variable is not set which is not as helpful.