### PR TITLE
Refs #757: show voucher input for subevents only if subevent is selected

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -442,7 +442,7 @@
             </form>
         {% endif %}
     {% endif %}
-    {% if vouchers_exist and not event.has_subevents or vouchers_exist and subevent %}
+    {% if show_vouchers %}
         <section class="front-page">
             <h3>{% trans "Redeem a voucher" %}</h3>
             <form method="get" action="{% eventurl event "presale:event.redeem" cart_namespace=cart_namespace %}">

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -442,7 +442,7 @@
             </form>
         {% endif %}
     {% endif %}
-    {% if vouchers_exist %}
+    {% if vouchers_exist and not event.has_subevents or vouchers_exist and subevent %}
         <section class="front-page">
             <h3>{% trans "Redeem a voucher" %}</h3>
             <form method="get" action="{% eventurl event "presale:event.redeem" cart_namespace=cart_namespace %}">

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -227,15 +227,20 @@ class EventIndex(EventViewMixin, CartMixin, TemplateView):
             context['items_by_category'] = item_group_by_category(items)
             context['display_add_to_cart'] = display_add_to_cart
 
+            # Show voucher option if an event is selected and vouchers exist
+            vouchers_exist = self.request.event.cache.get('vouchers_exist')
+            if vouchers_exist is None:
+                vouchers_exist = self.request.event.vouchers.exists()
+                self.request.event.cache.set('vouchers_exist', vouchers_exist)
+            context['show_vouchers'] = vouchers_exist
+        else:
+            context['show_vouchers'] = False
+
+        context['ev'] = self.subevent or self.request.event
         context['subevent'] = self.subevent
         context['cart'] = self.get_cart()
         context['has_addon_choices'] = get_cart(self.request).filter(item__addons__isnull=False).exists()
-        vouchers_exist = self.request.event.cache.get('vouchers_exist')
-        if vouchers_exist is None:
-            vouchers_exist = self.request.event.vouchers.exists()
-            self.request.event.cache.set('vouchers_exist', vouchers_exist)
-        context['vouchers_exist'] = vouchers_exist
-        context['ev'] = self.subevent or self.request.event
+
         if self.subevent:
             context['frontpage_text'] = str(self.subevent.frontpage_text)
         else:


### PR DESCRIPTION
This reworks the condition on when the voucher input field should be shown in the presale event page.

Now, not only do vouchers need to exists, but if subevents exists, one must be selected for the input field to show up.