### PR TITLE
Add media-src CSP to middleware

### DIFF
--- a/src/pretix/base/middleware.py
+++ b/src/pretix/base/middleware.py
@@ -189,6 +189,7 @@ class SecurityMiddleware(MiddlewareMixin):
             'connect-src': ["{dynamic}", "{media}", "https://checkout.stripe.com"],
             'img-src': ["{static}", "{media}", "data:", "https://*.stripe.com"],
             'font-src': ["{static}"],
+            'media-src': ["{static}", "data:"],
             # form-action is not only used to match on form actions, but also on URLs
             # form-actions redirect to. In the context of e.g. payment providers or
             # single-sign-on this can be nearly anything so we cannot really restrict


### PR DESCRIPTION
As of now, pretix does not have any default Content-Security-Policy for `media-src`es.

This PR will take care of this - and help me for a future plugin development :)