### PR TITLE
Allow markdown rendering in transaction comments.

### DIFF
--- a/src/pretix/plugins/banktransfer/static/pretixplugins/banktransfer/ui.js
+++ b/src/pretix/plugins/banktransfer/static/pretixplugins/banktransfer/ui.js
@@ -31,6 +31,9 @@ var bankimport_transactionlist = {
             "success": function (data) {
                 if (data.status == "ok") {
                     $("tr[data-id=" + id + "]").removeClass("has-error");
+                    if (data.comment) {
+                        bankimport_transactionlist.comment_reset_to_text(id, data.comment, data.plain);
+                    }
                     success();
                 } else {
                     $("tr[data-id=" + id + "] button").prop("disabled", false);
@@ -66,12 +69,13 @@ var bankimport_transactionlist = {
         });
     },
 
-    comment_reset_to_text: function (id, text) {
+    comment_reset_to_text: function (id, text, plain) {
         var $box = $("tr[data-id=" + id + "] .comment-box");
+        $box[0].dataset["plain"] = plain;
         $box.html("")
             .append($("<strong>").text(gettext("Comment:")))
             .append(" ")
-            .append($("<span>").addClass("comment").text(text))
+            .append($("<span>").addClass("comment").append(" ").append(text))
             .append(" ")
             .append($("<a>").addClass("comment-modify btn btn-default btn-xs")
                         .append("<span class='fa fa-edit'></span>"));
@@ -81,7 +85,8 @@ var bankimport_transactionlist = {
         var $box = $(e.target).closest("div");
         var id = $box.closest("tr").attr("data-id");
         var $inp = $("<textarea>").addClass("form-control");
-        var orig_text = $box.find(".comment").text();
+        var orig_rendered = $box.find(".comment");
+        var orig_text = $box[0].dataset.plain;
         $inp.val(orig_text);
 
         var $btngrp = $("<div>");
@@ -99,11 +104,10 @@ var bankimport_transactionlist = {
             var text = $box.find("textarea").val();
             $box.find("input, textarea, button").prop("disabled", true);
             bankimport_transactionlist._action(id, "comment:" + text, function () {
-                bankimport_transactionlist.comment_reset_to_text(id, text);
             });
         });
         $btn2.click(function () {
-            bankimport_transactionlist.comment_reset_to_text(id, orig_text);
+            bankimport_transactionlist.comment_reset_to_text(id, orig_rendered, orig_text);
         });
 
         e.preventDefault();

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/transaction_list.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/transaction_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load rich_text %}
 {% load staticfiles %}
 <div class="table-responsive">
     {% csrf_token %}
@@ -57,9 +58,9 @@
                 <td>
                     {{ trans.payer }}<br/>
                     {{ trans.reference }}
-                    <div class="comment-box">
+                    <div class="comment-box" data-plain="{{ trans.comment }}">
                         <strong>{% trans "Comment:" %}</strong>
-                        <span class="comment">{{ trans.comment }}</span>
+                        <span class="comment">{{ trans.comment|rich_text }}</span>
                         <a href="#" class="comment-modify btn btn-default btn-xs">
                             <span class="fa fa-edit"></span>
                         </a>

--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -106,10 +106,13 @@ class ActionView(View):
             return self._retry(trans)
 
     def _comment(self, trans, comment):
+        from pretix.base.templatetags.rich_text import rich_text
         trans.comment = comment
         trans.save()
         return JsonResponse({
-            'status': 'ok'
+            'status': 'ok',
+            'comment': rich_text(comment),
+            'plain': comment,
         })
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
This commit allows transaction comments to display newlines and URLs in
a useful way, helping when additional data (such as a reference to a
ticket system or a longer discussion) is required.
This PR also prevents pretix from having to bring its own chat system ;)