### PR TITLE
fix "typo" Referrer-Options -> Referrer-Options

### DIFF
--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -213,7 +213,7 @@ The following snippet is an example on how to configure a nginx proxy for pretix
         ssl_certificate /path/to/cert.chain.pem;
         ssl_certificate_key /path/to/key.pem;
 
-        add_header Referrer-Options same-origin;
+        add_header Referrer-Policy same-origin;
         add_header X-Content-Type-Options nosniff;
 
         location / {


### PR DESCRIPTION
this header was probably meant - at least it's the one that's actually used in the wild.