### PR TITLE
Fix register exporter signal name in doc

### DIFF
--- a/doc/development/api/exporter.rst
+++ b/doc/development/api/exporter.rst
@@ -21,10 +21,10 @@ that we'll provide in this plugin::
 
     from django.dispatch import receiver
 
-    from pretix.base.signals import register_data_exporter
+    from pretix.base.signals import register_data_exporters
 
 
-    @receiver(register_data_exporter, dispatch_uid="exporter_myexporter")
+    @receiver(register_data_exporters, dispatch_uid="exporter_myexporter")
     def register_data_exporter(sender, **kwargs):
         from .exporter import MyExporter
         return MyExporter


### PR DESCRIPTION
The signal is defined at 
https://github.com/pretix/pretix/blob/353dce789d5dfe6c0ebf6e98257999325b6958f1/src/pretix/base/signals.py#L143
and ends with an s.