### PR TITLE
[WIP] Banktransfer code prefix (Fix #529)

### DIFF
--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -24,7 +24,9 @@ from pretix.control.permissions import (
 from pretix.control.views.organizer import OrganizerDetailViewMixin
 from pretix.plugins.banktransfer import csvimport, mt940import
 from pretix.plugins.banktransfer.models import BankImportJob, BankTransaction
-from pretix.plugins.banktransfer.tasks import get_prefix_event_map, process_banktransfers
+from pretix.plugins.banktransfer.tasks import (
+    get_prefix_event_map, process_banktransfers,
+)
 
 logger = logging.getLogger('pretix.plugins.banktransfer')
 

--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -24,7 +24,7 @@ from pretix.control.permissions import (
 from pretix.control.views.organizer import OrganizerDetailViewMixin
 from pretix.plugins.banktransfer import csvimport, mt940import
 from pretix.plugins.banktransfer.models import BankImportJob, BankTransaction
-from pretix.plugins.banktransfer.tasks import process_banktransfers, get_prefix_event_map
+from pretix.plugins.banktransfer.tasks import get_prefix_event_map, process_banktransfers
 
 logger = logging.getLogger('pretix.plugins.banktransfer')
 


### PR DESCRIPTION
Add an optional setting in the banktransfer plugin to change the code
prefix from the default value of the event slug to an arbitary string.

This is a work is progress, so there are no tests yet. I'd just like to have some feedback if my approach makes sense :-)

This implementation does retain codes used in previous orders. I've added a function, that takes an organizer or event and returns a map of valid reference code prefixes to the actual event. This is used during transfer processing and in the review functionality for not matched transfers.