### PR TITLE
Fix #751 -- calculate payment fees in OrderChangeManager

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -513,7 +513,7 @@ def _perform_order(event: str, payment_provider: str, position_ids: List[str],
             invoice = generate_invoice(order, trigger_pdf=not event.settings.invoice_email_attachment)
             # send_mail will trigger PDF generation later
 
-    if order.total == Decimal('0.00'):
+    if order.payment_provider == 'free':
         email_template = event.settings.mail_text_order_free
         log_entry = 'pretix.event.order.email.order_free'
     else:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -825,8 +825,10 @@ class OrderChangeManager:
             raise OrderError(self.error_messages['paid_price_change'])
 
     def _check_paid_to_free(self):
-        if self.order.total == 0 and (self._totaldiff < 0 or self.split_order and self.split_order.total > 0):
+        if self.order.total == 0 and (self._totaldiff < 0 or (self.split_order and self.split_order.total > 0)):
             # if the order becomes free, mark it paid using the 'free' provider
+            # this could happen if positions have been made cheaper or removed (_totaldiff < 0)
+            # or positions got split off to a new order (split_order with positive total)
             try:
                 mark_order_paid(
                     self.order, 'free', send_mail=False, count_waitinglist=False,

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1018,10 +1018,12 @@ class OrderChangeManager:
     def _payment_fee_diff(self):
         prov = self._get_payment_provider()
         if prov:
-            old_fee = prov.calculate_fee(self.order.total)
-            new_total = self.order.total + self._totaldiff
+            old_total = sum([p.price for p in self.order.positions.all()])
+            new_total = old_total + self._totaldiff
+            old_fee = self.order.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT).value
             if new_total != 0:
-                self._totaldiff += prov.calculate_fee(new_total) - old_fee
+                new_fee = prov.calculate_fee(new_total)
+                self._totaldiff += new_fee - old_fee
 
     def _reissue_invoice(self):
         i = self.order.invoices.filter(is_cancellation=False).last()

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1017,7 +1017,8 @@ class OrderChangeManager:
 
     def _payment_fee_diff(self):
         prov = self._get_payment_provider()
-        if prov:
+        if self.order.status != Order.STATUS_PAID and prov:
+            #payment fees of paid orders do not change
             try:
                 old_fee = self.order.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT).value
             except OrderFee.MultipleObjectsReturned:

--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -204,7 +204,6 @@ class ReturnView(StripeOrderView, View):
         prov = self.pprov
         prov._init_api()
         src = stripe.Source.retrieve(request.GET.get('source'))
-        print(src.client_secret, request.GET.get('client_secret'))
         if src.client_secret != request.GET.get('client_secret'):
             messages.error(self.request, _('Sorry, there was an error in the payment process. Please check the link '
                                            'in your emails to continue.'))
@@ -232,7 +231,6 @@ class ReturnView(StripeOrderView, View):
         return self._redirect_to_order()
 
     def _redirect_to_order(self):
-        print(self.request.session.get('payment_stripe_order_secret'), self.order.secret)
         if self.request.session.get('payment_stripe_order_secret') != self.order.secret:
             messages.error(self.request, _('Sorry, there was an error in the payment process. Please check the link '
                                            'in your emails to continue.'))

--- a/src/tests/base/test_orders.py
+++ b/src/tests/base/test_orders.py
@@ -734,6 +734,7 @@ class OrderChangeManagerTests(TestCase):
         ia = self._enable_reverse_charge()
         self.ocm.recalculate_taxes()
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         ops = list(self.order.positions.all())
         for op in ops:
             assert op.price == Decimal('21.50')
@@ -791,6 +792,7 @@ class OrderChangeManagerTests(TestCase):
         prov.settings.set('_fee_reverse_calc', False)
         self.ocm.change_price(self.op1, Decimal('23.00'))
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         self.order.refresh_from_db()
         assert self.order.total == Decimal('47.92')
         fee = self.order.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT)
@@ -879,6 +881,7 @@ class OrderChangeManagerTests(TestCase):
         prov.settings.set('_fee_reverse_calc', False)
         self.ocm.recalculate_taxes()
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         self.order.refresh_from_db()
 
         # Check if reverse charge is active
@@ -911,7 +914,6 @@ class OrderChangeManagerTests(TestCase):
         # New order
         assert self.op2.order != self.order
         o2 = self.op2.order
-        print([p.price for p in o2.positions.all()], [p.value for p in o2.fees.all()])
         assert o2.total == Decimal('21.93')
         fee = o2.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT)
         assert fee.value == Decimal('0.43')
@@ -971,6 +973,7 @@ class OrderChangeManagerTests(TestCase):
         prov.settings.set('_fee_reverse_calc', False)
         self.ocm.change_price(self.op1, Decimal('23.00'))
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         self.order.refresh_from_db()
         assert self.order.total == Decimal('47.92')
         fee = self.order.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT)
@@ -1019,6 +1022,7 @@ class OrderChangeManagerTests(TestCase):
         self.event.settings.invoice_include_free = False
         self.ocm.change_price(self.op2, Decimal('0.00'))
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         self.op2.refresh_from_db()
         self.ocm._invoice_dirty = False
 
@@ -1038,6 +1042,7 @@ class OrderChangeManagerTests(TestCase):
     def test_split_to_original_free(self):
         self.ocm.change_price(self.op2, Decimal('0.00'))
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         self.op2.refresh_from_db()
 
         self.ocm.split(self.op1)
@@ -1054,6 +1059,7 @@ class OrderChangeManagerTests(TestCase):
     def test_split_to_new_free(self):
         self.ocm.change_price(self.op2, Decimal('0.00'))
         self.ocm.commit()
+        self.ocm = OrderChangeManager(self.order, None)
         self.op2.refresh_from_db()
 
         self.ocm.split(self.op2)


### PR DESCRIPTION
Is there a way to make this 'more robust'? 