### PR TITLE
Fix #731 -- Display negative payment method fees correctly

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
@@ -12,7 +12,7 @@
                         <div class="panel-heading">
                             <h4 class="panel-title">
                                 {% if show_fees %}
-                                    <strong class="pull-right">+ {{ p.fee|floatformat:2 }} {{ event.currency }}</strong>
+                                <strong class="pull-right">{% if p.fee < 0 %}-{% else %}+{% endif %} {{ p.fee|floatformat:2|cut:"-" }} {{ event.currency }}</strong>
                                 {% endif %}
                                 <input type="radio" name="payment" value="{{ p.provider.identifier }}"
                                         data-parent="#payment_accordion"


### PR DESCRIPTION
This was the nicest version I could think of. 😄 

This is how it looks like:
![screenshot from 2017-12-31 19-50-30](https://user-images.githubusercontent.com/5970076/34463739-26fd6704-ee66-11e7-8caa-87d8dd0be392.png)
