### PR TITLE
fix wrong stripe version in setup.py

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -97,7 +97,7 @@ setup(
         'pycparser==2.13',
         'django-redis==4.7.*',
         'redis==2.10.5',
-        'stripe==1.22.*',
+        'stripe==1.62.*',
         'chardet<3.1.0,>=3.0.2',
         'mt-940==4.7',
         'django-i18nfield>=1.0.1',


### PR DESCRIPTION
When installing pretix from pip, stripe integration fails. This happens because [setup.py wants to install stripe==1.22.*](https://github.com/pretix/pretix/blob/5f607cc03409160437f6490032b04a463b4205ee/src/setup.py#L100) while [requirements/production.txt wants stripe==1.62.*](https://github.com/pretix/pretix/blob/5f607cc03409160437f6490032b04a463b4205ee/src/requirements/production.txt#L35) – the former is incorrect. Installing stripe 1.22.* causes [this line](https://github.com/pretix/pretix/blob/5f607cc03409160437f6490032b04a463b4205ee/src/pretix/plugins/stripe/payment.py#L384) to fail with `AttributeError: module 'stripe' has no attribute 'Source'`.

This commit updates the setup.py to require the correct version of the stripe bindings.