### PR TITLE
Enable nl2br plugin for Markdown rendering

### DIFF
--- a/src/pretix/base/templatetags/rich_text.py
+++ b/src/pretix/base/templatetags/rich_text.py
@@ -84,7 +84,7 @@ def markdown_compile(source):
             source,
             extensions=[
                 'markdown.extensions.sane_lists',
-                # 'markdown.extensions.nl2br',  # TODO: Enable, but check backwards-compatibility issues e.g. with mails
+                'markdown.extensions.nl2br'
             ]
         ),
         tags=ALLOWED_TAGS,

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -102,7 +102,7 @@
 
     {% if frontpage_text and not cart_namespace %}
         <div>
-            {{ frontpage_text|rich_text|linebreaksbr }}
+            {{ frontpage_text|rich_text }}
         </div>
     {% endif %}
 


### PR DESCRIPTION
The frontpage text is already markdown, and will receive its formatting via the rich_text filter.
When applying the additional linebreaksbr filter, it will add unnecessary blank lines.

I'm using the hosted pretix version. 

Test for frontpage text: 

````
Test 

* test1
* test2
````

Before (screenshot): 

---

![before](https://user-images.githubusercontent.com/3957921/52533531-5428fe00-2d35-11e9-891d-f822c3524b0e.png)

----


After (screenshot): 

----
![after](https://user-images.githubusercontent.com/3957921/52533532-568b5800-2d35-11e9-9702-4c713a110c81.png)

----
