### PR TITLE
Implement progress indicator during checkout

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -498,7 +498,7 @@ class ConfirmStep(CartMixin, AsyncAction, TemplateFlowStep):
     template_name = "pretixpresale/event/checkout_confirm.html"
     task = perform_order
     known_errortypes = ['OrderError']
-    label = pgettext_lazy('checkoutflow', 'Confirm order')
+    label = pgettext_lazy('checkoutflow', 'Review order')
     icon = 'eye'
 
     def is_applicable(self, request):

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
@@ -40,6 +40,7 @@
         </div>
     </div>
     <h2>{% trans "Checkout" %}</h2>
+    {% include "pretixpresale/event/fragment_checkoutflow.html" %}
     {% block inner %}
     {% endblock %}
 {% endblock %}

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -3,9 +3,9 @@
 {% load bootstrap3 %}
 {% load eventurl %}
 {% load eventsignal %}
-{% block title %}{% trans "Confirm order" %}{% endblock %}
+{% block title %}{% trans "Review order" %}{% endblock %}
 {% block content %}
-    <h2>{% trans "Confirm order" %}</h2>
+    <h2>{% trans "Review order" %}</h2>
     {% include "pretixpresale/event/fragment_checkoutflow.html" %}
     <p>{% trans "Please review the details below and confirm your order." %}</p>
     <form method="post" data-asynctask>

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -6,6 +6,7 @@
 {% block title %}{% trans "Confirm order" %}{% endblock %}
 {% block content %}
     <h2>{% trans "Confirm order" %}</h2>
+    {% include "pretixpresale/event/fragment_checkoutflow.html" %}
     <p>{% trans "Please review the details below and confirm your order." %}</p>
     <form method="post" data-asynctask>
         {% csrf_token %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_checkoutflow.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_checkoutflow.html
@@ -19,7 +19,7 @@
             <span class="fa fa-ticket"></span>
         </div>
         <div class="checkout-step-label">
-            {% trans "Done" context "checkoutflow" %}
+            {% trans "Order confirmed" context "checkoutflow" %}
         </div>
     </a>
 </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_checkoutflow.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_checkoutflow.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+<div class="checkout-flow">
+    {% for step in checkout_flow %}
+        <a {% if step.c_is_before %}href="{{ step.c_resolved_url }}"{% endif %} class="checkout-step {% if step.c_is_before %}step-done{% elif request.resolver_match.kwargs.step == step.identifier %}step-current{% endif %}">
+            <div class="checkout-step-bar-left"></div>
+            <div class="checkout-step-bar-right"></div>
+            <div class="checkout-step-icon">
+                <span class="fa {% if step.c_is_before %}fa-check{% elif step.icon %}fa-{{ step.icon }}{% else %}fa-pencil{% endif %}"></span>
+            </div>
+            <div class="checkout-step-label">
+                {{ step.label }}
+            </div>
+        </a>
+    {% endfor %}
+    <a class="checkout-step">
+        <div class="checkout-step-bar-left"></div>
+        <div class="checkout-step-bar-right"></div>
+        <div class="checkout-step-icon">
+            <span class="fa fa-ticket"></span>
+        </div>
+        <div class="checkout-step-label">
+            {% trans "Done" context "checkoutflow" %}
+        </div>
+    </a>
+</div>

--- a/src/pretix/presale/views/checkout.py
+++ b/src/pretix/presale/views/checkout.py
@@ -41,7 +41,7 @@ class CheckoutView(View):
         except CartError as e:
             cart_error = e
 
-        flow = get_checkout_flow(self.request.event)
+        flow = request._checkout_flow = get_checkout_flow(self.request.event)
         previous_step = None
         for step in flow:
             if not step.is_applicable(request):
@@ -64,4 +64,6 @@ class CheckoutView(View):
                 return handler(request)
             else:
                 previous_step = step
+                step.c_is_before = True
+                step.c_resolved_url = step.get_step_url(request)
         raise Http404()

--- a/src/pretix/static/pretixpresale/scss/_checkout.scss
+++ b/src/pretix/static/pretixpresale/scss/_checkout.scss
@@ -68,6 +68,10 @@
     &.step-current .checkout-step-bar-left {
       background: $brand-success;
     }
+    &:last-child .checkout-step-bar-right,
+    &:first-child .checkout-step-bar-left {
+      background: transparent;
+    }
 
     &:hover, &:active {
       text-decoration: none;

--- a/src/pretix/static/pretixpresale/scss/_checkout.scss
+++ b/src/pretix/static/pretixpresale/scss/_checkout.scss
@@ -1,6 +1,7 @@
 .checkout-flow {
   display: flex;
   flex-direction: row;
+  margin: 15px 0 13px 0;
 
   .checkout-step {
     flex: 1;

--- a/src/pretix/static/pretixpresale/scss/_checkout.scss
+++ b/src/pretix/static/pretixpresale/scss/_checkout.scss
@@ -1,0 +1,81 @@
+.checkout-flow {
+  display: flex;
+  flex-direction: row;
+
+  .checkout-step {
+    flex: 1;
+    text-align: center;
+    padding: 10px 0;
+    position: relative;
+
+    .checkout-step-icon {
+      border: 1px solid $text-muted;
+      display: inline-block;
+      width: 30px;
+      height: 30px;
+      line-height: 28px;
+      border-radius: 15px;
+      color: $text-muted;
+      z-index: 200;
+      background: white;
+      position: relative;
+    }
+
+    .checkout-step-label {
+      padding-top: 10px;
+      color: $text-muted;
+    }
+
+    .checkout-step-bar-left {
+      position: absolute;
+      top: 22px;
+      left: 0;
+      width: 50%;
+      height: 6px;
+      background: $gray-lighter;
+      z-index: 100;
+    }
+    .checkout-step-bar-right {
+      position: absolute;
+      top: 22px;
+      left: 50%;
+      width: 50%;
+      height: 6px;
+      background: $gray-lighter;
+      z-index: 100;
+    }
+
+    &.step-done .checkout-step-icon {
+      border: 1px solid $brand-success;
+      background: $brand-success;
+      color: white;
+    }
+    &.step-done .checkout-step-label {
+      color: $brand-success;
+    }
+    &.step-done .checkout-step-bar-left, &.step-done .checkout-step-bar-right {
+      background: $brand-success;
+    }
+
+    &.step-current .checkout-step-icon {
+      border: 1px solid darken($brand-info, 20%);
+      background: darken($brand-info, 20%);
+      color: white;
+    }
+    &.step-current .checkout-step-label {
+      color: darken($brand-info, 20%);
+    }
+    &.step-current .checkout-step-bar-left {
+      background: $brand-success;
+    }
+
+    &:hover, &:active {
+      text-decoration: none;
+    }
+  }
+}
+@media(max-width: $screen-sm-max) {
+  .checkout-step-label {
+    display: none;
+  }
+}

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -7,6 +7,7 @@
 @import "_cart.scss";
 @import "_forms.scss";
 @import "_calendar.scss";
+@import "_checkout.scss";
 @import "../../pretixbase/scss/webfont.scss";
 
 footer {


### PR DESCRIPTION
as part of a reaction to #670 

Minimal case:
![download 2](https://user-images.githubusercontent.com/64280/32614446-92315d4a-c56d-11e7-8d25-3991b89ec111.png)
![download 3](https://user-images.githubusercontent.com/64280/32614549-cb043a98-c56d-11e7-8307-d3d4856652f3.png)

Maximal case:
![download](https://user-images.githubusercontent.com/64280/32614353-5b66c1b0-c56d-11e7-8d94-99ef15c22755.png)

On Mobile:
![2017-11-09-164147_320x154_scrot](https://user-images.githubusercontent.com/64280/32614358-5fde4060-c56d-11e7-8238-ca5b92db299d.png)

What do you all think? 

@rixx @stapelberg @breunigs @janx2 opinions on this? :)