### PR TITLE
Use config.getboolean to get metrics enabled value

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -121,7 +121,7 @@ EMAIL_SUBJECT_PREFIX = '[pretix] '
 
 ADMINS = [('Admin', n) for n in config.get('mail', 'admins', fallback='').split(",") if n]
 
-METRICS_ENABLED = config.get('metrics', 'enabled', fallback=False)
+METRICS_ENABLED = config.getboolean('metrics', 'enabled', fallback=False)
 METRICS_USER = config.get('metrics', 'user', fallback="metrics")
 METRICS_PASSPHRASE = config.get('metrics', 'passphrase', fallback="")
 


### PR DESCRIPTION
Given the following configuration:

[metrics]
enabled=False

Using config.get results in a METRICS_ENABLED value that always
evaluates to True. This PR switches to config.getboolean so that metrics
can be disabled without deleting the configuration values.