### PR TITLE
Allow empty plugin responses

### DIFF
--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -173,11 +173,12 @@ class OrderDetail(OrderView):
             p.additional_fields = []
             data = p.meta_info_data
             for r, response in sorted(responses, key=lambda r: str(r[0])):
-                for key, value in response.items():
-                    p.additional_fields.append({
-                        'answer': data.get('question_form_data', {}).get(key),
-                        'question': value.label
-                    })
+                if response:
+                    for key, value in response.items():
+                        p.additional_fields.append({
+                            'answer': data.get('question_form_data', {}).get(key),
+                            'question': value.label
+                        })
 
             p.has_questions = (
                 p.additional_fields or

--- a/src/pretix/presale/views/__init__.py
+++ b/src/pretix/presale/views/__init__.py
@@ -67,11 +67,12 @@ class CartMixin:
             responses = question_form_fields.send(sender=self.request.event, position=cp)
             data = cp.meta_info_data
             for r, response in sorted(responses, key=lambda r: str(r[0])):
-                for key, value in response.items():
-                    pos_additional_fields[cp.pk].append({
-                        'answer': data.get('question_form_data', {}).get(key),
-                        'question': value.label
-                    })
+                if response:
+                    for key, value in response.items():
+                        pos_additional_fields[cp.pk].append({
+                            'answer': data.get('question_form_data', {}).get(key),
+                            'question': value.label
+                        })
 
         # Group items of the same variation
         # We do this by list manipulations instead of a GROUP BY query, as


### PR DESCRIPTION
While plugin developers are supposed to return an empty dictionary, it's
conceivable that they might just put in a `return` if their field is not
needed, and pretix being generous about this would be cool.