### PR TITLE
Fix #871 -- move footer to main container

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -42,20 +42,20 @@
 <div class="container">
     {% block page %}
     {% endblock %}
+    <footer>
+        {% block footer %}
+        {% endblock %}
+        {% if footer_text %}
+            {{ footer_text }}
+            &middot;
+        {% endif %}
+        {% for f in footer %}
+            <a href="{% safelink f.url %}" target="_blank" rel="noopener">{{ f.label }}</a>
+            &middot;
+        {% endfor %}
+        {% include "pretixpresale/base_footer.html" %}
+    </footer>
 </div>
-<footer>
-    {% block footer %}
-    {% endblock %}
-    {% if footer_text %}
-        {{ footer_text }}
-        &middot;
-    {% endif %}
-    {% for f in footer %}
-        <a href="{% safelink f.url %}" target="_blank" rel="noopener">{{ f.label }}</a>
-        &middot;
-    {% endfor %}
-    {% include "pretixpresale/base_footer.html" %}
-</footer>
 <div id="ajaxerr">
 </div>
 <div id="loadingmodal">


### PR DESCRIPTION
At the moment, the top level container div carries all of the content html, except the footer. This moves the footer into the container to make styling the document easier. (See #871)

I'm unsure about the above block. I only saw it used for the "This shop is only visible to you" banner, which I did not move.