### PR TITLE
Fix #357 -- Implement go to for vouchers

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/vouchers/index.html
+++ b/src/pretix/control/templates/pretixcontrol/vouchers/index.html
@@ -11,7 +11,7 @@
         {% endblocktrans %}
     </p>
     <div class="row filter-form">
-        <form class="col-md-2 col-xs-6"
+        <form class="col-lg-2 col-sm-6 col-xs-6"
               action="{% url "control:event.vouchers.go" event=request.event.slug organizer=request.event.organizer.slug %}">
             <div class="input-group">
                 <input type="text" name="code" class="form-control" placeholder="{% trans "Voucher code" %}" autofocus>
@@ -21,31 +21,31 @@
             </div>
         </form>
         <form class="" action="" method="get">
-            <div class="col-md-2 col-xs-6">
+            <div class="col-lg-2 col-sm-3 col-xs-6">
                 {% bootstrap_field filter_form.search layout='inline' %}
             </div>
-            <div class="col-md-2 col-xs-6">
+            <div class="col-lg-1 col-sm-3 col-xs-6">
                 {% bootstrap_field filter_form.tag layout='inline' %}
             </div>
             {% if request.event.has_subevents %}
-                <div class="col-md-1 col-xs-6">
+                <div class="col-lg-1 col-sm-3 col-xs-6">
                     {% bootstrap_field filter_form.status layout='inline' %}
                 </div>
-                <div class="col-md-2 col-xs-6">
+                <div class="col-lg-2 col-sm-3 col-xs-6">
                     {% bootstrap_field filter_form.subevent layout='inline' %}
                 </div>
             {% else %}
-                <div class="col-md-3 col-xs-6">
+                <div class="col-lg-3 col-sm-6 col-xs-6">
                     {% bootstrap_field filter_form.status layout='inline' %}
                 </div>
             {% endif %}
-            <div class="col-md-2 col-xs-6">
+            <div class="col-lg-2 col-sm-6 col-xs-6">
                 {% bootstrap_field filter_form.itemvar layout='inline' %}
             </div>
-            <div class="col-md-1 col-xs-6">
+            <div class="col-lg-1 col-sm-6 col-xs-6">
                 {% bootstrap_field filter_form.qm layout='inline' %}
             </div>
-            <div class="col-md-2 col-xs-6">
+            <div class="col-lg-1 col-sm-6 col-xs-6">
                 <button class="btn btn-primary btn-block" type="submit">
                     <span class="fa fa-filter"></span>
                     <span class="hidden-md">

--- a/src/pretix/control/templates/pretixcontrol/vouchers/index.html
+++ b/src/pretix/control/templates/pretixcontrol/vouchers/index.html
@@ -11,6 +11,15 @@
         {% endblocktrans %}
     </p>
     <div class="row filter-form">
+        <form class="col-md-2 col-xs-6"
+              action="{% url "control:event.vouchers.go" event=request.event.slug organizer=request.event.organizer.slug %}">
+            <div class="input-group">
+                <input type="text" name="code" class="form-control" placeholder="{% trans "Voucher code" %}" autofocus>
+                <span class="input-group-btn">
+                    <button class="btn btn-primary" type="submit">{% trans "Go!" %}</button>
+                </span>
+            </div>
+        </form>
         <form class="" action="" method="get">
             <div class="col-md-2 col-xs-6">
                 {% bootstrap_field filter_form.search layout='inline' %}

--- a/src/pretix/control/urls.py
+++ b/src/pretix/control/urls.py
@@ -151,6 +151,7 @@ urlpatterns = [
         url(r'^vouchers/(?P<voucher>\d+)/delete$', vouchers.VoucherDelete.as_view(),
             name='event.voucher.delete'),
         url(r'^vouchers/add$', vouchers.VoucherCreate.as_view(), name='event.vouchers.add'),
+        url(r'^vouchers/go$', vouchers.VoucherGo.as_view(), name='event.vouchers.go'),
         url(r'^vouchers/bulk_add$', vouchers.VoucherBulkCreate.as_view(), name='event.vouchers.bulk'),
         url(r'^orders/(?P<code>[0-9A-Z]+)/transition$', orders.OrderTransition.as_view(),
             name='event.order.transition'),

--- a/src/pretix/control/views/vouchers.py
+++ b/src/pretix/control/views/vouchers.py
@@ -230,10 +230,10 @@ class VoucherGo(EventPermissionRequiredMixin, View):
     permission = 'can_view_vouchers'
 
     def get_voucher(self, code):
-        return Voucher.objects.get(code=code, event=self.request.event)
+        return Voucher.objects.get(code__iexact=code, event=self.request.event)
 
     def get(self, request, *args, **kwargs):
-        code = request.GET.get("code", "").upper().strip()
+        code = request.GET.get("code", "").strip()
         try:
             voucher = self.get_voucher(code)
             return redirect('control:event.voucher', event=request.event.slug, organizer=request.event.organizer.slug,


### PR DESCRIPTION
In regards to the issue #357 (Search orders/go to voucher):
It seems that partial search works for Orders.
And this PR is about adding Go input to the Vouchers page.
But I also have a couple questions:
1_ I haven't used Djnango translation systems before and my question is about that. The text I added ("There is no voucher with the given voucher code."), even though is passed to the _ugettext_lazy_ function does not appear in the _.po_ file. How is that being added?
2_ As you can see in the images below, the filter section of the Vouchers page is getting cluttered and I'm wondering what you think should be done here.

Order list:
<img width="1147" alt="screen shot 2018-03-30 at 2 34 38 pm" src="https://user-images.githubusercontent.com/4794780/38154824-12ede046-3429-11e8-93ff-b907c8e14288.png">

Vouchers list:
<img width="1140" alt="screen shot 2018-03-30 at 2 34 48 pm" src="https://user-images.githubusercontent.com/4794780/38154835-2606d6a6-3429-11e8-8143-55f639eb3456.png">

This is my first PR to this repo, and I think my code conforms to the guidelines. But please let me know if there is something I'm missing.

Thank you