### PR TITLE
Update development documentation, update demo URL

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -86,7 +86,7 @@ and head to http://localhost:8000/
 
 As we did not implement an overall front page yet, you need to go directly to
 http://localhost:8000/control/ for the admin view or, if you imported the test
-data as suggested above, to the event page at http://localhost:8000/bigevents/2018/
+data as suggested above, to the event page at http://localhost:8000/bigevents/2019/
 
 .. note:: If you want the development server to listen on a different interface or
           port (for example because you develop on `pretixdroid`_), you can check


### PR DESCRIPTION
When using the test data generation script, the demo conference no longer has the URL ``/bigevents/2018``, but is now moved to ``/bigevents/2019`` . This confused me in the beginning.