### PR TITLE
Fix #798 -- Show availability for addon products

### DIFF
--- a/src/pretix/presale/forms/checkout.py
+++ b/src/pretix/presale/forms/checkout.py
@@ -152,6 +152,9 @@ class AddOnsForm(forms.Form):
             n += ' – {}'.format(_('SOLD OUT'))
         elif avail[0] < 100:
             n += ' – {}'.format(_('Currently unavailable'))
+        else:
+            if avail[1] is not None and event.settings.show_quota_left:
+                n += ' – {}'.format(_('%(num)s currently available') % {'num': avail[1]})
 
         return n
 


### PR DESCRIPTION
This is a very basic approach to address the request of Issue #798 .  
Probably this is not really what you want to see here, since it really looks awkward. Please don't blame me for it :relaxed: 

It's currently showing at https://pretix.460.kif.rocks/sandbox/kif-sandbox/

This is a sandbox shop, so feel free to put something in the cart to see the addon page.