### PR TITLE
Organizer color & settings propagation

### DIFF
--- a/src/pretix/control/forms/organizer.py
+++ b/src/pretix/control/forms/organizer.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.utils.translation import ugettext_lazy as _
 from i18nfield.forms import I18nFormField, I18nTextarea
 
@@ -118,6 +119,16 @@ class OrganizerSettingsForm(SettingsForm):
         label=_("Use languages"),
         widget=forms.CheckboxSelectMultiple,
         help_text=_('Choose all languages that your organizer homepage should be available in.')
+    )
+
+    organizer_primary_color = forms.CharField(
+        label=_("Primary color"),
+        required=False,
+        validators=[
+            RegexValidator(regex='^#[0-9a-fA-F]{6}$',
+                           message=_('Please enter the hexadecimal code of a color, e.g. #990000.'))
+        ],
+        widget=forms.TextInput(attrs={'class': 'colorpickerfield'})
     )
 
     organizer_homepage_text = I18nFormField(

--- a/src/pretix/control/forms/organizer.py
+++ b/src/pretix/control/forms/organizer.py
@@ -9,6 +9,7 @@ from pretix.base.forms import I18nModelForm, SettingsForm
 from pretix.base.models import Organizer, Team
 from pretix.control.forms import ExtFileField
 from pretix.multidomain.models import KnownDomain
+from pretix.presale.style import get_fonts
 
 
 class OrganizerForm(I18nModelForm):
@@ -114,14 +115,16 @@ class TeamForm(forms.ModelForm):
 
 class OrganizerSettingsForm(SettingsForm):
 
-    locales = forms.MultipleChoiceField(
-        choices=settings.LANGUAGES,
-        label=_("Use languages"),
-        widget=forms.CheckboxSelectMultiple,
-        help_text=_('Choose all languages that your organizer homepage should be available in.')
+    organizer_info_text = I18nFormField(
+        label=_('Info text'),
+        required=False,
+        widget=I18nTextarea,
+        help_text=_('Not displayed anywhere by default, but if you want to, you can use this e.g. in ticket templates.')
     )
 
-    organizer_primary_color = forms.CharField(
+
+class OrganizerDisplaySettingsForm(SettingsForm):
+    primary_color = forms.CharField(
         label=_("Primary color"),
         required=False,
         validators=[
@@ -130,21 +133,12 @@ class OrganizerSettingsForm(SettingsForm):
         ],
         widget=forms.TextInput(attrs={'class': 'colorpickerfield'})
     )
-
     organizer_homepage_text = I18nFormField(
         label=_('Homepage text'),
         required=False,
         widget=I18nTextarea,
         help_text=_('This will be displayed on the organizer homepage.')
     )
-
-    organizer_info_text = I18nFormField(
-        label=_('Info text'),
-        required=False,
-        widget=I18nTextarea,
-        help_text=_('Not displayed anywhere by default, but if you want to, you can use this e.g. in ticket templates.')
-    )
-
     organizer_logo_image = ExtFileField(
         label=_('Logo image'),
         ext_whitelist=(".png", ".jpg", ".gif", ".jpeg"),
@@ -152,7 +146,6 @@ class OrganizerSettingsForm(SettingsForm):
         help_text=_('If you provide a logo image, we will by default not show your organization name '
                     'in the page header. We will show your logo with a maximal height of 120 pixels.')
     )
-
     event_list_type = forms.ChoiceField(
         label=_('Default overview style'),
         choices=(
@@ -160,3 +153,22 @@ class OrganizerSettingsForm(SettingsForm):
             ('calendar', _('Calendar'))
         )
     )
+    locales = forms.MultipleChoiceField(
+        choices=settings.LANGUAGES,
+        label=_("Use languages"),
+        widget=forms.CheckboxSelectMultiple,
+        help_text=_('Choose all languages that your organizer homepage should be available in.')
+    )
+    primary_font = forms.ChoiceField(
+        label=_('Font'),
+        choices=[
+            ('Open Sans', 'Open Sans')
+        ],
+        help_text=_('Only respected by modern browsers.')
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['primary_font'].choices += [
+            (a, a) for a in get_fonts()
+        ]

--- a/src/pretix/control/templates/pretixcontrol/event/base.html
+++ b/src/pretix/control/templates/pretixcontrol/event/base.html
@@ -8,7 +8,7 @@
         <a href="{% url 'control:event.index' organizer=request.event.organizer.slug event=request.event.slug %}"
                 {% if url_name == "event.index" %}class="active"{% endif %}>
             <i class="fa fa-dashboard fa-fw"></i>
-            {% trans "Dashboard" %}
+            {% trans "Event dashboard" %}
         </a>
     </li>
     {% if 'can_change_event_settings' in request.eventpermset %}

--- a/src/pretix/control/templates/pretixcontrol/event/display.html
+++ b/src/pretix/control/templates/pretixcontrol/event/display.html
@@ -1,17 +1,24 @@
 {% extends "pretixcontrol/event/settings_base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load hierarkey_form %}
 {% block inside %}
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form %}
         <fieldset>
-            <legend>{% trans "Display settings" %}</legend>
-            {% bootstrap_field form.primary_color layout="horizontal" %}
-            {% bootstrap_field form.primary_font layout="horizontal" %}
+            <legend>{% trans "Event page" %}</legend>
             {% bootstrap_field form.logo_image layout="horizontal" %}
             {% bootstrap_field form.frontpage_text layout="horizontal" %}
             {% bootstrap_field form.show_variations_expanded layout="horizontal" %}
+        </fieldset>
+        <fieldset>
+            <legend>{% trans "Shop design" %}</legend>
+            {% url "control:organizer.display" organizer=request.organizer.slug as org_url %}
+            {% propagated request.event org_url "primary_color" "primary_font" %}
+                {% bootstrap_field form.primary_color layout="horizontal" %}
+                {% bootstrap_field form.primary_font layout="horizontal" %}
+            {% endpropagated %}
         </fieldset>
         <div class="form-group submit-group">
             <button type="submit" class="btn btn-primary btn-save">

--- a/src/pretix/control/templates/pretixcontrol/organizers/base.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/base.html
@@ -26,6 +26,13 @@
                 </a>
             </li>
         {% endif %}
+        {% if 'can_change_organizer_settings' in request.orgapermset %}
+            <li {% if "organizer.display" in url_name %}class="active"{% endif %}>
+                <a href="{% url "control:organizer.display" organizer=organizer.slug %}">
+                    {% trans "Display" %}
+                </a>
+            </li>
+        {% endif %}
         {% for nav in nav_organizer %}
             <li {% if nav.active %}class="active"{% endif %}>
                 <a href="{{ nav.url }}">

--- a/src/pretix/control/templates/pretixcontrol/organizers/display.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/display.html
@@ -1,0 +1,32 @@
+{% extends "pretixcontrol/organizers/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% block inner %}
+    <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
+        {% csrf_token %}
+        <fieldset>
+            <legend>{% trans "Organizer page" %}</legend>
+            {% bootstrap_form_errors form %}
+            {% bootstrap_field form.locales layout="horizontal" %}
+            {% bootstrap_field form.organizer_logo_image layout="horizontal" %}
+            {% bootstrap_field form.organizer_homepage_text layout="horizontal" %}
+            {% bootstrap_field form.event_list_type layout="horizontal" %}
+        </fieldset>
+        <fieldset>
+            <legend>{% trans "Shop design" %}</legend>
+            <p class="help-block">
+                {% blocktrans trimmed %}
+                    These settings will be used for the organizer page as well as for the default settings
+                    for all events in this account that do not have their own design settings.
+                {% endblocktrans %}
+            </p>
+            {% bootstrap_field form.primary_color layout="horizontal" %}
+            {% bootstrap_field form.primary_font layout="horizontal" %}
+        </fieldset>
+        <div class="form-group submit-group">
+            <button type="submit" class="btn btn-primary btn-save">
+                {% trans "Save" %}
+            </button>
+        </div>
+    </form>
+{% endblock %}

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -17,15 +17,6 @@
             {% endif %}
         </fieldset>
         <fieldset>
-            <legend>{% trans "Display settings" %}</legend>
-            {% bootstrap_form_errors sform %}
-            {% bootstrap_field sform.locales layout="horizontal" %}
-            {% bootstrap_field sform.organizer_primary_color layout="horizontal" %}
-            {% bootstrap_field sform.organizer_logo_image layout="horizontal" %}
-            {% bootstrap_field sform.organizer_homepage_text layout="horizontal" %}
-            {% bootstrap_field sform.event_list_type layout="horizontal" %}
-        </fieldset>
-        <fieldset>
             <legend>{% trans "Other" %}</legend>
             {% bootstrap_form_errors sform %}
             {% bootstrap_field sform.organizer_info_text layout="horizontal" %}

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -20,6 +20,7 @@
             <legend>{% trans "Display settings" %}</legend>
             {% bootstrap_form_errors sform %}
             {% bootstrap_field sform.locales layout="horizontal" %}
+            {% bootstrap_field sform.organizer_primary_color layout="horizontal" %}
             {% bootstrap_field sform.organizer_logo_image layout="horizontal" %}
             {% bootstrap_field sform.organizer_homepage_text layout="horizontal" %}
             {% bootstrap_field sform.event_list_type layout="horizontal" %}

--- a/src/pretix/control/templatetags/hierarkey_form.py
+++ b/src/pretix/control/templatetags/hierarkey_form.py
@@ -1,0 +1,68 @@
+from django import template
+from django.template import Node
+from django.utils.translation import ugettext as _
+
+register = template.Library()
+
+
+class PropagatedNode(Node):
+    def __init__(self, nodelist, event, field_names, url):
+        self.nodelist = nodelist
+        self.event = template.Variable(event)
+        self.field_names = field_names
+        self.url = template.Variable(url)
+
+    def render(self, context):
+        event = self.event.resolve(context)
+        url = self.url.resolve(context)
+        body = self.nodelist.render(context)
+
+        if all([fn not in event.settings._cache() for fn in self.field_names]):
+            body = """
+            <div class="propagated-settings-box">
+                <input type="hidden" name="_settings_ignore" value="{fnames}">
+                <div class="propagated-settings-form blurred">
+                    {body}
+                </div>
+                <div class="propagated-settings-overlay">
+                    <h4><span class="fa fa-link"></span> {text_inh}</h4>
+                    <p>
+                        {text_expl}
+                    </p>
+                    <button class="btn btn-default" name="decouple" value="{fnames}" data-action="unlink">
+                        <span class="fa fa-unlink"></span> {text_unlink}
+                    </button>
+                    <a class="btn btn-default" href="{url}" target="_blank">
+                        <span class="fa fa-group"></span> {text_orga}
+                    </a>
+                </div>
+            </div>
+            """.format(
+                body=body,
+                text_inh=_("Organizer-level settings"),
+                fnames=','.join(self.field_names),
+                text_expl=_(
+                    'These settings are currently set on organizer level. This way, you can easily change them for '
+                    'all of your events at the same time. You can either go to the organizer settings to change them '
+                    'or decouple them from the organizer account to change them for this event individually.'
+                ),
+                text_unlink=_('Change only for this event'),
+                text_orga=_('Change for all events'),
+                url=url
+            )
+
+        return body
+
+
+@register.tag
+def propagated(parser, token):
+    try:
+        tag, event, url, *args = token.split_contents()
+    except ValueError:
+        raise template.TemplateSyntaxError(
+            "%r tag requires at least three arguments" % token.contents.split()[0]
+        )
+
+    nodelist = parser.parse(('endpropagated',))
+    parser.delete_first_token()
+    return PropagatedNode(nodelist, event, [f[1:-1] for f in args], url)

--- a/src/pretix/control/urls.py
+++ b/src/pretix/control/urls.py
@@ -35,6 +35,8 @@ urlpatterns = [
     url(r'^organizers/add$', organizer.OrganizerCreate.as_view(), name='organizers.add'),
     url(r'^organizer/(?P<organizer>[^/]+)/$', organizer.OrganizerDetail.as_view(), name='organizer'),
     url(r'^organizer/(?P<organizer>[^/]+)/edit$', organizer.OrganizerUpdate.as_view(), name='organizer.edit'),
+    url(r'^organizer/(?P<organizer>[^/]+)/settings/display$', organizer.OrganizerDisplaySettings.as_view(),
+        name='organizer.display'),
     url(r'^organizer/(?P<organizer>[^/]+)/teams$', organizer.TeamListView.as_view(), name='organizer.teams'),
     url(r'^organizer/(?P<organizer>[^/]+)/team/add$', organizer.TeamCreateView.as_view(), name='organizer.team.add'),
     url(r'^organizer/(?P<organizer>[^/]+)/team/(?P<team>[^/]+)/$', organizer.TeamMemberView.as_view(),

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -24,6 +24,7 @@ from pretix.control.forms.organizer import (
 from pretix.control.permissions import OrganizerPermissionRequiredMixin
 from pretix.control.signals import nav_organizer
 from pretix.helpers.urls import build_absolute_uri
+from pretix.presale.style import regenerate_organizer_css
 
 
 class OrganizerList(ListView):
@@ -135,6 +136,7 @@ class OrganizerUpdate(OrganizerPermissionRequiredMixin, UpdateView):
                 user=self.request.user,
                 data={k: form.cleaned_data.get(k) for k in form.changed_data}
             )
+        regenerate_organizer_css.apply_async(args=(self.request.organizer.pk,))
         messages.success(self.request, _('Your changes have been saved.'))
         return super().form_valid(form)
 

--- a/src/pretix/presale/context.py
+++ b/src/pretix/presale/context.py
@@ -57,6 +57,8 @@ def contextprocessor(request):
         ctx['languages'] = [get_language_info(code) for code in request.event.settings.locales]
 
     if hasattr(request, 'organizer'):
+        if request.organizer.settings.presale_css_file and not hasattr(request, 'event'):
+            ctx['css_file'] = default_storage.url(request.organizer.settings.presale_css_file)
         ctx['organizer_logo'] = request.organizer.settings.get('organizer_logo_image', as_type=str, default='')[7:]
         ctx['organizer_homepage_text'] = request.organizer.settings.get('organizer_homepage_text', as_type=LazyI18nString)
         ctx['organizer'] = request.organizer

--- a/src/pretix/presale/style.py
+++ b/src/pretix/presale/style.py
@@ -11,23 +11,22 @@ from django.core.files.storage import default_storage
 from django.dispatch import Signal
 from django.templatetags.static import static as _static
 
-from pretix.base.models import Event
+from pretix.base.models import Event, Event_SettingsStore, Organizer
 from pretix.base.services.async import ProfiledTask
 from pretix.celery_app import app
 from pretix.multidomain.urlreverse import get_domain
 
 logger = logging.getLogger('pretix.presale.style')
+affected_keys = ['primary_font', 'primary_color']
 
 
-@app.task(base=ProfiledTask)
-def regenerate_css(event_id: int):
-    event = Event.objects.select_related('organizer').get(pk=event_id)
+def compile_scss(object):
     sassdir = os.path.join(settings.STATIC_ROOT, 'pretixpresale/scss')
 
     def static(path):
         sp = _static(path)
         if not settings.MEDIA_URL.startswith("/") and sp.startswith("/"):
-            domain = get_domain(event.organizer)
+            domain = get_domain(object.organizer if isinstance(object, Event) else object)
             if domain:
                 siteurlsplit = urlsplit(settings.SITE_URL)
                 if siteurlsplit.port and siteurlsplit.port not in (80, 443):
@@ -38,15 +37,16 @@ def regenerate_css(event_id: int):
         return '"{}"'.format(sp)
 
     sassrules = []
-    if event.settings.get('primary_color'):
-        sassrules.append('$brand-primary: {};'.format(event.settings.get('primary_color')))
+    if object.settings.get('primary_color'):
+        sassrules.append('$brand-primary: {};'.format(object.settings.get('primary_color')))
 
-    font = event.settings.get('primary_font')
+    font = object.settings.get('primary_font')
     if font != 'Open Sans':
         sassrules.append(get_font_stylesheet(font))
-        sassrules.append('$font-family-sans-serif: "{}", "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif !default'.format(
-            font
-        ))
+        sassrules.append(
+            '$font-family-sans-serif: "{}", "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif !default'.format(
+                font
+            ))
 
     sassrules.append('@import "main.scss";')
 
@@ -58,6 +58,14 @@ def regenerate_css(event_id: int):
         custom_functions=cf
     )
     checksum = hashlib.sha1(css.encode('utf-8')).hexdigest()
+    return css, checksum
+
+
+@app.task(base=ProfiledTask)
+def regenerate_css(event_id: int):
+    event = Event.objects.select_related('organizer').get(pk=event_id)
+    css, checksum = compile_scss(event)
+
     fname = '{}/{}/presale.{}.css'.format(
         event.organizer.slug, event.slug, checksum[:16]
     )
@@ -66,6 +74,28 @@ def regenerate_css(event_id: int):
         newname = default_storage.save(fname, ContentFile(css.encode('utf-8')))
         event.settings.set('presale_css_file', newname)
         event.settings.set('presale_css_checksum', checksum)
+
+
+@app.task(base=ProfiledTask)
+def regenerate_organizer_css(organizer_id: int):
+    organizer = Organizer.objects.get(pk=organizer_id)
+    css, checksum = compile_scss(organizer)
+
+    fname = '{}/presale.{}.css'.format(
+        organizer.slug, checksum[:16]
+    )
+
+    if organizer.settings.get('presale_css_checksum', '') != checksum:
+        newname = default_storage.save(fname, ContentFile(css.encode('utf-8')))
+        organizer.settings.set('presale_css_file', newname)
+        organizer.settings.set('presale_css_checksum', checksum)
+
+    non_inherited_events = set(Event_SettingsStore.objects.filter(
+        event__organizer=organizer, key__in=affected_keys
+    ).values_list('event_id', flat=True))
+    for event in organizer.events.all():
+        if event.pk not in non_inherited_events:
+            regenerate_css.apply_async(args=(event.pk,))
 
 
 register_fonts = Signal()

--- a/src/pretix/presale/style.py
+++ b/src/pretix/presale/style.py
@@ -91,8 +91,8 @@ def regenerate_organizer_css(organizer_id: int):
         organizer.settings.set('presale_css_checksum', checksum)
 
     non_inherited_events = set(Event_SettingsStore.objects.filter(
-        event__organizer=organizer, key__in=affected_keys
-    ).values_list('event_id', flat=True))
+        object__organizer=organizer, key__in=affected_keys
+    ).values_list('object_id', flat=True))
     for event in organizer.events.all():
         if event.pk not in non_inherited_events:
             regenerate_css.apply_async(args=(event.pk,))

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -312,4 +312,13 @@ $(function () {
             }
         );
     });
+
+    $(".propagated-settings-box button[data-action=unlink]").click(function(ev) {
+        var $box = $(this).closest(".propagated-settings-box");
+        $box.find(".propagated-settings-overlay").fadeOut();
+        $box.find("input[name=_settings_ignore]").attr("name", "decouple");
+        $box.find(".propagated-settings-form").removeClass("blurred");
+        ev.preventDefault();
+        return true;
+    })
 });

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -213,3 +213,30 @@ pre.mail-preview {
     border-left: 0;
   }
 }
+
+.propagated-settings-box {
+  position: relative;
+
+  .propagated-settings-overlay {
+    background: rgba(255, 255, 255, 0.7);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+  }
+
+  .propagated-settings-form.blurred {
+    -webkit-filter: blur(2px);
+    -moz-filter: blur(2px);
+    -ms-filter: blur(2px);
+    -o-filter: blur(2px);
+    filter: blur(2px);
+  }
+}
+@media (max-width: $screen-sm-max) {
+  .propagated-settings-box {
+    min-height: 250px;
+  }
+}

--- a/src/tests/control/test_organizer.py
+++ b/src/tests/control/test_organizer.py
@@ -1,0 +1,60 @@
+import datetime
+
+from tests.base import SoupTest, extract_form_fields
+
+from pretix.base.models import Event, Organizer, Team, User
+
+
+class OrganizerTest(SoupTest):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user('dummy@dummy.dummy', 'dummy')
+        self.orga1 = Organizer.objects.create(name='CCC', slug='ccc')
+        self.orga2 = Organizer.objects.create(name='MRM', slug='mrm')
+        self.event1 = Event.objects.create(
+            organizer=self.orga1, name='30C3', slug='30c3',
+            date_from=datetime.datetime(2013, 12, 26, tzinfo=datetime.timezone.utc),
+            plugins='pretix.plugins.banktransfer,tests.testdummy'
+        )
+
+        t = Team.objects.create(organizer=self.orga1, can_create_events=True, can_change_event_settings=True,
+                                can_change_items=True, can_change_organizer_settings=True)
+        t.members.add(self.user)
+        t.limit_events.add(self.event1)
+
+        self.client.login(email='dummy@dummy.dummy', password='dummy')
+
+    def test_organizer_list(self):
+        doc = self.get_doc('/control/organizers/')
+        tabletext = doc.select("#page-wrapper .table")[0].text
+        self.assertIn("CCC", tabletext)
+        self.assertNotIn("MRM", tabletext)
+
+    def test_organizer_detail(self):
+        doc = self.get_doc('/control/organizer/ccc/')
+        tabletext = doc.select("#page-wrapper .table")[0].text
+        self.assertIn("30C3", tabletext)
+
+    def test_organizer_settings(self):
+        doc = self.get_doc('/control/organizer/%s/edit' % (self.orga1.slug,))
+        doc.select("[name=name]")[0]['value'] = "CCC e.V."
+
+        doc = self.post_doc('/control/organizer/%s/edit' % (self.orga1.slug,),
+                            extract_form_fields(doc.select('.container-fluid form')[0]))
+        assert len(doc.select(".alert-success")) > 0
+        assert doc.select("[name=name]")[0]['value'] == "CCC e.V."
+        self.orga1.refresh_from_db()
+        assert self.orga1.name == "CCC e.V."
+
+    def test_organizer_display_settings(self):
+        assert not self.orga1.settings.presale_css_checksum
+        doc = self.get_doc('/control/organizer/%s/settings/display' % (self.orga1.slug,))
+        doc.select("[name=primary_color]")[0]['value'] = "#33c33c"
+
+        doc = self.post_doc('/control/organizer/%s/settings/display' % (self.orga1.slug,),
+                            extract_form_fields(doc.select('.container-fluid form')[0]))
+        assert len(doc.select(".alert-success")) > 0
+        assert doc.select("[name=primary_color]")[0]['value'] == "#33c33c"
+        self.orga1.settings.flush()
+        assert self.orga1.settings.primary_color == "#33c33c"
+        assert self.orga1.settings.presale_css_checksum

--- a/src/tests/control/test_permissions.py
+++ b/src/tests/control/test_permissions.py
@@ -96,6 +96,7 @@ event_urls = [
 organizer_urls = [
     'organizer/abc/edit',
     'organizer/abc/',
+    'organizer/abc/settings/display',
     'organizer/abc/teams',
     'organizer/abc/team/1/',
     'organizer/abc/team/1/edit',
@@ -316,6 +317,7 @@ organizer_permission_urls = [
     ("can_change_teams", "organizer/dummy/team/1/edit", 200),
     ("can_change_teams", "organizer/dummy/team/1/delete", 200),
     ("can_change_organizer_settings", "organizer/dummy/edit", 200),
+    ("can_change_organizer_settings", "organizer/dummy/settings/display", 200),
 ]
 
 

--- a/src/tests/presale/test_style.py
+++ b/src/tests/presale/test_style.py
@@ -1,0 +1,130 @@
+import datetime
+import os.path
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from pretix.base.models import Event, Organizer
+from pretix.multidomain.models import KnownDomain
+from pretix.presale.style import regenerate_css, regenerate_organizer_css
+
+
+class StyleTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.orga = Organizer.objects.create(name='CCC', slug='ccc')
+        self.event = Event.objects.create(
+            organizer=self.orga, name='30C3', slug='30c3',
+            date_from=datetime.datetime(2013, 12, 26, tzinfo=datetime.timezone.utc),
+            live=True
+        )
+
+    def test_organizer_generate_css_for_inherited_events(self):
+        self.orga.settings.primary_color = "#33c33c"
+        regenerate_organizer_css.apply(args=(self.orga.pk,))
+        self.orga.settings.flush()
+        assert self.orga.settings.presale_css_file
+        with open(os.path.join(settings.MEDIA_ROOT, self.orga.settings.presale_css_file), 'r') as c:
+            assert '#33c33c' in c.read()
+
+        self.event.settings.flush()
+        assert self.event.settings.presale_css_file
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert '#33c33c' in c.read()
+
+    def test_organizer_generate_css_only_for_inherited_events(self):
+        self.orga.settings.primary_color = "#33c33c"
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_organizer_css.apply(args=(self.orga.pk,))
+        self.orga.settings.flush()
+        assert self.orga.settings.presale_css_file
+        with open(os.path.join(settings.MEDIA_ROOT, self.orga.settings.presale_css_file), 'r') as c:
+            assert '#33c33c' in c.read()
+
+        self.event.settings.flush()
+        assert self.event.settings.presale_css_file
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert '#34c34c' not in c.read()
+            assert '#33c33c' not in c.read()
+
+    def test_event_generate_css_individually(self):
+        self.orga.settings.primary_color = "#33c33c"
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+
+        self.event.settings.flush()
+        assert self.event.settings.presale_css_file
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert '#34c34c' in c.read()
+            assert '#33c33c' not in c.read()
+
+        regenerate_organizer_css.apply(args=(self.orga.pk,))
+
+        self.event.settings.flush()
+        assert self.event.settings.presale_css_file
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert '#34c34c' in c.read()
+            assert '#33c33c' not in c.read()
+
+    def test_event_generate_css_new_file(self):
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+
+        self.event.settings.flush()
+        fname = self.event.settings.presale_css_file
+
+        self.event.settings.primary_color = "#ff00ff"
+        regenerate_css.apply(args=(self.event.pk,))
+        self.event.settings.flush()
+        assert self.event.settings.presale_css_file != fname
+
+    def test_event_generate_css_cache_file(self):
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+
+        self.event.settings.flush()
+        fname = self.event.settings.presale_css_file
+
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+        self.event.settings.flush()
+        assert self.event.settings.presale_css_file == fname
+
+    @override_settings(
+        MEDIA_URL="https://usercontent.pretix.space/media/",
+        SITE_URL="https://pretix.eu"
+    )
+    def test_seperate_media_domain(self):
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+        self.event.settings.flush()
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert 'https://pretix.eu/static/' in c.read()
+
+    @override_settings(
+        MEDIA_URL="https://usercontent.pretix.space/media/",
+        SITE_URL="https://pretix.eu"
+    )
+    def test_seperate_media_domain_and_organizer_domain(self):
+        KnownDomain.objects.create(domainname="test.pretix.eu", organizer=self.orga)
+
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+        self.event.settings.flush()
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert 'https://test.pretix.eu/static/' in c.read()
+
+    @override_settings(
+        STATIC_URL="https://static.pretix.files/static/",
+        MEDIA_URL="https://usercontent.pretix.space/media/",
+        SITE_URL="https://pretix.eu"
+    )
+    def test_seperate_media_domain_and_static_domain(self):
+        KnownDomain.objects.create(domainname="test.pretix.eu", organizer=self.orga)
+
+        self.event.settings.primary_color = "#34c34c"
+        regenerate_css.apply(args=(self.event.pk,))
+        self.event.settings.flush()
+        with open(os.path.join(settings.MEDIA_ROOT, self.event.settings.presale_css_file), 'r') as c:
+            assert 'https://static.pretix.files/static/' in c.read()
+            assert 'https://test.pretix.eu/static/' not in c.read()


### PR DESCRIPTION
Added a "primary color option" for organizer pages (cf. event).
The selected color will not yet be set as default value for the organizers' events, because I still have to figure out an elegant way to do so.
I will continue working on the organizer page adding a language selector and restructuring the control interface in order to replicate the workflow for editing events. In the process I will deal with the default value issue.
Also, there will be unit tests for the new features.