### PR TITLE
Fix italics underscores in markdown doc (Fix #748)

### DIFF
--- a/doc/user/markdown.rst
+++ b/doc/user/markdown.rst
@@ -25,7 +25,7 @@ To set a text in italics, you can put it in asterisks or underscores. For exampl
 
 will become:
 
-    Please *really* pay your _ticket_.
+    Please *really* pay your *ticket*.
 
 If you set double asterisks or underscores, the text will be printed in bold. For example,
 


### PR DESCRIPTION
I settled for using `*`, since that's how you do italics in rst. 