### PR TITLE
Fix #1247 -- Allow team invites to be resent

### DIFF
--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -389,6 +389,9 @@ def pretixcontrol_logentry_display(sender: Event, logentry: LogEntry, **kwargs):
     if logentry.action_type == 'pretix.team.invite.created':
         return _('{user} has been invited to the team.').format(user=data.get('email'))
 
+    if logentry.action_type == 'pretix.team.invite.resent':
+        return _('Invite for {user} has been resent.').format(user=data.get('email'))
+
     if logentry.action_type == 'pretix.team.invite.deleted':
         return _('The invite for {user} has been revoked.').format(user=data.get('email'))
 

--- a/src/pretix/control/templates/pretixcontrol/organizers/team_members.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/team_members.html
@@ -51,6 +51,10 @@
                         {{ i.email }}
                         <span class="fa fa-envelope-o" data-toggle="tooltip"
                               title="{% trans "invited, pending response" %}"></span>
+                        <button type="submit" name="resend-invite" value="{{ i.id }}">
+                            <span class="fa fa-repeat" data-toggle="tooltip"
+                                title="{% trans "resend invite" %}"></span>
+                        </button>
                     </td>
                     <td class="text-right">
                         <button type="submit" name="remove-invite" value="{{ i.id }}"

--- a/src/pretix/control/templates/pretixcontrol/organizers/team_members.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/team_members.html
@@ -51,9 +51,9 @@
                         {{ i.email }}
                         <span class="fa fa-envelope-o" data-toggle="tooltip"
                               title="{% trans "invited, pending response" %}"></span>
-                        <button type="submit" name="resend-invite" value="{{ i.id }}">
-                            <span class="fa fa-repeat" data-toggle="tooltip"
-                                title="{% trans "resend invite" %}"></span>
+                        <button type="submit" name="resend-invite" value="{{ i.id }}"
+                                data-toggle="tooltip" title="{% trans "resend invite" %}">
+                            <span class="fa fa-repeat"></span>
                         </button>
                     </td>
                     <td class="text-right">

--- a/src/pretix/control/templates/pretixcontrol/organizers/team_members.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/team_members.html
@@ -52,7 +52,8 @@
                         <span class="fa fa-envelope-o" data-toggle="tooltip"
                               title="{% trans "invited, pending response" %}"></span>
                         <button type="submit" name="resend-invite" value="{{ i.id }}"
-                                data-toggle="tooltip" title="{% trans "resend invite" %}">
+                                data-toggle="tooltip" title="{% trans "resend invite" %}"
+                                class="btn-invisible">
                             <span class="fa fa-repeat"></span>
                         </button>
                     </td>

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -555,6 +555,22 @@ class TeamMemberView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixin,
                 messages.success(self.request, _('The invite has been revoked.'))
                 return redirect(self.get_success_url())
 
+        elif 'resend-invite' in request.POST:
+            try:
+                invite = self.object.invites.get(pk=request.POST.get('resend-invite'))
+            except TeamInvite.DoesNotExist:
+                messages.error(self.request, _('Invalid invite selected.'))
+                return redirect(self.get_success_url())
+            else:
+                self._send_invite(invite)
+                self.object.log_action(
+                    'pretix.team.invite.resent', user=self.request.user, data={
+                        'email': invite.email
+                    }
+                )
+                messages.success(self.request, _('The invite has been resent.'))
+                return redirect(self.get_success_url())
+
         elif 'remove-token' in request.POST:
             try:
                 token = self.object.tokens.get(pk=request.POST.get('remove-token'))

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -518,7 +518,7 @@ class TeamMemberView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixin,
         if 'remove-member' in request.POST:
             try:
                 user = User.objects.get(pk=request.POST.get('remove-member'))
-            except User.DoesNotExist:
+            except (User.DoesNotExist, ValueError):
                 pass
             else:
                 other_admin_teams = self.request.organizer.teams.exclude(pk=self.object.pk).filter(
@@ -542,7 +542,7 @@ class TeamMemberView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixin,
         elif 'remove-invite' in request.POST:
             try:
                 invite = self.object.invites.get(pk=request.POST.get('remove-invite'))
-            except TeamInvite.DoesNotExist:
+            except (TeamInvite.DoesNotExist, ValueError):
                 messages.error(self.request, _('Invalid invite selected.'))
                 return redirect(self.get_success_url())
             else:
@@ -558,7 +558,7 @@ class TeamMemberView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixin,
         elif 'resend-invite' in request.POST:
             try:
                 invite = self.object.invites.get(pk=request.POST.get('resend-invite'))
-            except TeamInvite.DoesNotExist:
+            except (TeamInvite.DoesNotExist, ValueError):
                 messages.error(self.request, _('Invalid invite selected.'))
                 return redirect(self.get_success_url())
             else:
@@ -574,7 +574,7 @@ class TeamMemberView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixin,
         elif 'remove-token' in request.POST:
             try:
                 token = self.object.tokens.get(pk=request.POST.get('remove-token'))
-            except TeamAPIToken.DoesNotExist:
+            except (TeamAPIToken.DoesNotExist, ValueError):
                 messages.error(self.request, _('Invalid token selected.'))
                 return redirect(self.get_success_url())
             else:

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -74,6 +74,11 @@
   outline: 0;
 }
 
+.btn-invisible {
+  background: transparent;
+  border: transparent;
+}
+
 .alert-primary, .alert-warning, .alert-info, .alert-success, .alert-danger {
   color: #3b3b3b;
 }

--- a/src/tests/control/test_teams.py
+++ b/src/tests/control/test_teams.py
@@ -247,11 +247,11 @@ def test_resend_invalid_invite(event, admin_user, admin_team, client):
 
     inv = admin_team.invites.create(email='foo@example.org')
     resp = client.post('/control/organizer/dummy/team/{}/'.format(admin_team.pk), {
-        'resend-invite': "foo{}bar".format(inv.pk)
+        'resend-invite': inv.pk + 1
     }, follow=True)
     assert b'alert-danger' in resp.content
     assert b'Invalid invite selected.' in resp.content
-    assert len(outbox) == 0
+    assert len(djmail.outbox) == 0
 
 
 @pytest.mark.django_db

--- a/src/tests/control/test_teams.py
+++ b/src/tests/control/test_teams.py
@@ -104,6 +104,21 @@ def test_team_remove_token(event, admin_user, admin_team, client):
 
 
 @pytest.mark.django_db
+def test_team_resend_invite(event, admin_user, admin_team, client):
+    client.login(email='dummy@dummy.dummy', password='dummy')
+    djmail.outbox = []
+
+    inv = admin_team.invites.create(email='foo@example.org')
+    resp = client.post('/control/organizer/dummy/team/{}/'.format(admin_team.pk), {
+        'resend-invite': str(inv.pk)
+    }, follow=True)
+    assert 'Admin team' in resp.rendered_content
+    assert admin_user.email in resp.rendered_content
+    assert 'foo@example.org' in resp.rendered_content
+    assert len(djmail.outbox) == 1
+
+
+@pytest.mark.django_db
 def test_team_revoke_invite(event, admin_user, admin_team, client):
     client.login(email='dummy@dummy.dummy', password='dummy')
 

--- a/src/tests/control/test_teams.py
+++ b/src/tests/control/test_teams.py
@@ -241,6 +241,20 @@ def test_remove_last_admin_team(event, admin_user, admin_team, client):
 
 
 @pytest.mark.django_db
+def test_resend_invalid_invite(event, admin_user, admin_team, client):
+    client.login(email='dummy@dummy.dummy', password='dummy')
+    djmail.outbox = []
+
+    inv = admin_team.invites.create(email='foo@example.org')
+    resp = client.post('/control/organizer/dummy/team/{}/'.format(admin_team.pk), {
+        'resend-invite': "foo{}bar".format(inv.pk)
+    }, follow=True)
+    assert b'alert-danger' in resp.content
+    assert b'Invalid invite selected.' in resp.content
+    assert len(outbox) == 0
+
+
+@pytest.mark.django_db
 def test_invite_invalid_token(event, admin_team, client):
     i = admin_team.invites.create(email='foo@bar.com')
     resp = client.get('/control/invite/foo{}bar'.format(i.token), follow=True)


### PR DESCRIPTION
The functionality is working, but it currently looks horrible, because the button gets rendered as a button (without any styling). It should be possible to remove the button styling, but that would probably require custom CSS for that single case. I thought it would be nice to have the resend functionality close to the envelope icon indicating, that an invite is still pending. Alternatively one could embrace the button being a button and style it like the "remove" button on the right and also move it to the right.