### PR TITLE
Fix bug in date/time question stats

### DIFF
--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -429,12 +429,12 @@ class QuestionView(EventPermissionRequiredMixin, QuestionMixin, ChartContainingV
         elif self.object.type in (Question.TYPE_TIME, Question.TYPE_DATE, Question.TYPE_DATETIME):
             qs = qs.order_by('answer')
             model_cache = {a.answer: a for a in qs}
-            qs = qs.values('answer').annotate(count=Count('id'))
+            qs = qs.values('answer').annotate(count=Count('id')).order_by('answer')
             for a in qs:
                 a['alink'] = a['answer']
                 a['answer'] = str(model_cache[a['answer']])
         else:
-            qs = qs.values('answer').annotate(count=Count('id')).order_by('-count')
+            qs = qs.order_by('answer').values('answer').annotate(count=Count('id')).order_by('-count')
 
             if self.object.type == Question.TYPE_BOOLEAN:
                 for a in qs:

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -427,14 +427,9 @@ class QuestionView(EventPermissionRequiredMixin, QuestionMixin, ChartContainingV
                 a['answer'] = str(a['options__answer'])
                 del a['options__answer']
         elif self.object.type in (Question.TYPE_TIME, Question.TYPE_DATE, Question.TYPE_DATETIME):
-            qs = qs.order_by('answer')
-            qs_model = qs
-            qs = qs.values('answer').annotate(count=Count('id')).order_by('-count')
-            for a, a_model in zip(qs, qs_model):
-                a['alink'] = a['answer']
-                a['answer'] = str(a_model)
+            qs = qs.order_by('answer').values('answer').annotate(count=Count('id'))
         else:
-            qs = qs.order_by('answer').values('answer').annotate(count=Count('id')).order_by('-count')
+            qs = qs.values('answer').annotate(count=Count('id')).order_by('-count')
 
             if self.object.type == Question.TYPE_BOOLEAN:
                 for a in qs:

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -427,7 +427,12 @@ class QuestionView(EventPermissionRequiredMixin, QuestionMixin, ChartContainingV
                 a['answer'] = str(a['options__answer'])
                 del a['options__answer']
         elif self.object.type in (Question.TYPE_TIME, Question.TYPE_DATE, Question.TYPE_DATETIME):
-            qs = qs.order_by('answer').values('answer').annotate(count=Count('id'))
+            qs = qs.order_by('answer')
+            model_cache = {a.answer: a for a in qs}
+            qs = qs.values('answer').annotate(count=Count('id'))
+            for a in qs:
+                a['alink'] = a['answer']
+                a['answer'] = str(model_cache[a['answer']])
         else:
             qs = qs.values('answer').annotate(count=Count('id')).order_by('-count')
 


### PR DESCRIPTION
As you can see, the table and graph data is messed up. Aggregation is not correct and links don't point to the correct filtered list:

![screenshot from 2018-05-18 14-14-57](https://user-images.githubusercontent.com/5970076/40235125-83c01f72-5aa9-11e8-9229-958b80abc3c3.png)

I streamlined the code and it's showing correct results now. Also, I changed the ordering for date/time questions.

![screenshot from 2018-05-18 14-29-22](https://user-images.githubusercontent.com/5970076/40235128-8564bcac-5aa9-11e8-96bf-d6cd94075df5.png)
