### PR TITLE
Update manual_smallscale.rst

### DIFF
--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -114,7 +114,7 @@ python installation::
 
     $ virtualenv -p python3 /var/pretix/venv
     $ source /var/pretix/venv/bin/activate
-    (venv)$ pip3 install -U pip setuptools wheel
+    (venv)$ pip3 install -U pip setuptools wheel typing
 
 We now install pretix, its direct dependencies and gunicorn. Replace ``mysql`` with ``postgres`` in the following
 command if you're running PostgreSQL::


### PR DESCRIPTION
  File "/var/pretix/venv/lib/python3.4/site-packages/hierarkey/models.py", line 6, in <module>
    from typing import Any, Callable, Optional
ImportError: No module named 'typing'

Added typing to the venv pip install list, as it seems to be required.