### PR TITLE
Updates the dependency versions for flake8

### DIFF
--- a/src/requirements/dev.txt
+++ b/src/requirements/dev.txt
@@ -1,8 +1,8 @@
 django-debug-toolbar==1.9.1
 sqlparse==0.2.1  # pinned due to difficulties with django-debug-toolbar
 # Testing requirements
-pep8==1.5.7  # exact requirement by flake8 2.4.0
-pyflakes==1.1.0  # later version causes problems currently
+pycodestyle >= 2.4.0, < 2.5.0 # requirement by flake8 3.6.0
+pyflakes >= 2.0.0, < 2.1.0 # requirement by flake8 3.6.0
 pep8-naming
 flake8
 codecov

--- a/src/setup.py
+++ b/src/setup.py
@@ -146,8 +146,8 @@ setup(
         'dev': [
             'django-debug-toolbar==1.9.1',
             'sqlparse==0.2.1',
-            'pep8==1.5.7',
-            'pyflakes==1.1.0',
+            'pycodestyle >= 2.4.0, < 2.5.0',
+            'pyflakes >= 2.0.0, < 2.1.0',
             'flake8',
             'pep8-naming',
             'coveralls',


### PR DESCRIPTION
Following the setup instructions resulted in the following error message:
```
pip3 install -r requirements.txt -r requirements/dev.txt
[...]
flake8 3.6.0 has requirement pyflakes<2.1.0,>=2.0.0, but you'll have pyflakes 1.1.0 which is incompatible.
```

**Fix:**
Pretix doesn't version pin flake8, but it's two requirements pep8 and pyflakes.
The current release flake8 3.6.0 (http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html#new-dependency-information) updates the version requirements for pyflakes and pycodestyle (former pep8).
I've transfered the version range into setup.py and requirements/dev.txt.

I am now able to rerun the dev-setup tutorial without errors.