### PR TITLE
rm superfluous closing anchor

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -74,7 +74,6 @@
                                     href="{% eventurl request.event "presale:event.checkout.start" cart_namespace=cart_namespace  %}">
                                 {% if has_addon_choices or cart.total == 0 %}
                                     <i class="fa fa-shopping-cart"></i> {% trans "Continue" %}
-                                    </a>
                                 {% else %}
                                     <i class="fa fa-shopping-cart"></i> {% trans "Proceed with checkout" %}
                                 {% endif %}


### PR DESCRIPTION
in templates/pretixpresale/events/index.html

Hey there!
I noticed that this closing anchor tag is not necessary and probably left over from some template refactor. 
So I thought I'll remove it :)

Thanks for working on pretix, it's really cool!