### PR TITLE
Fix #779: add form field for unpaid option of checkin lists in subevent detail view

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/subevents/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/detail.html
@@ -178,9 +178,9 @@
                                         </h4>
                                     </div>
                                     <div class="panel-body form-horizontal">
+                                        {% bootstrap_field cl_formset.empty_form.include_pending layout="control" %}
                                         {% bootstrap_field cl_formset.empty_form.all_products layout="control" %}
                                         {% bootstrap_field cl_formset.empty_form.limit_products layout="control" %}
-                                        {% bootstrap_field cl_formset.empty_form.include_pending layout="control" %}
                                     </div>
                                 </div>
                             {% endescapescript %}

--- a/src/pretix/control/templates/pretixcontrol/subevents/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/detail.html
@@ -150,9 +150,9 @@
                                     </div>
                                     <div class="panel-body form-horizontal">
                                         {% bootstrap_form_errors form %}
+                                        {% bootstrap_field form.include_pending layout="control" %}
                                         {% bootstrap_field form.all_products layout="control" %}
                                         {% bootstrap_field form.limit_products layout="control" %}
-                                        {% bootstrap_field form.include_pending layout="control" %}
                                     </div>
                                 </div>
                             {% endfor %}

--- a/src/pretix/control/templates/pretixcontrol/subevents/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/detail.html
@@ -152,6 +152,7 @@
                                         {% bootstrap_form_errors form %}
                                         {% bootstrap_field form.all_products layout="control" %}
                                         {% bootstrap_field form.limit_products layout="control" %}
+                                        {% bootstrap_field form.include_pending layout="control" %}
                                     </div>
                                 </div>
                             {% endfor %}
@@ -179,6 +180,7 @@
                                     <div class="panel-body form-horizontal">
                                         {% bootstrap_field cl_formset.empty_form.all_products layout="control" %}
                                         {% bootstrap_field cl_formset.empty_form.limit_products layout="control" %}
+                                        {% bootstrap_field cl_formset.empty_form.include_pending layout="control" %}
                                     </div>
                                 </div>
                             {% endescapescript %}

--- a/src/pretix/control/views/subevents.py
+++ b/src/pretix/control/views/subevents.py
@@ -148,6 +148,7 @@ class SubEventEditorMixin(MetaDataEditorMixin):
                     'name': cl.name,
                     'all_products': cl.all_products,
                     'limit_products': cl.limit_products.all(),
+                    'include_pending': cl.include_pending,
                 } for cl in self.copy_from.checkinlist_set.prefetch_related('limit_products')
             ]
             extra = len(kwargs['initial'])
@@ -156,6 +157,7 @@ class SubEventEditorMixin(MetaDataEditorMixin):
                 {
                     'name': '',
                     'all_products': True,
+                    'include_pending': False,
                 }
             ]
             extra = 1


### PR DESCRIPTION
This was easier than I thought it would be, although I had to guess a bit...

![screenshot from 2018-02-22 13-47-00](https://user-images.githubusercontent.com/5970076/36539407-074062be-17d7-11e8-82eb-8a80fc928ae0.png)
