### PR TITLE
Sendmail plugin: Allow filtering for check-ins

### DIFF
--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -11,7 +11,6 @@ from pretix.control.forms.widgets import Select2, Select2Multiple
 
 
 class MailForm(forms.Form):
-    NOT_CHECKED_IN = "NotCheckedIn"
     recipients = forms.ChoiceField(
         label=_('Send email to'),
         widget=forms.RadioSelect,

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -29,6 +29,9 @@ class MailForm(forms.Form):
         required=True,
         queryset=Item.objects.none()
     )
+    filter_checkins = forms.BooleanField(
+        label=_('Filter check-in status'),
+        required=False)
     checkin_lists = SafeModelMultipleChoiceField(queryset=CheckinList.objects.none(), required=False)  # overridden later
     not_checked_in = forms.BooleanField(label=_("Only send to customers not checked in"), required=False)
     subevent = forms.ModelChoiceField(

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -5,7 +5,7 @@ from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 
 from pretix.base.email import get_available_placeholders
 from pretix.base.forms import PlaceholderValidator
-from pretix.base.models import Item, Order, SubEvent
+from pretix.base.models import CheckinList, Item, Order, SubEvent
 from pretix.control.forms.widgets import Select2
 
 
@@ -26,6 +26,17 @@ class MailForm(forms.Form):
         label=_('Only send to people who bought'),
         required=True,
         queryset=Item.objects.none()
+    )
+    filter_checkins = forms.BooleanField(
+        label=_('Only send to people checked in'),
+        required=False)
+    checkin_lists = forms.ModelMultipleChoiceField(
+        widget=forms.CheckboxSelectMultiple(
+            attrs={'class': 'scrolling-multiple-choice'}
+        ),
+        label=_('Only send to people checked in'),
+        required=False,
+        queryset=CheckinList.objects.none()
     )
     subevent = forms.ModelChoiceField(
         SubEvent.objects.none(),
@@ -95,6 +106,13 @@ class MailForm(forms.Form):
         self.fields['items'].queryset = event.items.all()
         if not self.initial.get('items'):
             self.initial['items'] = event.items.all()
+
+        self.fields['checkin_lists'].queryset = event.checkin_lists.all()
+        if not self.initial.get('checkin_lists'):
+            self.initial['checkin_lists'] = event.checkin_lists.all()
+
+        if not self.initial.get('filter_checkins'):
+            self.initial['filter_checkins'] = False
 
         if event.has_subevents:
             self.fields['subevent'].queryset = event.subevents.all()

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -30,9 +30,10 @@ class MailForm(forms.Form):
     )
     filter_checkins = forms.BooleanField(
         label=_('Filter check-in status'),
-        required=False)
+        required=False
+    )
     checkin_lists = SafeModelMultipleChoiceField(queryset=CheckinList.objects.none(), required=False)  # overridden later
-    not_checked_in = forms.BooleanField(label=_("Only send to customers not checked in"), required=False)
+    not_checked_in = forms.BooleanField(label=_("Send to customers not checked in"), required=False)
     subevent = forms.ModelChoiceField(
         SubEvent.objects.none(),
         label=_('Only send to customers of'),
@@ -110,11 +111,12 @@ class MailForm(forms.Form):
                     'event': event.slug,
                     'organizer': event.organizer.slug,
                 }),
-                'data-placeholder': _('Only send to customers checked in'),
+                'data-placeholder': _('Send to customers checked in on list'),
                 'data-inverse-dependency': '#id_not_checked_in'
             }
         )
         self.fields['checkin_lists'].widget.choices = self.fields['checkin_lists'].choices
+        self.fields['checkin_lists'].label = _('Send to customers checked in on list')
 
         if event.has_subevents:
             self.fields['subevent'].queryset = event.subevents.all()

--- a/src/pretix/plugins/sendmail/tasks.py
+++ b/src/pretix/plugins/sendmail/tasks.py
@@ -34,11 +34,12 @@ def send_mails(event: Event, user: int, subject: dict, message: dict, orders: li
                     continue
 
                 if filter_checkins:
-                    checkins = p.checkins.all()
-                    if not_checked_in:
-                        if checkins:
-                            continue
-                    elif not any(c.list_id in checkin_lists for c in checkins):
+                    checkins = list(p.checkins.all())
+                    allowed = (
+                        (not_checked_in and not checkins)
+                        or (any(c.list_id in checkin_lists for c in checkins))
+                    )
+                    if not allowed:
                         continue
 
                 if not p.attendee_email:

--- a/src/pretix/plugins/sendmail/tasks.py
+++ b/src/pretix/plugins/sendmail/tasks.py
@@ -35,7 +35,8 @@ def send_mails(event: Event, user: int, subject: dict, message: dict, orders: li
                 if p.item_id not in items and not any(a.item_id in items for a in p.addons.all()):
                     continue
 
-                if forms.MailForm.NOT_CHECKED_IN not in checkin_lists and not any(str(c.list_id) in checkin_lists for c in p.checkins.all()):
+                checkins = p.checkins.all()
+                if not (forms.MailForm.NOT_CHECKED_IN in checkin_lists and not checkins) and not any(str(c.list_id) in checkin_lists for c in checkins):
                     continue
 
                 if not p.attendee_email:

--- a/src/pretix/plugins/sendmail/tasks.py
+++ b/src/pretix/plugins/sendmail/tasks.py
@@ -12,7 +12,7 @@ from . import forms
 
 @app.task(base=ProfiledEventTask)
 def send_mails(event: Event, user: int, subject: dict, message: dict, orders: list, items: list,
-               recipients: str, checkin_lists: list) -> None:
+               recipients: str, not_checked_in: bool, checkin_lists: list) -> None:
     failures = []
     user = User.objects.get(pk=user) if user else None
     orders = Order.objects.filter(pk__in=orders, event=event)
@@ -36,7 +36,8 @@ def send_mails(event: Event, user: int, subject: dict, message: dict, orders: li
                     continue
 
                 checkins = p.checkins.all()
-                if not (forms.MailForm.NOT_CHECKED_IN in checkin_lists and not checkins) and not any(str(c.list_id) in checkin_lists for c in checkins):
+                if not (not_checked_in and not checkins) and \
+                    not any(c.list_id in checkin_lists for c in checkins):
                     continue
 
                 if not p.attendee_email:

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -23,7 +23,9 @@
                         {% if log.pdata.items %}
                             <br/><span class="fa fa-shopping-cart fa-fw"></span> {{ log.pdata.items|join:", " }}
                         {% endif %}
-                        {% if log.pdata.checkin_lists %}
+                        {% if log.pdata.not_checked_in %}
+                            <br/><span class="fa fa-check-square-o fa-fw"></span> {% trans "All customers not checked in" %}
+                        {% elif log.pdata.checkin_lists %}
                             <br/><span class="fa fa-check-square-o fa-fw"></span> {{ log.pdata.checkin_lists|join:", " }}
                         {% endif %}
                         {% if log.pdata.subevent_obj %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -23,7 +23,7 @@
                         {% if log.pdata.items %}
                             <br/><span class="fa fa-shopping-cart fa-fw"></span> {{ log.pdata.items|join:", " }}
                         {% endif %}
-                        {% if log.pdata.filter_checkins and log.pdata.checkin_lists %}
+                        {% if log.pdata.checkin_lists %}
                             <br/><span class="fa fa-check-square-o fa-fw"></span> {{ log.pdata.checkin_lists|join:", " }}
                         {% endif %}
                         {% if log.pdata.subevent_obj %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -26,7 +26,8 @@
                         {% if log.pdata.filter_checkins %}
                             {% if log.pdata.not_checked_in %}
                                 <br/><span class="fa fa-check-square-o fa-fw"></span> {% trans "All customers not checked in" %}
-                            {% else %}
+                            {% endif %}
+                            {% if log.pdata.checkin_lists %}
                                 <br/><span class="fa fa-check-square-o fa-fw"></span> {{ log.pdata.checkin_lists|join:", " }}
                             {% endif %}
                         {% endif %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -23,6 +23,9 @@
                         {% if log.pdata.items %}
                             <br/><span class="fa fa-shopping-cart fa-fw"></span> {{ log.pdata.items|join:", " }}
                         {% endif %}
+                        {% if log.pdata.filter_checkins and log.pdata.checkin_lists %}
+                            <br/><span class="fa fa-check-square-o fa-fw"></span> {{ log.pdata.checkin_lists|join:", " }}
+                        {% endif %}
                         {% if log.pdata.subevent_obj %}
                             <br/><span class="fa fa-calendar fa-fw"></span> {{ log.pdata.subevent_obj }}
                         {% endif %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/history.html
@@ -23,10 +23,12 @@
                         {% if log.pdata.items %}
                             <br/><span class="fa fa-shopping-cart fa-fw"></span> {{ log.pdata.items|join:", " }}
                         {% endif %}
-                        {% if log.pdata.not_checked_in %}
-                            <br/><span class="fa fa-check-square-o fa-fw"></span> {% trans "All customers not checked in" %}
-                        {% elif log.pdata.checkin_lists %}
-                            <br/><span class="fa fa-check-square-o fa-fw"></span> {{ log.pdata.checkin_lists|join:", " }}
+                        {% if log.pdata.filter_checkins %}
+                            {% if log.pdata.not_checked_in %}
+                                <br/><span class="fa fa-check-square-o fa-fw"></span> {% trans "All customers not checked in" %}
+                            {% else %}
+                                <br/><span class="fa fa-check-square-o fa-fw"></span> {{ log.pdata.checkin_lists|join:", " }}
+                            {% endif %}
                         {% endif %}
                         {% if log.pdata.subevent_obj %}
                             <br/><span class="fa fa-calendar fa-fw"></span> {{ log.pdata.subevent_obj }}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -13,20 +13,7 @@
                 {% bootstrap_field form.subevent layout='horizontal' %}
             {% endif %}
             {% bootstrap_field form.items layout='horizontal' %}
-            <div class="panel-group">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <label data-toggle="collapse" data-target="#checkin_filter">
-                            {{ form.filter_checkins }} {{ form.filter_checkins.label }}
-                        </label>
-                    </div>
-                    <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
-                        {% bootstrap_field form.checkin_lists layout='horizontal' %}
-                    </div>
-                </div>
-            </div>
-
-
+            {% bootstrap_field form.checkin_lists layout='horizontal' %}
             {% bootstrap_field form.subject layout='horizontal' %}
             {% bootstrap_field form.message layout='horizontal' %}
             {% if request.method == "POST" %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -13,6 +13,7 @@
                 {% bootstrap_field form.subevent layout='horizontal' %}
             {% endif %}
             {% bootstrap_field form.items layout='horizontal' %}
+            {% bootstrap_field form.not_checked_in layout='horizontal' %}
             {% bootstrap_field form.checkin_lists layout='horizontal' %}
             {% bootstrap_field form.subject layout='horizontal' %}
             {% bootstrap_field form.message layout='horizontal' %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -13,8 +13,19 @@
                 {% bootstrap_field form.subevent layout='horizontal' %}
             {% endif %}
             {% bootstrap_field form.items layout='horizontal' %}
-            {% bootstrap_field form.not_checked_in layout='horizontal' %}
-            {% bootstrap_field form.checkin_lists layout='horizontal' %}
+            <div class="panel-group">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <label data-toggle="collapse" data-target="#checkin_filter">
+                            {{ form.filter_checkins }} {{ form.filter_checkins.label }}
+                        </label>
+                    </div>
+                    <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
+                        {% bootstrap_field form.not_checked_in layout='horizontal' %}
+                        {% bootstrap_field form.checkin_lists layout='horizontal' %}
+                    </div>
+                </div>
+            </div>
             {% bootstrap_field form.subject layout='horizontal' %}
             {% bootstrap_field form.message layout='horizontal' %}
             {% if request.method == "POST" %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -13,6 +13,20 @@
                 {% bootstrap_field form.subevent layout='horizontal' %}
             {% endif %}
             {% bootstrap_field form.items layout='horizontal' %}
+            <div class="panel-group">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <label data-toggle="collapse" data-target="#checkin_filter">
+                            {{ form.filter_checkins }} {{ form.filter_checkins.label }}
+                        </label>
+                    </div>
+                    <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
+                        {% bootstrap_field form.checkin_lists layout='horizontal' %}
+                    </div>
+                </div>
+            </div>
+
+
             {% bootstrap_field form.subject layout='horizontal' %}
             {% bootstrap_field form.message layout='horizontal' %}
             {% if request.method == "POST" %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -13,16 +13,20 @@
                 {% bootstrap_field form.subevent layout='horizontal' %}
             {% endif %}
             {% bootstrap_field form.items layout='horizontal' %}
-            <div class="panel-group">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <label data-toggle="collapse" data-target="#checkin_filter">
-                            {{ form.filter_checkins }} {{ form.filter_checkins.label }}
-                        </label>
-                    </div>
-                    <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
-                        {% bootstrap_field form.not_checked_in layout='horizontal' %}
-                        {% bootstrap_field form.checkin_lists layout='horizontal' %}
+            <div class="row">
+                <div class="col-md-9 col-md-offset-3">
+                    <div class="panel-group">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <label data-toggle="collapse" data-target="#checkin_filter">
+                                    {{ form.filter_checkins }} {{ form.filter_checkins.label }}
+                                </label>
+                            </div>
+                            <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
+                                {% bootstrap_field form.not_checked_in layout='horizontal' %}
+                                {% bootstrap_field form.checkin_lists layout='horizontal' %}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -54,14 +54,9 @@ class SenderView(EventPermissionRequiredMixin, FormView):
                         id=logentry.parsed_data['item']['id']
                     )
                 if 'checkin_lists' in logentry.parsed_data:
-                    kwargs['initial']['checkin_lists'] = self.request.event.checkin_lists.filter(
-                        id__in=[a['id'] for a in logentry.parsed_data['items']]
-                    )
+                    kwargs['initial']['checkin_lists'] = logentry.parsed_data['checkin_lists']
                 elif logentry.parsed_data.get('checkin_list'):
-                    kwargs['initial']['checkin_lists'] = self.request.event.checkin_lists.filter(
-                        id=logentry.parsed_data['item']['id']
-                    )
-                kwargs['initial']['filter_checkins'] = logentry.parsed_data.get('filter_checkins', False)
+                    kwargs['initial']['checkin_lists'] = [logentry.parsed_data['checkin_list']['id']]
                 if logentry.parsed_data.get('subevent'):
                     try:
                         kwargs['initial']['subevent'] = self.request.event.subevents.get(
@@ -85,8 +80,10 @@ class SenderView(EventPermissionRequiredMixin, FormView):
         orders = qs.filter(statusq)
         orders = orders.filter(all_positions__item_id__in=[i.pk for i in form.cleaned_data.get('items')],
                                all_positions__canceled=False)
-        if form.cleaned_data.get('filter_checkins', False):
-            orders = orders.filter(all_positions__checkins__list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists')])
+        checkinq = Q(all_positions__checkins__list_id__in=[i for i in form.cleaned_data.get('checkin_lists', []) if i != forms.MailForm.NOT_CHECKED_IN])
+        if forms.MailForm.NOT_CHECKED_IN in form.cleaned_data.get('checkin_lists', []):
+            checkinq |= Q(all_positions__checkins__list_id=None)
+        orders = orders.filter(checkinq)
         if form.cleaned_data.get('subevent'):
             orders = orders.filter(all_positions__subevent__in=(form.cleaned_data.get('subevent'),),
                                    all_positions__canceled=False)
@@ -130,8 +127,7 @@ class SenderView(EventPermissionRequiredMixin, FormView):
                 'message': form.cleaned_data['message'].data,
                 'orders': [o.pk for o in orders],
                 'items': [i.pk for i in form.cleaned_data.get('items')],
-                'filter_checkins': form.cleaned_data.get('filter_checkins', False),
-                'checkin_lists': [i.pk for i in form.cleaned_data.get('checkin_lists')]
+                'checkin_lists': form.cleaned_data.get('checkin_lists')
             }
         )
         self.request.event.log_action('pretix.plugins.sendmail.sent',
@@ -173,8 +169,9 @@ class EmailHistoryView(EventPermissionRequiredMixin, ListView):
             i.pk: str(i) for i in self.request.event.items.all()
         }
         checkin_list_cache = {
-            i.pk: str(i) for i in self.request.event.checkin_lists.all()
+            str(i.pk): str(i) for i in self.request.event.checkin_lists.all()
         }
+        checkin_list_cache[forms.MailForm.NOT_CHECKED_IN] = _("Not checked in")
         status = dict(Order.STATUS_CHOICE)
         status['overdue'] = _('pending with payment overdue')
         status['r'] = status['c']
@@ -193,7 +190,7 @@ class EmailHistoryView(EventPermissionRequiredMixin, ListView):
                 itemcache[i['id']] for i in log.pdata.get('items', [])
             ]
             log.pdata['checkin_lists'] = [
-                checkin_list_cache[i['id']] for i in log.pdata.get('checkin_lists', [])
+                checkin_list_cache[i] for i in log.pdata.get('checkin_lists', []) if i in checkin_list_cache
             ]
             if log.pdata.get('subevent'):
                 try:

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -2,7 +2,7 @@ import logging
 
 import bleach
 from django.contrib import messages
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.timezone import now
@@ -11,7 +11,7 @@ from django.views.generic import FormView, ListView
 
 from pretix.base.email import get_available_placeholders
 from pretix.base.i18n import LazyI18nString, language
-from pretix.base.models import LogEntry, Order
+from pretix.base.models import LogEntry, Order, OrderPosition
 from pretix.base.models.event import SubEvent
 from pretix.base.services.mail import TolerantDict
 from pretix.base.templatetags.rich_text import markdown_compile_email
@@ -77,27 +77,30 @@ class SenderView(EventPermissionRequiredMixin, FormView):
         if 'overdue' in form.cleaned_data['sendto']:
             statusq |= Q(status=Order.STATUS_PENDING, expires__lt=now())
         orders = qs.filter(statusq)
-        orders = orders.filter(all_positions__item_id__in=[i.pk for i in form.cleaned_data.get('items')],
-                               all_positions__canceled=False)
+
+        opq = OrderPosition.objects.filter(
+            order=OuterRef('pk'),
+            canceled=False,
+            item_id__in=[i.pk for i in form.cleaned_data.get('items')],
+        )
 
         if form.cleaned_data.get('filter_checkins'):
             ql = []
             if form.cleaned_data.get('not_checked_in'):
-                ql.append(Q(all_positions__checkins__list_id=None, all_positions__canceled=False))
+                ql.append(Q(checkins__list_id=None))
             if form.cleaned_data.get('checkin_lists'):
                 ql.append(Q(
-                    all_positions__checkins__list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
-                    all_positions__canceled=False
+                    checkins__list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
                 ))
             if len(ql) == 2:
-                orders = orders.filter(ql[0] | ql[1])
+                opq = opq.filter(ql[0] | ql[1])
             else:
-                orders = orders.filter(ql[0])
+                opq = opq.filter(ql[0])
 
         if form.cleaned_data.get('subevent'):
-            orders = orders.filter(all_positions__subevent__in=(form.cleaned_data.get('subevent'),),
-                                   all_positions__canceled=False)
-        orders = orders.distinct()
+            opq = opq.filter(subevent=form.cleaned_data.get('subevent'))
+
+        orders = orders.annotate(match_pos=Exists(opq)).filter(match_pos=True).distinct()
 
         self.output = {}
         if not orders:

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -173,7 +173,6 @@ class EmailHistoryView(EventPermissionRequiredMixin, ListView):
         checkin_list_cache = {
             i.pk: str(i) for i in self.request.event.checkin_lists.all()
         }
-        checkin_list_cache[forms.MailForm.NOT_CHECKED_IN] = _("Not checked in")
         status = dict(Order.STATUS_CHOICE)
         status['overdue'] = _('pending with payment overdue')
         status['r'] = status['c']

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -256,7 +256,7 @@ var form_handlers = function (el) {
         dependency.on("change", update);
     });
 
-    el.find("input[data-inverse-dependency]").each(function () {
+    $("select[data-inverse-dependency], input[data-inverse-dependency]").each(function () {
         var dependency = $(this).attr("data-inverse-dependency");
         if (dependency.substr(0, 1) === '<') {
             dependency = $(this).closest("form, .form-horizontal").find(dependency.substr(1));

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -256,7 +256,7 @@ var form_handlers = function (el) {
         dependency.on("change", update);
     });
 
-    $("select[data-inverse-dependency], input[data-inverse-dependency]").each(function () {
+    el.find("select[data-inverse-dependency], input[data-inverse-dependency]").each(function () {
         var dependency = $(this).attr("data-inverse-dependency");
         if (dependency.substr(0, 1) === '<') {
             dependency = $(this).closest("form, .form-horizontal").find(dependency.substr(1));
@@ -273,7 +273,7 @@ var form_handlers = function (el) {
         dependency.on("change", update);
     });
 
-    $("div[data-display-dependency], input[data-display-dependency]").each(function () {
+    el.find("div[data-display-dependency], input[data-display-dependency]").each(function () {
         var dependent = $(this),
             dependency = $($(this).attr("data-display-dependency")),
             update = function (ev) {

--- a/src/tests/plugins/test_sendmail.py
+++ b/src/tests/plugins/test_sendmail.py
@@ -430,6 +430,24 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
 
+    djmail.outbox = []
+    response = logged_in_client.post(sendmail_url,
+                                     {'sendto': 'n',
+                                      'recipients': 'attendees',
+                                      'items': pos2.item_id,
+                                      'subject_0': 'Test subject',
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'filter_checkins': 'on',
+                                      'checkin_lists': [chkl2.id],
+                                      'not_checked_in': 'on',
+                                      },
+                                     follow=True)
+    assert response.status_code == 200
+    assert 'alert-success' in response.rendered_content
+    assert len(djmail.outbox) == 2
+    assert djmail.outbox[0].to == ['attendee1@dummy.test']
+    assert djmail.outbox[1].to == ['attendee2@dummy.test']
+
     # Test that filtering is ignored if filter_checkins is not set
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,

--- a/src/tests/plugins/test_sendmail.py
+++ b/src/tests/plugins/test_sendmail.py
@@ -392,15 +392,14 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
         p.attendee_email = 'attendee1@dummy.test'
         p.save()
         pos2 = order.positions.create(item=item, price=0, attendee_email='attendee2@dummy.test')
-        _ = Checkin.objects.create(position=pos2, list=chkl2)
+        Checkin.objects.create(position=pos2, list=chkl2)
 
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'n',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
-                                      'filter_checkins': True,
-                                      'checkin_lists': chkl2.id,
+                                      'checkin_lists': [str(chkl2.id)],
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.'
                                       },

--- a/src/tests/plugins/test_sendmail.py
+++ b/src/tests/plugins/test_sendmail.py
@@ -8,7 +8,6 @@ from django_scopes import scopes_disabled
 from pretix.base.models import (
     Checkin, Event, Item, Order, OrderPosition, Organizer, Team, User,
 )
-from pretix.plugins.sendmail.forms import MailForm
 
 
 @pytest.fixture
@@ -86,7 +85,7 @@ def test_sendmail_simple_case(logged_in_client, sendmail_url, event, order, pos)
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -113,7 +112,7 @@ def test_sendmail_email_not_sent_if_order_not_match(logged_in_client, sendmail_u
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert 'alert-danger' in response.rendered_content
@@ -131,7 +130,7 @@ def test_sendmail_preview(logged_in_client, sendmail_url, event, order, pos):
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'action': 'preview',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -148,7 +147,7 @@ def test_sendmail_invalid_data(logged_in_client, sendmail_url, event, order, pos
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
 
@@ -179,7 +178,7 @@ def test_sendmail_multi_locales(logged_in_client, sendmail_url, event, item):
                                       'message_0': 'Test message',
                                       'subject_1': 'Benutzer',
                                       'message_1': 'Test nachricht',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -217,7 +216,7 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'subevent': se1.pk,
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -232,7 +231,7 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'subevent': se2.pk,
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert len(djmail.outbox) == 0
@@ -254,7 +253,7 @@ def test_sendmail_placeholder(logged_in_client, sendmail_url, event, order, pos)
                                       'subject_0': '{code} Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'action': 'preview',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
 
@@ -278,7 +277,7 @@ def test_sendmail_attendee_mails(logged_in_client, sendmail_url, event, order, p
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -303,7 +302,7 @@ def test_sendmail_both_mails(logged_in_client, sendmail_url, event, order, pos):
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -331,7 +330,7 @@ def test_sendmail_both_but_same_address(logged_in_client, sendmail_url, event, o
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -356,7 +355,7 @@ def test_sendmail_attendee_fallback(logged_in_client, sendmail_url, event, order
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -386,7 +385,7 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
                                           'items': i2.pk,
                                           'subject_0': 'Test subject',
                                           'message_0': 'This is a test file for sending mails.',
-                                          'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                          'not_checked_in': 'on',
                                           },
                                          follow=True)
     assert response.status_code == 200
@@ -413,7 +412,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
                                      {'sendto': 'n',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
-                                      'checkin_lists': [str(chkl2.id)],
+                                      'checkin_lists': [chkl2.id],
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.'
                                       },
@@ -430,7 +429,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
                                      {'sendto': 'n',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
-                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'not_checked_in': 'on',
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.'
                                       },

--- a/src/tests/plugins/test_sendmail.py
+++ b/src/tests/plugins/test_sendmail.py
@@ -8,6 +8,7 @@ from django_scopes import scopes_disabled
 from pretix.base.models import (
     Checkin, Event, Item, Order, OrderPosition, Organizer, Team, User,
 )
+from pretix.plugins.sendmail.forms import MailForm
 
 
 @pytest.fixture
@@ -84,7 +85,8 @@ def test_sendmail_simple_case(logged_in_client, sendmail_url, event, order, pos)
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -110,7 +112,8 @@ def test_sendmail_email_not_sent_if_order_not_match(logged_in_client, sendmail_u
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert 'alert-danger' in response.rendered_content
@@ -127,7 +130,8 @@ def test_sendmail_preview(logged_in_client, sendmail_url, event, order, pos):
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'action': 'preview'
+                                      'action': 'preview',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -144,6 +148,7 @@ def test_sendmail_invalid_data(logged_in_client, sendmail_url, event, order, pos
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
 
@@ -173,7 +178,8 @@ def test_sendmail_multi_locales(logged_in_client, sendmail_url, event, item):
                                       'subject_0': 'Test subject',
                                       'message_0': 'Test message',
                                       'subject_1': 'Benutzer',
-                                      'message_1': 'Test nachricht'
+                                      'message_1': 'Test nachricht',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -210,7 +216,8 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'subevent': se1.pk
+                                      'subevent': se1.pk,
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -224,7 +231,8 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'subevent': se2.pk
+                                      'subevent': se2.pk,
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert len(djmail.outbox) == 0
@@ -245,7 +253,8 @@ def test_sendmail_placeholder(logged_in_client, sendmail_url, event, order, pos)
                                       'items': pos.item_id,
                                       'subject_0': '{code} Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'action': 'preview'
+                                      'action': 'preview',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
 
@@ -268,7 +277,8 @@ def test_sendmail_attendee_mails(logged_in_client, sendmail_url, event, order, p
                                       'recipients': 'attendees',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -292,7 +302,8 @@ def test_sendmail_both_mails(logged_in_client, sendmail_url, event, order, pos):
                                       'recipients': 'both',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -319,7 +330,8 @@ def test_sendmail_both_but_same_address(logged_in_client, sendmail_url, event, o
                                       'recipients': 'both',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -343,7 +355,8 @@ def test_sendmail_attendee_fallback(logged_in_client, sendmail_url, event, order
                                       'recipients': 'attendees',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -372,7 +385,8 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
                                           'recipients': 'attendees',
                                           'items': i2.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails.'
+                                          'message_0': 'This is a test file for sending mails.',
+                                          'checkin_lists': [MailForm.NOT_CHECKED_IN],
                                           },
                                          follow=True)
     assert response.status_code == 200
@@ -408,5 +422,22 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     assert 'alert-success' in response.rendered_content
     assert len(djmail.outbox) == 1
     assert djmail.outbox[0].to == ['attendee2@dummy.test']
+    assert '/ticket/' in djmail.outbox[0].body
+    assert '/order/' not in djmail.outbox[0].body
+
+    djmail.outbox = []
+    response = logged_in_client.post(sendmail_url,
+                                     {'sendto': 'n',
+                                      'recipients': 'attendees',
+                                      'items': pos2.item_id,
+                                      'checkin_lists': [MailForm.NOT_CHECKED_IN],
+                                      'subject_0': 'Test subject',
+                                      'message_0': 'This is a test file for sending mails.'
+                                      },
+                                     follow=True)
+    assert response.status_code == 200
+    assert 'alert-success' in response.rendered_content
+    assert len(djmail.outbox) == 1
+    assert djmail.outbox[0].to == ['attendee1@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body

--- a/src/tests/plugins/test_sendmail.py
+++ b/src/tests/plugins/test_sendmail.py
@@ -85,7 +85,6 @@ def test_sendmail_simple_case(logged_in_client, sendmail_url, event, order, pos)
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -112,7 +111,6 @@ def test_sendmail_email_not_sent_if_order_not_match(logged_in_client, sendmail_u
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert 'alert-danger' in response.rendered_content
@@ -130,7 +128,6 @@ def test_sendmail_preview(logged_in_client, sendmail_url, event, order, pos):
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'action': 'preview',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -147,7 +144,6 @@ def test_sendmail_invalid_data(logged_in_client, sendmail_url, event, order, pos
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
 
@@ -178,7 +174,6 @@ def test_sendmail_multi_locales(logged_in_client, sendmail_url, event, item):
                                       'message_0': 'Test message',
                                       'subject_1': 'Benutzer',
                                       'message_1': 'Test nachricht',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -216,7 +211,6 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'subevent': se1.pk,
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -231,7 +225,6 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'subevent': se2.pk,
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert len(djmail.outbox) == 0
@@ -253,7 +246,6 @@ def test_sendmail_placeholder(logged_in_client, sendmail_url, event, order, pos)
                                       'subject_0': '{code} Test subject',
                                       'message_0': 'This is a test file for sending mails.',
                                       'action': 'preview',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
 
@@ -277,7 +269,6 @@ def test_sendmail_attendee_mails(logged_in_client, sendmail_url, event, order, p
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -302,7 +293,6 @@ def test_sendmail_both_mails(logged_in_client, sendmail_url, event, order, pos):
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -330,7 +320,6 @@ def test_sendmail_both_but_same_address(logged_in_client, sendmail_url, event, o
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -355,7 +344,6 @@ def test_sendmail_attendee_fallback(logged_in_client, sendmail_url, event, order
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.',
-                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -385,7 +373,6 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
                                           'items': i2.pk,
                                           'subject_0': 'Test subject',
                                           'message_0': 'This is a test file for sending mails.',
-                                          'not_checked_in': 'on',
                                           },
                                          follow=True)
     assert response.status_code == 200
@@ -412,6 +399,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
                                      {'sendto': 'n',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
+                                      'filter_checkins': 'on',
                                       'checkin_lists': [chkl2.id],
                                       'subject_0': 'Test subject',
                                       'message_0': 'This is a test file for sending mails.'
@@ -429,9 +417,10 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
                                      {'sendto': 'n',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
-                                      'not_checked_in': 'on',
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.'
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'filter_checkins': 'on',
+                                      'not_checked_in': 'on',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -440,3 +429,45 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     assert djmail.outbox[0].to == ['attendee1@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
+
+    # Test that filtering is ignored if filter_checkins is not set
+    djmail.outbox = []
+    response = logged_in_client.post(sendmail_url,
+                                     {'sendto': 'n',
+                                      'recipients': 'attendees',
+                                      'items': pos2.item_id,
+                                      'subject_0': 'Test subject',
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'not_checked_in': 'on',
+                                      },
+                                     follow=True)
+    assert response.status_code == 200
+    assert 'alert-success' in response.rendered_content
+    assert len(djmail.outbox) == 2
+    assert '/ticket/' in djmail.outbox[0].body
+    assert '/order/' not in djmail.outbox[0].body
+    assert '/ticket/' in djmail.outbox[1].body
+    assert '/order/' not in djmail.outbox[1].body
+    to_emails = set(*zip(*[mail.to for mail in djmail.outbox]))
+    assert to_emails == {'attendee1@dummy.test', 'attendee2@dummy.test'}
+
+    # Test that filtering is ignored if filter_checkins is not set
+    djmail.outbox = []
+    response = logged_in_client.post(sendmail_url,
+                                     {'sendto': 'n',
+                                      'recipients': 'attendees',
+                                      'items': pos2.item_id,
+                                      'subject_0': 'Test subject',
+                                      'message_0': 'This is a test file for sending mails.',
+                                      'checkin_lists': [chkl2.id],
+                                      },
+                                     follow=True)
+    assert response.status_code == 200
+    assert 'alert-success' in response.rendered_content
+    assert len(djmail.outbox) == 2
+    assert '/ticket/' in djmail.outbox[0].body
+    assert '/order/' not in djmail.outbox[0].body
+    assert '/ticket/' in djmail.outbox[1].body
+    assert '/order/' not in djmail.outbox[1].body
+    to_emails = set(*zip(*[mail.to for mail in djmail.outbox]))
+    assert to_emails == {'attendee1@dummy.test', 'attendee2@dummy.test'}


### PR DESCRIPTION
This PR adds the ability to send mass emails to all attendees who have checked in (with the ability to filter for specific checkin lists). This is sort-of what was asked in #1369 (It is not possible to filter for users who never checked in)