### PR TITLE
Change semantics of changing orders

### DIFF
--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -680,6 +680,7 @@ class OrderPositionViewSet(mixins.DestroyModelMixin, viewsets.ReadOnlyModelViewS
                     raise ValidationError('No variation given')
                 if variation.item != item:
                     raise ValidationError('Variation does not belong to item')
+                kwargs['variation'] = variation
             else:
                 variation = None
                 kwargs['variation'] = None

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -846,8 +846,8 @@ class OrderChangeManager:
         'addon_invalid': _('The selected base position does not allow you to add this product as an add-on.'),
         'subevent_required': _('You need to choose a subevent for the new position.'),
     }
-    ItemOperation = namedtuple('ItemOperation', ('position', 'item', 'variation', 'price'))
-    SubeventOperation = namedtuple('SubeventOperation', ('position', 'subevent', 'price'))
+    ItemOperation = namedtuple('ItemOperation', ('position', 'item', 'variation'))
+    SubeventOperation = namedtuple('SubeventOperation', ('position', 'subevent'))
     PriceOperation = namedtuple('PriceOperation', ('position', 'price'))
     CancelOperation = namedtuple('CancelOperation', ('position',))
     AddOperation = namedtuple('AddOperation', ('item', 'variation', 'price', 'addon_to', 'subevent'))
@@ -867,33 +867,18 @@ class OrderChangeManager:
         self.notify = notify
         self._invoice_dirty = False
 
-    def change_item(self, position: OrderPosition, item: Item, variation: Optional[ItemVariation], keep_price=False):
+    def change_item(self, position: OrderPosition, item: Item, variation: Optional[ItemVariation]):
         if (not variation and item.has_variations) or (variation and variation.item_id != item.pk):
             raise OrderError(self.error_messages['product_without_variation'])
-
-        if keep_price:
-            price = TaxedPrice(gross=position.price, net=position.price - position.tax_value,
-                               tax=position.tax_value, rate=position.tax_rate,
-                               name=position.tax_rule.name if position.tax_rule else None)
-        else:
-            price = get_price(item, variation, voucher=position.voucher, subevent=position.subevent,
-                              invoice_address=self._invoice_address)
-
-        if price is None:  # NOQA
-            raise OrderError(self.error_messages['product_invalid'])
 
         new_quotas = (variation.quotas.filter(subevent=position.subevent)
                       if variation else item.quotas.filter(subevent=position.subevent))
         if not new_quotas:
             raise OrderError(self.error_messages['quota_missing'])
 
-        if self.order.event.settings.invoice_include_free or price.gross != Decimal('0.00') or position.price != Decimal('0.00'):
-            self._invoice_dirty = True
-
-        self._totaldiff += price.gross - position.price
         self._quotadiff.update(new_quotas)
         self._quotadiff.subtract(position.quotas)
-        self._operations.append(self.ItemOperation(position, item, variation, price))
+        self._operations.append(self.ItemOperation(position, item, variation))
 
     def change_subevent(self, position: OrderPosition, subevent: SubEvent):
         price = get_price(position.item, position.variation, voucher=position.voucher, subevent=subevent,
@@ -907,19 +892,15 @@ class OrderChangeManager:
         if not new_quotas:
             raise OrderError(self.error_messages['quota_missing'])
 
-        if self.order.event.settings.invoice_include_free or price.gross != Decimal('0.00') or position.price != Decimal('0.00'):
-            self._invoice_dirty = True
-
-        self._totaldiff += price.gross - position.price
         self._quotadiff.update(new_quotas)
         self._quotadiff.subtract(position.quotas)
-        self._operations.append(self.SubeventOperation(position, subevent, price))
+        self._operations.append(self.SubeventOperation(position, subevent))
 
     def regenerate_secret(self, position: OrderPosition):
         self._operations.append(self.RegenerateSecretOperation(position))
 
     def change_price(self, position: OrderPosition, price: Decimal):
-        price = position.item.tax(price)
+        price = position.item.tax(price, base_price_is='gross')
 
         self._totaldiff += price.gross - position.price
 
@@ -1076,14 +1057,11 @@ class OrderChangeManager:
                     'new_variation': op.variation.pk if op.variation else None,
                     'old_price': op.position.price,
                     'addon_to': op.position.addon_to_id,
-                    'new_price': op.price.gross
+                    'new_price': op.position.price
                 })
                 op.position.item = op.item
                 op.position.variation = op.variation
-                op.position.price = op.price.gross
-                op.position.tax_rate = op.price.rate
-                op.position.tax_value = op.price.tax
-                op.position.tax_rule = op.item.tax_rule
+                op.position._calculate_tax()
                 op.position.save()
             elif isinstance(op, self.SubeventOperation):
                 self.order.log_action('pretix.event.order.changed.subevent', user=self.user, auth=self.auth, data={
@@ -1092,13 +1070,9 @@ class OrderChangeManager:
                     'old_subevent': op.position.subevent.pk,
                     'new_subevent': op.subevent.pk,
                     'old_price': op.position.price,
-                    'new_price': op.price.gross
+                    'new_price': op.position.price
                 })
                 op.position.subevent = op.subevent
-                op.position.price = op.price.gross
-                op.position.tax_rate = op.price.rate
-                op.position.tax_value = op.price.tax
-                op.position.tax_rule = op.position.item.tax_rule
                 op.position.save()
             elif isinstance(op, self.PriceOperation):
                 self.order.log_action('pretix.event.order.changed.price', user=self.user, auth=self.auth, data={
@@ -1109,9 +1083,7 @@ class OrderChangeManager:
                     'new_price': op.price.gross
                 })
                 op.position.price = op.price.gross
-                op.position.tax_rate = op.price.rate
-                op.position.tax_value = op.price.tax
-                op.position.tax_rule = op.position.item.tax_rule
+                op.position._calculate_tax()
                 op.position.save()
             elif isinstance(op, self.CancelOperation):
                 for opa in op.position.addons.all():

--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -43,6 +43,7 @@
             <script type="text/javascript" src="{% static "pretixcontrol/js/ui/subevent.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixcontrol/js/ui/question.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixcontrol/js/ui/mail.js" %}"></script>
+            <script type="text/javascript" src="{% static "pretixcontrol/js/ui/orderchange.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixcontrol/js/ui/typeahead.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixcontrol/js/ui/quicksetup.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixbase/js/details.js" %}"></script>

--- a/src/pretix/control/templates/pretixcontrol/order/change.html
+++ b/src/pretix/control/templates/pretixcontrol/order/change.html
@@ -1,6 +1,7 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load money %}
 {% block title %}
     {% blocktrans trimmed with code=order.code %}
         Change order: {{ code }}
@@ -71,92 +72,87 @@
                     </h3>
                 </div>
                 <div class="panel-body">
-                    <div class="form-inline form-order-change">
+                    <div class="form-order-change" data-pricecalc-endpoint="{% url "api-v1:orderposition-price_calc" organizer=order.event.organizer.slug event=order.event.slug pk=position.pk %}">
                         {% bootstrap_form_errors position.form %}
                         {% if position.custom_error %}
                             <div class="alert alert-danger">
                                 {{ position.custom_error }}
                             </div>
                         {% endif %}
-                        <p class="help-block">
-                            {% trans "Ticket secret:" %} {{ position.secret|slice:":12" }}…
-                        </p>
-                        <div class="radio">
-                            <label>
-                                <input name="{{ position.form.prefix }}-operation" type="radio" value=""
-                                        {% if not position.form.operation.value %}checked="checked"{% endif %}>
-                                {% trans "Keep unchanged" %}
-                            </label>
+                        <div class="row">
+                            <div class="col-sm-5 col-sm-offset-3">
+                                <strong>{% trans "Current value" %}</strong>
+                            </div>
+                            <div class="col-sm-4">
+                                <strong>{% trans "Change to" %}</strong>
+                            </div>
                         </div>
-                        <div class="radio">
-                            <label>
-                                <input name="{{ position.form.prefix }}-operation" type="radio" value="product"
-                                        {% if position.form.operation.value == "product" %}checked="checked"{% endif %}>
-                                {% trans "Change product to" %}
+                        <div class="row">
+                            <div class="col-sm-3">
+                                <strong>{% trans "Product" %}</strong>
+                            </div>
+                            <div class="col-sm-5">
+                                {{ position.item }}
+                                {% if position.variation %}
+                                    – {{ position.variation }}
+                                {% endif %}
+                            </div>
+                            <div class="col-sm-4">
                                 {% bootstrap_field position.form.itemvar layout='inline' %}
-                            </label>
-                            <label class="checkbox">
-                                {{ position.form.change_product_keep_price }}
-                                {% trans "Keep price the same" %}
-                            </label>
+                            </div>
                         </div>
+
                         {% if request.event.has_subevents %}
-                            <div class="radio">
-                                <label>
-                                    <input name="{{ position.form.prefix }}-operation" type="radio" value="subevent"
-                                            {% if position.form.operation.value == "subevent" %}checked="checked"{% endif %}>
-                                    {% trans "Change date to" context "subevent" %}
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <strong>{% trans "Date" context "subevent" %}</strong>
+                                </div>
+                                <div class="col-sm-5">
+                                    {{ position.subevent }}
+                                </div>
+                                <div class="col-sm-4">
                                     {% bootstrap_field position.form.subevent layout='inline' %}
-                                </label>
+                                </div>
                             </div>
                         {% endif %}
-                        <div class="radio">
-                            <label>
-                                <input name="{{ position.form.prefix }}-operation" type="radio" value="price"
-                                        {% if position.form.operation.value == "price" %}checked="checked"{% endif %}>
-                                {% trans "Change price to" %}
+
+                        <div class="row">
+                            <div class="col-sm-3">
+                                <strong>{% trans "Price" %}</strong>
+                            </div>
+                            <div class="col-sm-5">
+                                {{ position.price|money:request.event.currency }}<br>
+                                {% if position.tax_rate %}
+                                    <small>{% blocktrans trimmed with rate=position.tax_rate name=position.tax_rule.name %}
+                                        <strong>incl.</strong> {{ rate }}% {{ name }}
+                                    {% endblocktrans %}</small>
+                                {% endif %}
+                            </div>
+                            <div class="col-sm-4 field-container">
                                 {% bootstrap_field position.form.price addon_after=request.event.currency layout='inline' %}
-                                {% if position.apply_tax %}
-                                    {% if position.item.tax_rule and not position.item.tax_rule.price_includes_tax %}
-                                        {% blocktrans trimmed with rate=position.item.tax_rule.rate name=position.item.tax_rule.name %}
-                                            <strong>plus</strong> {{ rate }}% {{ name }}
-                                        {% endblocktrans %}
-                                    {% elif position.item.tax_rule %}
-                                        {% blocktrans trimmed with rate=position.item.tax_rule.rate name=position.item.tax_rule.name %}
-                                            <strong>incl.</strong> {{ rate }}% {{ name }}
-                                        {% endblocktrans %}
-                                    {% endif %}
-                                {% else %}
-                                    {% trans "no taxes apply" %}
-                                {% endif %}
-                            </label>
+                                <small><strong>{% trans "including all taxes" %}</strong></small>
+                            </div>
                         </div>
-                        <div class="radio">
-                            <label>
-                                <input name="{{ position.form.prefix }}-operation" type="radio" value="split"
-                                        {% if position.form.operation.value == "split" %}checked="checked"{% endif %}>
-                                {% trans "Split into new order" %}
-                            </label>
+
+                        <div class="row">
+                            <div class="col-sm-3">
+                                <strong>{% trans "Ticket secret" %}</strong>
+                            </div>
+                            <div class="col-sm-5">
+                                {{ position.secret|slice:":12" }}…
+                            </div>
+                            <div class="col-sm-4">
+                                {% bootstrap_field position.form.operation_secret layout='inline' %}
+                            </div>
                         </div>
-                        <div class="radio">
-                            <label>
-                                <input name="{{ position.form.prefix }}-operation" type="radio" value="secret"
-                                        {% if position.form.operation.value == "secret" %}checked="checked"{% endif %}>
-                                {% trans "Generate a new secret" %}
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input name="{{ position.form.prefix }}-operation" type="radio" value="cancel"
-                                        {% if position.form.operation.value == "cancel" %}checked="checked"{% endif %}>
-                                {% trans "Cancel position" %}
-                                {% if position.addons.exists %}
-                                    <em class="text-danger">
-                                        {% trans "Removing this position will also remove all add-ons to this position." %}
-                                    </em>
-                                {% endif %}
-                            </label>
-                        </div>
+
+                        {% bootstrap_field position.form.operation_cancel layout='inline' %}
+                        {% bootstrap_field position.form.operation_split layout='inline' %}
+                        {% if position.addons.exists %}
+                            <em class="text-danger">
+                                {% trans "Removing this position will also remove all add-ons to this position." %}
+                            </em>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/src/pretix/static/pretixcontrol/js/ui/orderchange.js
+++ b/src/pretix/static/pretixcontrol/js/ui/orderchange.js
@@ -1,0 +1,51 @@
+/*global $, gettext*/
+$(function () {
+    // Question view
+    if (!$(".form-order-change").length) {
+        return;
+    }
+    $(".form-order-change").each(function () {
+        var url = $(this).attr("data-pricecalc-endpoint");
+        var $itemvar = $(this).find("[name*=itemvar]");
+        var $subevent = $(this).find("[name*=subevent]");
+        var $price = $(this).find("[name*=price]");
+        var update_price = function () {
+            console.log(url);
+            var itemvar = $itemvar.val();
+            var item = null;
+            var variation = null;
+            if (itemvar.indexOf("-")) {
+                item = parseInt(itemvar.split("-")[0]);
+                variation = parseInt(itemvar.split("-")[1]);
+            } else {
+                item = parseInt(itemvar);
+            }
+            $price.closest(".field-container").append("<small class=\"loading-indicator\"><span class=\"fa fa-cog fa-spin\"></span> " +
+                gettext("Calculating default price…") + "</small>");
+            $.ajax(
+                {
+                    'type': 'POST',
+                    'url': url,
+                    'headers': {'X-CSRFToken': $("input[name=csrfmiddlewaretoken]").val()},
+                    'data': JSON.stringify({
+                        'item': item,
+                        'variation': variation,
+                        'subevent': $subevent.val(),
+                        'locale': $("body").attr("data-pretixlocale"),
+                    }),
+                    'contentType': "application/json",
+                    'success': function (data) {
+                        $price.val(data.gross_formatted);
+                        $price.closest(".field-container").find(".loading-indicator").remove();
+                    },
+                    // 'error': …
+                    'context': this,
+                    'dataType': 'json',
+                    'timeout': 30000
+                }
+            );
+        };
+        $itemvar.on("change", update_price);
+        $subevent.on("change", update_price);
+    });
+});

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -407,6 +407,12 @@ table td > .checkbox input[type="checkbox"] {
   }
 }
 
+.form-order-change {
+  .row {
+    padding: 5px 0;
+  }
+}
+
 @media(max-width: $screen-xs-max) {
   .nameparts-form-group {
     display: block;
@@ -455,3 +461,4 @@ table td > .checkbox input[type="checkbox"] {
     }
   }
 }
+

--- a/src/tests/api/test_permissions.py
+++ b/src/tests/api/test_permissions.py
@@ -25,6 +25,7 @@ event_permission_sub_urls = [
     ('get', 'can_view_orders', 'orders/', 200),
     ('get', 'can_view_orders', 'orderpositions/', 200),
     ('delete', 'can_change_orders', 'orderpositions/1/', 404),
+    ('post', 'can_change_orders', 'orderpositions/1/price_calc/', 404),
     ('get', 'can_view_vouchers', 'vouchers/', 200),
     ('get', 'can_view_orders', 'invoices/', 200),
     ('get', 'can_view_orders', 'invoices/1/', 404),

--- a/src/tests/control/test_orders.py
+++ b/src/tests/control/test_orders.py
@@ -935,11 +935,9 @@ class OrderChangeTests(SoupTest):
         self.client.post('/control/event/{}/{}/orders/{}/change'.format(
             self.event.organizer.slug, self.event.slug, self.order.code
         ), {
-            'op-{}-operation'.format(self.op1.pk): 'product',
             'op-{}-itemvar'.format(self.op1.pk): str(self.shirt.pk),
-            'op-{}-operation'.format(self.op2.pk): '',
-            'op-{}-itemvar'.format(self.op2.pk): str(self.ticket.pk),
-            'add-itemvar'.format(self.op2.pk): str(self.ticket.pk),
+            'op-{}-price'.format(self.op1.pk): str('12.00'),
+            'add-itemvar': str(self.ticket.pk),
         })
         self.op1.refresh_from_db()
         self.order.refresh_from_db()
@@ -965,14 +963,9 @@ class OrderChangeTests(SoupTest):
         self.client.post('/control/event/{}/{}/orders/{}/change'.format(
             self.event.organizer.slug, self.event.slug, self.order.code
         ), {
-            'op-{}-operation'.format(self.op1.pk): 'subevent',
             'op-{}-subevent'.format(self.op1.pk): str(se2.pk),
-            'op-{}-itemvar'.format(self.op1.pk): str(self.ticket.pk),
-            'op-{}-operation'.format(self.op2.pk): '',
-            'op-{}-itemvar'.format(self.op2.pk): str(self.ticket.pk),
-            'op-{}-subevent'.format(self.op2.pk): str(se1.pk),
-            'add-itemvar'.format(self.op2.pk): str(self.ticket.pk),
-            'add-subevent'.format(self.op2.pk): str(se1.pk),
+            'add-itemvar': str(self.ticket.pk),
+            'add-subevent': str(se1.pk),
         })
         self.op1.refresh_from_db()
         self.op2.refresh_from_db()
@@ -989,7 +982,7 @@ class OrderChangeTests(SoupTest):
             'op-{}-price'.format(self.op1.pk): '24.00',
             'op-{}-operation'.format(self.op2.pk): '',
             'op-{}-itemvar'.format(self.op2.pk): str(self.ticket.pk),
-            'add-itemvar'.format(self.op2.pk): str(self.ticket.pk),
+            'add-itemvar': str(self.ticket.pk),
         })
         self.op1.refresh_from_db()
         self.order.refresh_from_db()
@@ -1001,13 +994,8 @@ class OrderChangeTests(SoupTest):
         self.client.post('/control/event/{}/{}/orders/{}/change'.format(
             self.event.organizer.slug, self.event.slug, self.order.code
         ), {
-            'op-{}-operation'.format(self.op1.pk): 'cancel',
-            'op-{}-itemvar'.format(self.op1.pk): str(self.ticket.pk),
-            'op-{}-price'.format(self.op1.pk): str(self.op1.price),
-            'op-{}-operation'.format(self.op2.pk): '',
-            'op-{}-itemvar'.format(self.op2.pk): str(self.ticket.pk),
-            'op-{}-price'.format(self.op2.pk): str(self.op2.price),
-            'add-itemvar'.format(self.op2.pk): str(self.ticket.pk),
+            'op-{}-operation_cancel'.format(self.op1.pk): 'on',
+            'add-itemvar': str(self.ticket.pk),
         })
         self.order.refresh_from_db()
         assert self.order.positions.count() == 1
@@ -1017,12 +1005,6 @@ class OrderChangeTests(SoupTest):
         self.client.post('/control/event/{}/{}/orders/{}/change'.format(
             self.event.organizer.slug, self.event.slug, self.order.code
         ), {
-            'op-{}-operation'.format(self.op1.pk): '',
-            'op-{}-operation'.format(self.op2.pk): '',
-            'op-{}-itemvar'.format(self.op2.pk): str(self.ticket.pk),
-            'op-{}-price'.format(self.op2.pk): str(self.op2.price),
-            'op-{}-itemvar'.format(self.op1.pk): str(self.ticket.pk),
-            'op-{}-price'.format(self.op1.pk): str(self.op1.price),
             'add-itemvar': str(self.shirt.pk),
             'add-do': 'on',
             'add-price': '14.00',
@@ -1047,7 +1029,7 @@ class OrderChangeTests(SoupTest):
             self.event.organizer.slug, self.event.slug, self.order.code
         ), {
             'other-recalculate_taxes': 'on',
-            'add-itemvar'.format(self.op2.pk): str(self.ticket.pk),
+            'add-itemvar': str(self.ticket.pk),
             'op-{}-operation'.format(self.op1.pk): '',
             'op-{}-operation'.format(self.op2.pk): '',
             'op-{}-itemvar'.format(self.op2.pk): str(self.ticket.pk),


### PR DESCRIPTION
This basically does two things to the "Change products" view of orders and the
OrderChangeManager program API:

1) It decouples changing items or subevents from changing prices.
   OrderChangeManager.change_item() and .change_subevent() no longer
   touch the price of a position. Instead .change_price() needs to be
   called explicitly. However, a client-side JavaScript component now
   *proposes* a new price based on the changed item or subevent.

2) The user interface now exposes the possibility of doing multiple
   things at the same time, i.e. changing the item, subevent and price
   in the same operation. OrderChangeManager already allowed this
   before.

(1) is basically a consequence of (2), while (2) is a prerequesite for
e.g. the `seating` branch, where changing the subevent will always
require changing the seat.