### PR TITLE
Document Debian dependency python-venv

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -21,6 +21,7 @@ Your should install the following on your system:
 * Python 3.5 or newer
 * ``pip`` for Python 3 (Debian package: ``python3-pip``)
 * ``python-dev`` for Python 3 (Debian package: ``python3-dev``)
+* ``python-venv`` for Python 3 (Debian package: ``python3-venv``)
 * ``libffi`` (Debian package: ``libffi-dev``)
 * ``libssl`` (Debian package: ``libssl-dev``)
 * ``libxml2`` (Debian package ``libxml2-dev``)

--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -21,7 +21,7 @@ Your should install the following on your system:
 * Python 3.5 or newer
 * ``pip`` for Python 3 (Debian package: ``python3-pip``)
 * ``python-dev`` for Python 3 (Debian package: ``python3-dev``)
-* ``python-venv`` for Python 3 (Debian package: ``python3-venv``)
+* On Debian/Ubuntu: ``python-venv`` for Python 3 (Debian package: ``python3-venv``)
 * ``libffi`` (Debian package: ``libffi-dev``)
 * ``libssl`` (Debian package: ``libssl-dev``)
 * ``libxml2`` (Debian package ``libxml2-dev``)


### PR DESCRIPTION
otherwise in the next step I get
```
$ python3 -m venv env
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt-get install python3-venv
```