### PR TITLE
fix placeholder for event deletion password

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1018,7 +1018,7 @@ class EventDeleteForm(forms.Form):
     }
     user_pw = forms.CharField(
         max_length=255,
-        label=_("New password"),
+        label=_("Your password"),
         widget=forms.PasswordInput()
     )
     slug = forms.CharField(


### PR DESCRIPTION
probably due to copypasta the event deletion form says "new password". This changes it to "Your password" to be in line with the data shredder pw confirmation field.