### PR TITLE
Fix #611 -- Fix overflow in payment information

### DIFF
--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -396,6 +396,11 @@ body.loading #wrapper {
     background-color: #eeeeee;
 }
 
+.panel-body {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+}
+
 .fa.disabled {
     color: $text-muted;
 }


### PR DESCRIPTION
Small style change that fixes long word overflow in .panel-body elements
in admin interface.

Fix #611