### PR TITLE
Fix UI crash in log entry view when `logentry.data` is list of dict

### DIFF
--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -312,7 +312,10 @@ def pretixcontrol_logentry_display(sender: Event, logentry: LogEntry, **kwargs):
             data['value'] = LazyI18nString(data['value'])
 
     if logentry.action_type in plains:
-        data = defaultdict(lambda: '?', data)
+        if type(data) == list:
+            data = [ defaultdict(lambda: '?', d) for d in data ]
+        else:
+            data = defaultdict(lambda: '?', data)
         return plains[logentry.action_type].format_map(data)
 
     if logentry.action_type.startswith('pretix.event.order.changed'):


### PR DESCRIPTION
When e.g. creating vouchers with the `voucher/batch_create` api, `logentry.data` is a list and not a dict.