### PR TITLE
Prevent broken 301 redirects

### DIFF
--- a/doc/admin/installation/docker_smallscale.rst
+++ b/doc/admin/installation/docker_smallscale.rst
@@ -226,6 +226,7 @@ The following snippet is an example on how to configure a nginx proxy for pretix
 
         location / {
             proxy_pass http://localhost:8345/;
+            proxy_redirect off;            
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header Host $http_host;

--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -227,6 +227,7 @@ The following snippet is an example on how to configure a nginx proxy for pretix
 
         location / {
             proxy_pass http://localhost:8345/;
+            proxy_redirect off;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
I tried to POST stuff to the API via HTTPS on my installation and it kept redirecting me. This tip helped:

https://djangodeployment.com/2017/01/24/fix-djangos-https-redirects-nginx/

It should be included into the installation docu.