### PR TITLE
Widget: set default number to 1 if there is only one product

### DIFF
--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -195,7 +195,7 @@ class WidgetAPIProductList(View):
                     } for item in g
                 ]
             })
-        return grps, display_add_to_cart
+        return grps, display_add_to_cart, len(items)
 
     def dispatch(self, request, *args, **kwargs):
         self.subevent = None
@@ -274,11 +274,12 @@ class WidgetAPIProductList(View):
                 fail = True
 
         if not fail and (ev.presale_is_running or request.event.settings.show_items_outside_presale_period):
-            data['items_by_category'], data['display_add_to_cart'] = self._get_items()
+            data['items_by_category'], data['display_add_to_cart'], data['itemnum'] = self._get_items()
             data['display_add_to_cart'] = data['display_add_to_cart'] and ev.presale_is_running
         else:
             data['items_by_category'] = []
             data['display_add_to_cart'] = False
+            data['itemnum'] = 0
 
         vouchers_exist = self.request.event.get_cache().get('vouchers_exist')
         if vouchers_exist is None:

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -150,7 +150,8 @@ Vue.component('availbox', {
         + '<input type="checkbox" value="1" v-bind:name="input_name">'
         + '</label>'
         + '<input type="number" class="pretix-widget-item-count-multiple" placeholder="0" min="0"'
-        + '       v-bind:max="order_max" v-bind:name="input_name" v-if="order_max !== 1">'
+        + '       :value="$root.itemnum == 1 ? 1 : false" v-bind:max="order_max" v-bind:name="input_name"'
+        + '       v-if="order_max !== 1">'
         + '</div>'
         + '</div>'),
     props: {
@@ -705,7 +706,8 @@ var create_widget = function (element) {
                 error_message: null,
                 error_url_after: null,
                 vouchers_exist: false,
-                cart_exists: false
+                cart_exists: false,
+                itemcount: 0
             }
         },
         created: function () {
@@ -733,6 +735,7 @@ var create_widget = function (element) {
                 app.cart_id = cart_id;
                 app.cart_exists = data.cart_exists;
                 app.vouchers_exist = data.vouchers_exist;
+                app.itemnum = data.itemnum;
                 app.loading--;
             }, function (error) {
                 app.categories = [];

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -150,7 +150,7 @@ Vue.component('availbox', {
         + '<input type="checkbox" value="1" v-bind:name="input_name">'
         + '</label>'
         + '<input type="number" class="pretix-widget-item-count-multiple" placeholder="0" min="0"'
-        + '       :value="$root.itemnum == 1 ? 1 : false" v-bind:max="order_max" v-bind:name="input_name"'
+        + '       :value="($root.itemnum == 1 && !item.has_variations) ? 1 : false" v-bind:max="order_max" v-bind:name="input_name"'
         + '       v-if="order_max !== 1">'
         + '</div>'
         + '</div>'),

--- a/src/tests/presale/test_widget.py
+++ b/src/tests/presale/test_widget.py
@@ -192,6 +192,7 @@ class WidgetCartTest(CartTestMixin, TestCase):
                     "name": "Everything"
                 }
             ],
+            "itemnum": 2,
             "display_add_to_cart": True,
             "cart_exists": False
         }
@@ -234,6 +235,7 @@ class WidgetCartTest(CartTestMixin, TestCase):
                     "name": "Everything"
                 }
             ],
+            "itemnum": 1,
             "display_add_to_cart": True,
             "cart_exists": False
         }
@@ -252,7 +254,8 @@ class WidgetCartTest(CartTestMixin, TestCase):
             "error": "This voucher is expired.",
             "items_by_category": [],
             "display_add_to_cart": False,
-            "cart_exists": False
+            "cart_exists": False,
+            "itemnum": 0,
         }
 
     def test_css_customized(self):


### PR DESCRIPTION
I think this makes sense as it is already done in the normal purchase flow outside the widget (since 8f2adf0a).
Was requested by internal support ticket # 2336058.