### PR TITLE
standardize use of check-in

### DIFF
--- a/doc/api/resources/checkinlists.rst
+++ b/doc/api/resources/checkinlists.rst
@@ -213,7 +213,7 @@ Endpoints
 
 .. http:delete:: /api/v1/organizers/(organizer)/events/(event)/checkinlist/(id)/
 
-   Delete a check-in list. Note that this also deletes the information on all checkins performed via this list.
+   Delete a check-in list. Note that this also deletes the information on all check-ins performed via this list.
 
    **Example request**:
 

--- a/doc/api/resources/orders.rst
+++ b/doc/api/resources/orders.rst
@@ -1,3 +1,5 @@
+.. spelling:: checkins
+
 Orders
 ======
 

--- a/doc/checkin_filter.py
+++ b/doc/checkin_filter.py
@@ -1,0 +1,9 @@
+from enchant.tokenize import Filter
+
+class CheckinFilter(Filter):
+    """ If a word looks like checkin_count, it refers to a so-called variable in
+    the code, and is treated as being spelled right."""
+
+    def _skip(self, word):
+        if word[:8] == "checkin_":
+            return True

--- a/doc/checkin_filter.py
+++ b/doc/checkin_filter.py
@@ -1,9 +1,11 @@
-from enchant.tokenize import Filter
+from enchant.tokenize import get_tokenizer, Filter, unit_tokenize
 
 class CheckinFilter(Filter):
     """ If a word looks like checkin_count, it refers to a so-called variable in
     the code, and is treated as being spelled right."""
 
-    def _skip(self, word):
+    def _split(self, word):
         if word[:8] == "checkin_":
-            return True
+            return unit_tokenize(word[8:])
+
+        return unit_tokenize(word)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -306,3 +306,7 @@ spelling_word_list_filename='spelling_wordlist.txt'
 # Boolean controlling whether suggestions for misspelled words are printed.
 # Defaults to False.
 spelling_show_suggestions=True
+
+# List of filter classes to be added to the tokenizer that produces words to be checked. 
+from checkin_filter import CheckinFilter
+spelling_filters=[CheckinFilter]

--- a/doc/plugins/pretixdroid.rst
+++ b/doc/plugins/pretixdroid.rst
@@ -157,7 +157,7 @@ uses to communicate with the pretix server.
 .. http:get:: /pretixdroid/api/(organizer)/(event)/status/
 
    Returns status information, such as the total number of tickets and the
-   number of performed checkins.
+   number of performed check-ins.
 
    **Example request**:
 

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -11,8 +11,6 @@ booleans
 cancelled
 casted
 checkbox
-checkin
-checkins
 checksum
 config
 contenttypes

--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -75,7 +75,7 @@ class CheckinList(LoggedModel):
 
 class Checkin(models.Model):
     """
-    A checkin object is created when a person enters the event.
+    A check-in object is created when a person enters the event.
     """
     position = models.ForeignKey('pretixbase.OrderPosition', related_name='checkins')
     datetime = models.DateTimeField(default=now)

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -179,7 +179,7 @@ class Item(LoggedModel):
     :type max_per_order: int
     :param min_per_order: Minimum number of times this item needs to be in an order if bought at all. None for unlimited.
     :type min_per_order: int
-    :param checkin_attention: Requires special attention at checkin
+    :param checkin_attention: Requires special attention at check-in
     :type checkin_attention: bool
     """
 


### PR DESCRIPTION
The main problem here is, that for readability, variables used in code should be spelled without dash, e.g. the variable `checkin_count` should not be spelled `check-in_count`. When documenting these variables, pyenchant seems to tokenize them on the `_`, and the `checkin`-part gets spell-checked and marked as wrong. 

To overcome this, we implement a custom filter, accepting words that start with `checkin_`. The problem here is, that then the `count`-part of `checkin_count` doesn't get spell-checked. 

I'm currently looking into solving this, but my inability to non-yakshave makes this hard ;)