### PR TITLE
Improve voucher filter

### DIFF
--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -42,7 +42,7 @@ class Voucher(LoggedModel):
     :param max_usages: The number of times this voucher can be redeemed
     :type max_usages: int
     :param redeemed: The number of times this voucher already has been redeemed
-    :type redeemed: bool
+    :type redeemed: int
     :param valid_until: The expiration date of this voucher (optional)
     :type valid_until: datetime
     :param block_quota: If set to true, this voucher will reserve quota for its holder

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -605,7 +605,7 @@ class VoucherFilterForm(FilterForm):
         label=_('Status'),
         choices=(
             ('', _('All')),
-            ('v', _('Valid')),
+            ('v', _('Unredeemed')),
             ('r', _('Redeemed')),
             ('e', _('Expired')),
             ('c', _('Redeemed and checked in with ticket')),


### PR DESCRIPTION
I had no real clue what "valid" was supposed to mean.

Bonus: Instead of "unredeemed" one could provide "redeemable", which would need to add an annotation to the filter queryset.