### PR TITLE
Fix #369 -- Connect with PayPal

### DIFF
--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -4,16 +4,15 @@ import urllib.parse
 from collections import OrderedDict
 
 import paypalrestsdk
-from paypalrestsdk.openid_connect import Tokeninfo
 from django import forms
 from django.contrib import messages
 from django.core import signing
 from django.http import HttpRequest
 from django.template.loader import get_template
 from django.urls import reverse
-from django.utils.crypto import get_random_string
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as __, ugettext_lazy as _
+from paypalrestsdk.openid_connect import Tokeninfo
 
 from pretix.base.decimal import round_decimal
 from pretix.base.models import Event, OrderPayment, OrderRefund, Quota
@@ -106,7 +105,7 @@ class Paypal(BasePaymentProvider):
                       'following button, you can either create a new PayPal account connect pretix to an existing '
                       'one.'),
                     self.get_connect_url(request),
-                    _('Connect with <i class="fa fa-paypal"></i> PayPal')
+                    _('Connect with {icon} PayPal').format(icon='<i class="fa fa-paypal"></i>')
                 )
             else:
                 return (
@@ -186,10 +185,10 @@ class Paypal(BasePaymentProvider):
                     },
                     "description": __('Event tickets for {event}').format(event=request.event.name),
                     "payee": {
-                        "email": "" or request.event.settings.payment_paypal_connect_user_id,
+                        "email": request.event.settings.payment_paypal_connect_user_id or "",
                         # If PayPal ever offers a good way to get the MerchantID via the Identifity API,
                         # we should use it instead of the merchant's eMail-address
-                        #"merchant_id": request.event.settings.payment_paypal_connect_user_id,
+                        # "merchant_id": request.event.settings.payment_paypal_connect_user_id or "",
                     }
                 }
             ]
@@ -433,10 +432,10 @@ class Paypal(BasePaymentProvider):
                         order=payment_obj.order.code
                     ),
                     "payee": {
-                        "email": "" or request.event.settings.payment_paypal_connect_user_id,
+                        "email": request.event.settings.payment_paypal_connect_user_id or "",
                         # If PayPal ever offers a good way to get the MerchantID via the Identifity API,
                         # we should use it instead of the merchant's eMail-address
-                        #"merchant_id": request.event.settings.payment_paypal_connect_user_id,
+                        # "merchant_id": request.event.settings.payment_paypal_connect_user_id or "",
                     }
                 }
             ]

--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -38,7 +38,7 @@ class Paypal(BasePaymentProvider):
 
     @property
     def settings_form_fields(self):
-        if self.settings.connect_client_id and not self.settings.secret_key:
+        if self.settings.connect_client_id and not self.settings.secret:
             # PayPal connect
             if self.settings.connect_user_id:
                 fields = [
@@ -93,7 +93,7 @@ class Paypal(BasePaymentProvider):
         return Tokeninfo.authorize_url({'scope': 'openid profile email'})
 
     def settings_content_render(self, request):
-        if self.settings.connect_client_id and not self.settings.secret_key:
+        if self.settings.connect_client_id and not self.settings.secret:
             # Use PayPal connect
             if not self.settings.connect_user_id:
                 return (

--- a/src/pretix/plugins/paypal/signals.py
+++ b/src/pretix/plugins/paypal/signals.py
@@ -57,6 +57,7 @@ def pretixcontrol_action_display(sender, action, request, **kwargs):
     ctx = {'data': data, 'event': sender, 'action': action}
     return template.render(ctx, request)
 
+
 @receiver(register_global_settings, dispatch_uid='paypal_global_settings')
 def register_global_settings(sender, **kwargs):
     return OrderedDict([

--- a/src/pretix/plugins/paypal/signals.py
+++ b/src/pretix/plugins/paypal/signals.py
@@ -70,7 +70,7 @@ def register_global_settings(sender, **kwargs):
             required=False,
         )),
         ('payment_paypal_connect_endpoint', forms.ChoiceField(
-            label=_('Endpoint'),
+            label=_('PayPal Connect Endpoint'),
             initial='live',
             choices=(
                 ('live', 'Live'),

--- a/src/pretix/plugins/paypal/signals.py
+++ b/src/pretix/plugins/paypal/signals.py
@@ -1,11 +1,14 @@
 import json
+from collections import OrderedDict
 
+from django import forms
 from django.dispatch import receiver
 from django.template.loader import get_template
 from django.utils.translation import ugettext_lazy as _
 
 from pretix.base.signals import (
-    logentry_display, register_payment_providers, requiredaction_display,
+    logentry_display, register_global_settings, register_payment_providers,
+    requiredaction_display,
 )
 
 
@@ -53,3 +56,16 @@ def pretixcontrol_action_display(sender, action, request, **kwargs):
 
     ctx = {'data': data, 'event': sender, 'action': action}
     return template.render(ctx, request)
+
+@receiver(register_global_settings, dispatch_uid='paypal_global_settings')
+def register_global_settings(sender, **kwargs):
+    return OrderedDict([
+        ('payment_paypal_connect_client_id', forms.CharField(
+            label=_('PayPal Connect: Client ID'),
+            required=False,
+        )),
+        ('payment_paypal_connect_secret_key', forms.CharField(
+            label=_('PayPal Connect: Secret key'),
+            required=False,
+        )),
+    ])

--- a/src/pretix/plugins/paypal/signals.py
+++ b/src/pretix/plugins/paypal/signals.py
@@ -69,4 +69,12 @@ def register_global_settings(sender, **kwargs):
             label=_('PayPal Connect: Secret key'),
             required=False,
         )),
+        ('payment_paypal_connect_endpoint', forms.ChoiceField(
+            label=_('Endpoint'),
+            initial='live',
+            choices=(
+                ('live', 'Live'),
+                ('sandbox', 'Sandbox'),
+            ),
+        )),
     ])

--- a/src/pretix/plugins/paypal/urls.py
+++ b/src/pretix/plugins/paypal/urls.py
@@ -3,8 +3,7 @@ from django.conf.urls import include, url
 from pretix.multidomain import event_url
 
 from .views import (
-    abort, redirect_view, success, oauth_disconnect, oauth_return,
-    webhook
+    abort, oauth_disconnect, oauth_return, redirect_view, success, webhook,
 )
 
 event_patterns = [

--- a/src/pretix/plugins/paypal/urls.py
+++ b/src/pretix/plugins/paypal/urls.py
@@ -2,7 +2,10 @@ from django.conf.urls import include, url
 
 from pretix.multidomain import event_url
 
-from .views import abort, redirect_view, success, webhook
+from .views import (
+    abort, redirect_view, success, oauth_disconnect, oauth_return,
+    webhook
+)
 
 event_patterns = [
     url(r'^paypal/', include([
@@ -19,5 +22,8 @@ event_patterns = [
 
 
 urlpatterns = [
+    url(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/paypal/disconnect/',
+        oauth_disconnect, name='oauth.disconnect'),
     url(r'^_paypal/webhook/$', webhook, name='webhook'),
+    url(r'^_paypal/oauth_return/$', oauth_return, name='oauth.return'),
 ]

--- a/src/pretix/plugins/paypal/views.py
+++ b/src/pretix/plugins/paypal/views.py
@@ -3,7 +3,6 @@ import logging
 from decimal import Decimal
 
 import paypalrestsdk
-from paypalrestsdk.openid_connect import Tokeninfo
 from django.contrib import messages
 from django.core import signing
 from django.db.models import Sum
@@ -14,10 +13,10 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from paypalrestsdk.openid_connect import Tokeninfo
 
 from pretix.base.models import Event, Order, OrderPayment, OrderRefund, Quota
 from pretix.base.payment import PaymentException
-from pretix.base.settings import GlobalSettingsObject
 from pretix.control.permissions import event_permission_required
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.plugins.paypal.models import ReferencedPayPalObject
@@ -40,6 +39,7 @@ def redirect_view(request, *args, **kwargs):
     r._csp_ignore = True
     return r
 
+
 def oauth_return(request, *args, **kwargs):
     if 'payment_paypal_oauth_event' not in request.session:
         messages.error(request, _('An error occurred during connecting with PayPal, please try again.'))
@@ -47,10 +47,8 @@ def oauth_return(request, *args, **kwargs):
 
     event = get_object_or_404(Event, pk=request.session['payment_paypal_oauth_event'])
 
-    gs = GlobalSettingsObject()
     prov = Paypal(event)
     prov.init_api()
-    testdata = {}
 
     try:
         tokeninfo = Tokeninfo.create(request.GET.get('code'))
@@ -71,6 +69,7 @@ def oauth_return(request, *args, **kwargs):
         'event': event.slug,
         'provider': 'paypal'
     }))
+
 
 def success(request, *args, **kwargs):
     pid = request.GET.get('paymentId')
@@ -236,6 +235,7 @@ def webhook(request, *args, **kwargs):
             pass
 
     return HttpResponse(status=200)
+
 
 @event_permission_required('can_change_event_settings')
 @require_POST

--- a/src/pretix/plugins/paypal/views.py
+++ b/src/pretix/plugins/paypal/views.py
@@ -3,18 +3,22 @@ import logging
 from decimal import Decimal
 
 import paypalrestsdk
+from paypalrestsdk.openid_connect import Tokeninfo
 from django.contrib import messages
 from django.core import signing
 from django.db.models import Sum
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from pretix.base.models import Order, OrderPayment, OrderRefund, Quota
+from pretix.base.models import Event, Order, OrderPayment, OrderRefund, Quota
 from pretix.base.payment import PaymentException
+from pretix.base.settings import GlobalSettingsObject
+from pretix.control.permissions import event_permission_required
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.plugins.paypal.models import ReferencedPayPalObject
 from pretix.plugins.paypal.payment import Paypal
@@ -36,6 +40,37 @@ def redirect_view(request, *args, **kwargs):
     r._csp_ignore = True
     return r
 
+def oauth_return(request, *args, **kwargs):
+    if 'payment_paypal_oauth_event' not in request.session:
+        messages.error(request, _('An error occurred during connecting with PayPal, please try again.'))
+        return redirect(reverse('control:index'))
+
+    event = get_object_or_404(Event, pk=request.session['payment_paypal_oauth_event'])
+
+    gs = GlobalSettingsObject()
+    prov = Paypal(event)
+    prov.init_api()
+    testdata = {}
+
+    try:
+        tokeninfo = Tokeninfo.create(request.GET.get('code'))
+        userinfo = Tokeninfo.create_with_refresh_token(tokeninfo['refresh_token']).userinfo()
+    except:
+        logger.exception('Failed to obtain OAuth token')
+        messages.error(request, _('An error occurred during connecting with PayPal, please try again.'))
+    else:
+        messages.success(request,
+                         _('Your PayPal account is now connected to pretix. You can change the settings in '
+                           'detail below.'))
+
+        event.settings.payment_paypal_connect_refresh_token = tokeninfo['refresh_token']
+        event.settings.payment_paypal_connect_user_id = userinfo.email
+
+    return redirect(reverse('control:event.settings.payment.provider', kwargs={
+        'organizer': event.organizer.slug,
+        'event': event.slug,
+        'provider': 'paypal'
+    }))
 
 def success(request, *args, **kwargs):
     pid = request.GET.get('paymentId')
@@ -201,3 +236,17 @@ def webhook(request, *args, **kwargs):
             pass
 
     return HttpResponse(status=200)
+
+@event_permission_required('can_change_event_settings')
+@require_POST
+def oauth_disconnect(request, **kwargs):
+    del request.event.settings.payment_paypal_connect_refresh_token
+    del request.event.settings.payment_paypal_connect_user_id
+    request.event.settings.payment_paypal__enabled = False
+    messages.success(request, _('Your PayPal account has been disconnected.'))
+
+    return redirect(reverse('control:event.settings.payment.provider', kwargs={
+        'organizer': request.event.organizer.slug,
+        'event': request.event.slug,
+        'provider': 'paypal'
+    }))


### PR DESCRIPTION
New feature to offer something similar to Stripe Connect.

As of now, the eMail-Address of the payee is transmitted instead of the MerchantID. For a later iteration, it might be interesting to use that one instead as it should be less volatile than an email-address. However - for the time being - I was unable to get the MerchantID using the REST API.