### PR TITLE
Add setting for enforcing 2FA

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -78,6 +78,10 @@ Example::
     Enables or disables nagging staff users for leaving comments on their sessions for auditability.
     Defaults to ``off``.
 
+``obligatory_2fa``
+    Enables or disables obligatory usage of Two-Factor Authentication for users of the pretix backend.
+    Defaults to ``False``
+
 
 Locale settings
 ---------------

--- a/src/pretix/control/middleware.py
+++ b/src/pretix/control/middleware.py
@@ -35,6 +35,19 @@ class PermissionMiddleware:
         "user.settings.notifications.off",
     )
 
+    EXCEPTIONS_2FA = (
+        "control:user.settings.2fa",
+        "control:user.settings.2fa.add",
+        "control:user.settings.2fa.enable",
+        "control:user.settings.2fa.disable",
+        "control:user.settings.2fa.regenemergency",
+        "control:user.settings.2fa.confirm.totp",
+        "control:user.settings.2fa.confirm.u2f",
+        "control:user.settings.2fa.delete",
+        "control:auth.logout",
+        "control:user.reauth"
+    )
+
     def __init__(self, get_response=None):
         self.get_response = get_response
         super().__init__()
@@ -74,8 +87,7 @@ class PermissionMiddleware:
             return self._login_redirect(request)
 
         if not request.user.require_2fa and settings.PRETIX_OBLIGATORY_2FA \
-            and not request.path.startswith('/control/settings/2fa/') \
-                and request.path not in ['/control/logout', '/control/login']:
+            and url_name not in self.EXCEPTIONS_2FA:
             return redirect(reverse('control:user.settings.2fa'))
 
         try:

--- a/src/pretix/control/middleware.py
+++ b/src/pretix/control/middleware.py
@@ -73,6 +73,11 @@ class PermissionMiddleware:
         if not request.user.is_authenticated:
             return self._login_redirect(request)
 
+        if not request.user.require_2fa and settings.PRETIX_OBLIGATORY_2FA \
+            and not request.path.startswith('/control/settings/2fa/') \
+                and request.path not in ['/control/logout', '/control/login']:
+            return redirect(reverse('control:user.settings.2fa'))
+
         try:
             # If this logic is updated, make sure to also update the logic in pretix/api/auth/permission.py
             assert_session_valid(request)

--- a/src/pretix/control/middleware.py
+++ b/src/pretix/control/middleware.py
@@ -36,16 +36,16 @@ class PermissionMiddleware:
     )
 
     EXCEPTIONS_2FA = (
-        "control:user.settings.2fa",
-        "control:user.settings.2fa.add",
-        "control:user.settings.2fa.enable",
-        "control:user.settings.2fa.disable",
-        "control:user.settings.2fa.regenemergency",
-        "control:user.settings.2fa.confirm.totp",
-        "control:user.settings.2fa.confirm.u2f",
-        "control:user.settings.2fa.delete",
-        "control:auth.logout",
-        "control:user.reauth"
+        "user.settings.2fa",
+        "user.settings.2fa.add",
+        "user.settings.2fa.enable",
+        "user.settings.2fa.disable",
+        "user.settings.2fa.regenemergency",
+        "user.settings.2fa.confirm.totp",
+        "user.settings.2fa.confirm.u2f",
+        "user.settings.2fa.delete",
+        "auth.logout",
+        "user.reauth"
     )
 
     def __init__(self, get_response=None):
@@ -86,10 +86,6 @@ class PermissionMiddleware:
         if not request.user.is_authenticated:
             return self._login_redirect(request)
 
-        if not request.user.require_2fa and settings.PRETIX_OBLIGATORY_2FA \
-            and url_name not in self.EXCEPTIONS_2FA:
-            return redirect(reverse('control:user.settings.2fa'))
-
         try:
             # If this logic is updated, make sure to also update the logic in pretix/api/auth/permission.py
             assert_session_valid(request)
@@ -99,6 +95,10 @@ class PermissionMiddleware:
         except SessionReauthRequired:
             if url_name not in ('user.reauth', 'auth.logout'):
                 return redirect(reverse('control:user.reauth') + '?next=' + quote(request.get_full_path()))
+
+        if not request.user.require_2fa and settings.PRETIX_OBLIGATORY_2FA \
+                and url_name not in self.EXCEPTIONS_2FA:
+            return redirect(reverse('control:user.settings.2fa'))
 
         if 'event' in url.kwargs and 'organizer' in url.kwargs:
             with scope(organizer=None):

--- a/src/pretix/control/templates/pretixcontrol/user/2fa_main.html
+++ b/src/pretix/control/templates/pretixcontrol/user/2fa_main.html
@@ -11,6 +11,24 @@
             smartphone or a hardware token generator and that changes on a regular basis.
         {% endblocktrans %}
     </p>
+    {% if settings.PRETIX_OBLIGATORY_2FA %}
+        <div class="panel panel-danger">
+            <div class="panel-heading">
+                <h3 class="panel-title">{% trans "Obligatory usage of two-factor authentication" %}</h3>
+            </div>
+            <div class="panel-body">
+                <p>
+                    <strong>{% trans "This system enforces the usage of two-factor authentication!" %}</strong>
+                </p>
+            {% if not devices|length %}
+                <p>{% trans "Please set up at least one device below." %}</p>
+            {% elif not user.require_2fa %}
+                <p>{% trans "Please activate two-factor authentication using the button below." %}</p>
+            {% endif %}
+            </div>
+        </div>
+
+    {% endif %}
     {% if user.require_2fa %}
         <div class="panel panel-success">
             <div class="panel-heading">

--- a/src/pretix/control/templates/pretixcontrol/user/2fa_main.html
+++ b/src/pretix/control/templates/pretixcontrol/user/2fa_main.html
@@ -12,7 +12,7 @@
         {% endblocktrans %}
     </p>
     {% if settings.PRETIX_OBLIGATORY_2FA %}
-        <div class="panel panel-danger">
+        <div class="panel panel-warning">
             <div class="panel-heading">
                 <h3 class="panel-title">{% trans "Obligatory usage of two-factor authentication" %}</h3>
             </div>
@@ -20,7 +20,7 @@
                 <p>
                     <strong>{% trans "This system enforces the usage of two-factor authentication!" %}</strong>
                 </p>
-            {% if not devices|length %}
+            {% if not devices %}
                 <p>{% trans "Please set up at least one device below." %}</p>
             {% elif not user.require_2fa %}
                 <p>{% trans "Please activate two-factor authentication using the button below." %}</p>
@@ -35,9 +35,11 @@
                 <h3 class="panel-title">{% trans "Two-factor status" %}</h3>
             </div>
             <div class="panel-body">
-                <a href="{% url "control:user.settings.2fa.disable" %}" class="btn btn-primary pull-right">
-                    {% trans "Disable" %}
-                </a>
+                {% if not settings.PRETIX_OBLIGATORY_2FA %}
+                    <a href="{% url "control:user.settings.2fa.disable" %}" class="btn btn-primary pull-right">
+                        {% trans "Disable" %}
+                    </a>
+                {% endif %}
                 <p>
                     <strong>{% trans "Two-factor authentication is currently enabled." %}</strong>
                 </p>

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -120,6 +120,7 @@ PRETIX_REGISTRATION = config.getboolean('pretix', 'registration', fallback=True)
 PRETIX_PASSWORD_RESET = config.getboolean('pretix', 'password_reset', fallback=True)
 PRETIX_LONG_SESSIONS = config.getboolean('pretix', 'long_sessions', fallback=True)
 PRETIX_ADMIN_AUDIT_COMMENTS = config.getboolean('pretix', 'audit_comments', fallback=False)
+PRETIX_OBLIGATORY_2FA = config.getboolean('pretix', 'obligatory_2fa', fallback=False)
 PRETIX_SESSION_TIMEOUT_RELATIVE = 3600 * 3
 PRETIX_SESSION_TIMEOUT_ABSOLUTE = 3600 * 12
 


### PR DESCRIPTION
This is a very quick hack for enforcing the usage of 2FA for backend-users.

I burried the setting in the pretix.cfg, as most users probably won't ever have a need to turn this on.

This hooks into the middleware and basically disallows access to any URL other than the 2FA-related ones, login and logout, if obligatory 2FA is set and the user hasn't enabled it yet.