### PR TITLE
remove alert since mail-typo-checking is disabled

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
@@ -96,12 +96,6 @@
                 </div>
             {% endfor %}
         </div>
-        <div class="alert alert-warning typo-alert">
-            <strong>{% trans "Are you sure your email address is correct?" %}</strong><br>
-            {% blocktrans trimmed with entered="<span data-typodisplay></span>" suggestion="<span data-typosuggest></span>" %}
-                You entered "{{ entered }}". Did you mean "{{ suggestion }}"?
-            {% endblocktrans %}
-        </div>
         <div class="row checkout-button-row">
             <div class="col-md-4">
                 <a class="btn btn-block btn-default btn-lg"


### PR DESCRIPTION
[This commit](https://github.com/pretix/pretix/commit/a62fbd54d4a1eba5cf243a449a20ac4610d478c4) removes the typo-checking for e-mail-adresses. Therefore, this box isn't needed either. Just running the shop from the current master leads to 
![pretix_typo_check_alert](https://user-images.githubusercontent.com/4692974/34162157-026b4f2e-e4d3-11e7-962b-c8a720ffaeba.png)

This might be because of my inability to work with pretix correctly, but I think this is the right thing to do ;)