### PR TITLE
Name presale index + unit test for URL names

### DIFF
--- a/src/pretix/multidomain/maindomain_urlconf.py
+++ b/src/pretix/multidomain/maindomain_urlconf.py
@@ -15,7 +15,7 @@ presale_patterns_main = [
     url(r'', include((locale_patterns + [
         url(r'^(?P<organizer>[^/]+)/', include(organizer_patterns)),
         url(r'^(?P<organizer>[^/]+)/(?P<event>[^/]+)/', include(event_patterns)),
-        url(r'^$', TemplateView.as_view(template_name='pretixpresale/index.html'))
+        url(r'^$', TemplateView.as_view(template_name='pretixpresale/index.html'), name="index")
     ], 'presale')))
 ]
 

--- a/src/tests/base/test_urls.py
+++ b/src/tests/base/test_urls.py
@@ -1,0 +1,41 @@
+from importlib import import_module
+
+from django.conf import settings
+from django.test import TestCase
+
+
+class URLTestCase(TestCase):
+    """
+    This test case tests for a name string on all URLs.  Unnamed
+    URLs will cause a TypeError in the metrics middleware.
+    """
+    pattern_attrs = ['urlpatterns', 'url_patterns']
+
+    def test_url_names(self):
+        urlconf = import_module(settings.ROOT_URLCONF)
+        nameless = self.find_nameless_urls(urlconf)
+        message = "URL regexes missing names: %s" % " ".join([n.regex.pattern for n in nameless])
+        self.assertIs(len(nameless), 0, message)
+
+    def find_nameless_urls(self, conf):
+        nameless = []
+        patterns = self.get_patterns(conf)
+        for u in patterns:
+            if self.has_patterns(u):
+                nameless.extend(self.find_nameless_urls(u))
+            else:
+                if u.name is None:
+                    nameless.append(u)
+        return nameless
+
+    def get_patterns(self, conf):
+        for pa in self.pattern_attrs:
+            if hasattr(conf, pa):
+                return getattr(conf, pa)
+        return []
+
+    def has_patterns(self, conf):
+        for pa in self.pattern_attrs:
+            if hasattr(conf, pa):
+                return True
+        return False


### PR DESCRIPTION
This PR can be split:  the first commit fixes a bug, and the second commit provides a unit test to prevent the bug from resurfacing.

The site index page failed to load with metrics collection enabled because the default URL did not have a name.  This caused the following:

```
ERROR 2018-02-23 02:10:03,916 django.request exception Internal Server Error: /
Traceback (most recent call last):
  File "/home/tim/src/pretix/pretix/venv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/home/tim/src/pretix/pretix/src/pretix/helpers/metrics/middleware.py", line 34, in __call__
    url_name=url.namespace + ':' + url.url_name)
TypeError: must be str, not NoneType
```
Adding a name to the index url and a test to ensure that all urls are named seemed like a solution that would allow the metrics collection to remain useful, but we could also approach this with a bug fix in `src/pretix/helpers/metrics/middleware.py`


