### PR TITLE
Remove obsolete reference to test data

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -65,7 +65,7 @@ Then, create the local database::
     python manage.py migrate
 
 A first user with username ``admin@localhost`` and password ``admin`` will be automatically
-created. 
+created.
 
 If you want to see pretix in a different language than English, you have to compile our language
 files::
@@ -81,8 +81,7 @@ To run the local development webserver, execute::
 and head to http://localhost:8000/
 
 As we did not implement an overall front page yet, you need to go directly to
-http://localhost:8000/control/ for the admin view or, if you imported the test
-data as suggested above, to the event page at http://localhost:8000/bigevents/2019/
+http://localhost:8000/control/ for the admin view.
 
 .. note:: If you want the development server to listen on a different interface or
           port (for example because you develop on `pretixdroid`_), you can check


### PR DESCRIPTION
The script to generate the test data and the instructions how to import it were removed in `e55f0cdf11f914b31a51f5a7ddffbde4b7394237`.