### PR TITLE
Fix #630 -- manual check-in of attendees

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/checkin/index.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/index.html
@@ -52,6 +52,8 @@
                 <table class="table table-condensed table-hover">
                     <thead>
                     <tr>
+                      <th>{% trans "CheckIn?" %}
+                      </th>
                         <th>{% trans "Order code" %} <a href="?{% url_replace request 'ordering' '-code'%}"><i class="fa fa-caret-down"></i></a>
                       <a href="?{% url_replace request 'ordering' 'code'%}"><i class="fa fa-caret-up"></i></a></th>
                         <th>{% trans "Item" %} <a href="?{% url_replace request 'ordering' '-item'%}"><i class="fa fa-caret-down"></i></a>
@@ -74,6 +76,11 @@
                     {% for e in entries %}
                         {% with e.checkins.first as checkin %}
                         <tr>
+                          <td> 
+                            <input type="checkbox" name="checkin"
+                                                   id="id_checkin" class=""
+                                                                   value="{{e.order.code}}"/>
+                          </td>
                             <td>
                                 <strong><a href="{% url "control:event.order" event=request.event.slug organizer=request.event.organizer.slug code=e.order.code %}">{{ e.order.code }}</a></strong>
                             </td>
@@ -106,6 +113,11 @@
                     {% endfor %}
                     </tbody>
                 </table>
+            </div>
+            <div class="form-group submit-group">
+              <button type="submit" class="btn btn-primary btn-save">
+                Check-In selected
+              </button>
             </div>
         </form>
     {% endif %}

--- a/src/pretix/control/templates/pretixcontrol/checkin/index.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/index.html
@@ -52,8 +52,7 @@
                 <table class="table table-condensed table-hover">
                     <thead>
                     <tr>
-                      <th>{% trans "CheckIn?" %}
-                      </th>
+                        <th />
                         <th>{% trans "Order code" %} <a href="?{% url_replace request 'ordering' '-code'%}"><i class="fa fa-caret-down"></i></a>
                       <a href="?{% url_replace request 'ordering' 'code'%}"><i class="fa fa-caret-up"></i></a></th>
                         <th>{% trans "Item" %} <a href="?{% url_replace request 'ordering' '-item'%}"><i class="fa fa-caret-down"></i></a>
@@ -79,7 +78,7 @@
                           <td> 
                             <input type="checkbox" name="checkin"
                                                    id="id_checkin" class=""
-                                                                   value="{{e.order.code}}"/>
+                                                                   value="{{e.pk}}"/>
                           </td>
                             <td>
                                 <strong><a href="{% url "control:event.order" event=request.event.slug organizer=request.event.organizer.slug code=e.order.code %}">{{ e.order.code }}</a></strong>
@@ -116,7 +115,7 @@
             </div>
             <div class="form-group submit-group">
               <button type="submit" class="btn btn-primary btn-save">
-                Check-In selected
+                {% trans "Check-In selected attendees" %}
               </button>
             </div>
         </form>

--- a/src/pretix/control/templates/pretixcontrol/checkin/index.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/index.html
@@ -113,11 +113,10 @@
                     </tbody>
                 </table>
             </div>
-            <div class="form-group submit-group">
-              <button type="submit" class="btn btn-primary btn-save">
+            <button type="submit" class="btn btn-primary btn-save">
                 {% trans "Check-In selected attendees" %}
-              </button>
-            </div>
+            </button>
         </form>
+        {% include "pretixcontrol/pagination.html" %}
     {% endif %}
 {% endblock %}

--- a/src/pretix/control/views/checkin.py
+++ b/src/pretix/control/views/checkin.py
@@ -91,7 +91,7 @@ class CheckInView(EventPermissionRequiredMixin, ListView):
                 'positionid': op.positionid,
                 'first': created,
                 'datetime': now()
-            })
+            }, user=request.user)
 
         messages.success(request, _('The selected tickets have been marked as checked in.'))
         return redirect(reverse('control:event.orders.checkins', kwargs={

--- a/src/tests/control/test_checkins.py
+++ b/src/tests/control/test_checkins.py
@@ -268,6 +268,7 @@ def test_checkins_list_mixed(client, checkin_list_env, query, expected):
     item_keys = [q.order.code + str(q.item.name) for q in qs]
     assert item_keys == expected
 
+
 @pytest.mark.django_db
 @pytest.mark.parametrize("query, expected", [
     ('status=&item=&user=', ['A1Ticket', 'A1Mascot', 'A2Ticket', 'A3Ticket']),

--- a/src/tests/control/test_checkins.py
+++ b/src/tests/control/test_checkins.py
@@ -268,6 +268,22 @@ def test_checkins_list_mixed(client, checkin_list_env, query, expected):
     item_keys = [q.order.code + str(q.item.name) for q in qs]
     assert item_keys == expected
 
+@pytest.mark.django_db
+@pytest.mark.parametrize("query, expected", [
+    ('status=&item=&user=', ['A1Ticket', 'A1Mascot', 'A2Ticket', 'A3Ticket']),
+    ('status=1&item=&user=', ['A1Ticket', 'A2Ticket', 'A3Ticket']),
+])
+def test_manual_checkins(client, checkin_list_env, query, expected):
+    client.login(email='dummy@dummy.dummy', password='dummy')
+    response = client.post('/control/event/dummy/dummy/checkins/', {
+        'checkin': [checkin_list_env[5][3].pk]
+    })
+    response = client.get('/control/event/dummy/dummy/checkins/?' + query)
+    qs = response.context['entries']
+    item_keys = [q.order.code + str(q.item.name) for q in qs]
+    print(item_keys)
+    assert item_keys == expected
+
 
 @pytest.fixture
 def checkin_list_with_addon_env():

--- a/src/tests/control/test_checkins.py
+++ b/src/tests/control/test_checkins.py
@@ -5,8 +5,8 @@ import pytest
 from django.utils.timezone import now
 
 from pretix.base.models import (
-    Checkin, Event, Item, ItemAddOn, ItemCategory, Order, OrderPosition,
-    Organizer, Team, User,
+    Checkin, Event, Item, ItemAddOn, ItemCategory, LogEntry, Order,
+    OrderPosition, Organizer, Team, User,
 )
 from pretix.control.views.dashboards import checkin_widget
 
@@ -270,20 +270,16 @@ def test_checkins_list_mixed(client, checkin_list_env, query, expected):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("query, expected", [
-    ('status=&item=&user=', ['A1Ticket', 'A1Mascot', 'A2Ticket', 'A3Ticket']),
-    ('status=1&item=&user=', ['A1Ticket', 'A2Ticket', 'A3Ticket']),
-])
-def test_manual_checkins(client, checkin_list_env, query, expected):
+def test_manual_checkins(client, checkin_list_env):
     client.login(email='dummy@dummy.dummy', password='dummy')
-    response = client.post('/control/event/dummy/dummy/checkins/', {
+    assert not checkin_list_env[5][3].checkins.exists()
+    client.post('/control/event/dummy/dummy/checkins/', {
         'checkin': [checkin_list_env[5][3].pk]
     })
-    response = client.get('/control/event/dummy/dummy/checkins/?' + query)
-    qs = response.context['entries']
-    item_keys = [q.order.code + str(q.item.name) for q in qs]
-    print(item_keys)
-    assert item_keys == expected
+    assert checkin_list_env[5][3].checkins.exists()
+    assert LogEntry.objects.filter(
+        action_type='pretix.control.views.checkin', object_id=checkin_list_env[5][3].order.pk
+    ).exists()
 
 
 @pytest.fixture


### PR DESCRIPTION

This enables manual check-in of attendees.  The post-code was heavily
copied from the APIRedeemView of the pretixdroid, thus so far this seems
to be working, but I have a few questions:

The checkin-Objects generated by the pretixdroid-app have a nonce.
Should the checkin object generated here have a nonce, too?

Should the result of the check-in be noted in any other way than by the
change of the status?