### PR TITLE
Fix #1111 -- Duplicate voucher warning

### DIFF
--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -13,6 +13,7 @@ from ..decimal import round_decimal
 from .base import LoggedModel
 from .event import Event, SubEvent
 from .items import Item, ItemVariation, Quota
+from .orders import Order
 
 
 def _generate_random_code(prefix=None):
@@ -380,3 +381,11 @@ class Voucher(LoggedModel):
                 return p.quantize(Decimal('1') / 10 ** places, ROUND_HALF_UP)
             return p
         return original_price
+
+    def distinct_orders(self):
+        """
+        Return the list of orders where this voucher has been used.
+        Each order will appear at most once.
+        """
+
+        return Order.objects.filter(all_positions__voucher__in=[self]).distinct()

--- a/src/pretix/control/templates/pretixcontrol/vouchers/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/vouchers/detail.html
@@ -9,9 +9,9 @@
         <div class="alert alert-warning">
             {% trans "This voucher already has been used. It is not recommended to modify it." %}
             <ul>
-            {% for op in voucher.orderposition_set.all %}
-                <li><a href="{% url "control:event.order" event=request.event.slug organizer=request.event.organizer.slug code=op.order.code %}">
-                    {% blocktrans with code=op.order.code %}Order {{ code }}{% endblocktrans %}
+            {% for order in voucher.distinct_orders %}
+                <li><a href="{% url "control:event.order" event=request.event.slug organizer=request.event.organizer.slug code=order.code %}">
+                    {% blocktrans with code=order.code %}Order {{ code }}{% endblocktrans %}
                 </a></li>
             {% endfor %}
             </ul>


### PR DESCRIPTION
Adds a new method to Voucher that selects all distinct orders containing
a position where the Voucher has been used, and changes the Voucher
detail view to use this method for the warning. Includes regression test.