### PR TITLE
Fix #908 -- Fix display of ticket download message

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -91,7 +91,7 @@
                     {% endfor %}
                 </p>
             {% endif %}
-        {% elif not download_buttons %}
+        {% elif not download_buttons and ticket_download_date %}
             <div class="alert alert-info">
                 {% blocktrans trimmed with date=ticket_download_date|date:"SHORT_DATE_FORMAT" %}
                     You will be able to download your tickets here starting on {{ date }}.


### PR DESCRIPTION
Hide download tickets message when no download date is specified.