### PR TITLE
Fix #861 -- Add event name to admin notification email

### DIFF
--- a/src/pretix/base/notifications.py
+++ b/src/pretix/base/notifications.py
@@ -174,6 +174,7 @@ class ParametrizedOrderNotificationType(NotificationType):
             title=self._title.format(order=order, event=logentry.event),
             url=order_url
         )
+        n.add_attribute(_('Event'), order.event.name)
         n.add_attribute(_('Order code'), order.code)
         n.add_attribute(_('Order total'), money_filter(order.total, logentry.event.currency))
         n.add_attribute(_('Order date'), date_format(order.datetime, 'SHORT_DATETIME_FORMAT'))


### PR DESCRIPTION
This adds the event name to admin notifications. Without this, it is not possible to distinguish between different event, if you have notifications enabled for multiple accounts (exept from the url).