### PR TITLE
Add external dependency libenchant1c2a

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -25,6 +25,7 @@ Your should install the following on your system:
 * ``libssl`` (Debian package: ``libssl-dev``)
 * ``libxml2`` (Debian package ``libxml2-dev``)
 * ``libxslt`` (Debian package ``libxslt1-dev``)
+* ``libenchant1c2a`` (Debian package ``libenchant1c2a``)
 * ``msgfmt`` (Debian package ``gettext``)
 * ``git``
 


### PR DESCRIPTION
otherwise I get

```
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-jq5wwsqg/pyenchant/setup.py", line 212, in <module>
        import enchant
      File "/tmp/pip-install-jq5wwsqg/pyenchant/enchant/__init__.py", line 92, in <module>
        from enchant import _enchant as _e
      File "/tmp/pip-install-jq5wwsqg/pyenchant/enchant/_enchant.py", line 145, in <module>
        raise ImportError(msg)
    ImportError: The 'enchant' C library was not found. Please install it via your OS package manager, or use a pre-built binary wheel from PyPI.
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-jq5wwsqg/pyenchant/
```

when running
` pip3 install -r requirements.txt -r requirements/dev.txt
`
