### PR TITLE
Make placeholders replace in subject

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -82,6 +82,7 @@ def mail(email: str, subject: str, template: Union[str, LazyI18nString],
                     'invoice_company': ''
                 })
         body, body_md = render_mail(template, context)
+        subject = str(subject).format_map(context)
         sender = sender or (event.settings.get('mail_from') if event else settings.MAIL_FROM)
 
         subject = str(subject)

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -23,7 +23,11 @@ class MailForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields['subject'] = I18nFormField(
             widget=I18nTextInput, required=True,
-            locales=event.settings.get('locales')
+            locales=event.settings.get('locales'),
+            help_text=_("Available placeholders: {expire_date}, {event}, {code}, {date}, {url}, "
+                        "{invoice_name}, {invoice_company}"),
+            validators=[PlaceholderValidator(['{expire_date}', '{event}', '{code}', '{date}', '{url}',
+                                              '{invoice_name}', '{invoice_company}'])]
         )
         self.fields['message'] = I18nFormField(
             widget=I18nTextarea, required=True,

--- a/src/tests/base/test_mail.py
+++ b/src/tests/base/test_mail.py
@@ -89,3 +89,13 @@ def test_send_mail_with_user_locale(env):
     assert len(djmail.outbox) == 1
     assert djmail.outbox[0].subject == 'Benutzer'
     assert 'The language code used for rendering this e-mail is de.' in djmail.outbox[0].body
+
+@pytest.mark.django_db
+def test_sendmail_placeholder(env):
+    djmail.outbox = []
+    event, user, organizer = env
+    mail('dummy@dummy.dummy', '{event} Test subject', 'mailtest.txt', {"event": event}, event)
+
+    assert len(djmail.outbox) == 1
+    assert djmail.outbox[0].to == [user.email]
+    assert djmail.outbox[0].subject == 'Dummy Test subject'

--- a/src/tests/plugins/test_sendmail.py
+++ b/src/tests/plugins/test_sendmail.py
@@ -213,3 +213,20 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order):
 
     assert response.status_code == 200
     assert 'Subevent FOO' in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_sendmail_placeholder(logged_in_client, sendmail_url, event, order):
+    djmail.outbox = []
+    response = logged_in_client.post(sendmail_url,
+                                     {'sendto': 'n',
+                                      'subject_0': '{code} Test subject',
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'action': 'preview'
+                                      },
+                                     follow=True)
+
+    assert response.status_code == 200
+    assert 'ORDER1234' in response.rendered_content
+
+    assert len(djmail.outbox) == 0


### PR DESCRIPTION
Placeholders in subject were not being replaced because there was
no `.format()` called on the subject.

This commit creates a context dict that is used for both the body
and the subject. It is then replaced using `.format_map()`

Fixes https://github.com/pretix/pretix/issues/531