### PR TITLE
Fix outside of body script element

### DIFF
--- a/src/pretix/base/templates/error.html
+++ b/src/pretix/base/templates/error.html
@@ -16,6 +16,6 @@
 <div class="container">
     {% block content %}{% endblock %}
 </div>
-</body>
 <script src="{% static "pretixbase/js/errors.js" %}"></script>
+</body>
 </html>


### PR DESCRIPTION
```
</body>
<script src="/static/pretixbase/js/errors.4db07680b709.js"></script>
</html>
```
The script tag is after the body tag. This merge request switches the corresponding lines.