### PR TITLE
Refs #754 -- check item tax_rule is not none

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -812,7 +812,7 @@ class OrderChangeManager:
         if price is None:
             price = get_price(item, variation, subevent=subevent, invoice_address=self._invoice_address)
         else:
-            if item.tax_rule.tax_applicable(self._invoice_address):
+            if item.tax_rule and item.tax_rule.tax_applicable(self._invoice_address):
                 price = item.tax(price, base_price_is='gross')
             else:
                 price = TaxedPrice(gross=price, net=price, tax=Decimal('0.00'), rate=Decimal('0.00'), name='')


### PR DESCRIPTION
While this is a simple fix, it at least makes it possible again to add products without tax rules.