### PR TITLE
Fix issue on old-style webhook URLs

### DIFF
--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -170,7 +170,7 @@ def webhook(request, *args, **kwargs):
         rso = ReferencedStripeObject.objects.select_related('order', 'order__event').get(reference=objid)
         return func(rso.order.event, event_json, objid, rso)
     except ReferencedStripeObject.DoesNotExist:
-        if event_json['data']['object']['object'] == "charge" and event_json['data']['object']['payment_intent']:
+        if event_json['data']['object']['object'] == "charge" and 'payment_intent' in event_json['data']['object']:
             # If we receive a charge webhook *before* the payment intent webhook, we don't know the charge ID yet
             # and can't match it -- but we know the payment intent ID!
             try:

--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -170,20 +170,24 @@ def webhook(request, *args, **kwargs):
         rso = ReferencedStripeObject.objects.select_related('order', 'order__event').get(reference=objid)
         return func(rso.order.event, event_json, objid, rso)
     except ReferencedStripeObject.DoesNotExist:
-        if hasattr(request, 'event'):
-            return func(request.event, event_json, objid, None)
-        else:
+        if event_json['data']['object']['object'] == "charge" and event_json['data']['object']['payment_intent']:
             # If we receive a charge webhook *before* the payment intent webhook, we don't know the charge ID yet
             # and can't match it -- but we know the payment intent ID!
-            if event_json['data']['object']['object'] == "charge" and event_json['data']['object']['payment_intent']:
-                try:
-                    rso = ReferencedStripeObject.objects.select_related('order', 'order__event').get(
-                        reference=event_json['data']['object']['payment_intent']
-                    )
-                    return func(rso.order.event, event_json, objid, rso)
-                except ReferencedStripeObject.DoesNotExist:
-                    pass
-
+            try:
+                rso = ReferencedStripeObject.objects.select_related('order', 'order__event').get(
+                    reference=event_json['data']['object']['payment_intent']
+                )
+                return func(rso.order.event, event_json, objid, rso)
+            except ReferencedStripeObject.DoesNotExist:
+                pass
+        elif hasattr(request, 'event') and func != paymentintent_webhook:
+            # This is a legacy integration from back when didn't have ReferencedStripeObject. This can't happen for
+            # payment intents or charges connected with payment intents since they didn't exist back then. Our best
+            # hope is to go for request.event and see if we can find the order ID.
+            return func(request.event, event_json, objid, None)
+        else:
+            # Okay, this is probably not an event that concerns us, maybe other applications talk to the same stripe
+            # account
             return HttpResponse("Unable to detect event", status=200)
 
 


### PR DESCRIPTION
In our logs, I found regular errors like these:

```
File "/src/pretix/src/pretix/plugins/stripe/views.py" in webhook
  170.         rso = ReferencedStripeObject.objects.select_related('order', 'order__event').get(reference=objid)

File "/usr/local/lib/python3.7/site-packages/django/db/models/query.py" in get
  408.                 self.model._meta.object_name

During handling of the above exception (ReferencedStripeObject matching query does not exist.), another exception occurred:

File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)

File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  115.                 response = self.process_exception_by_middleware(e, request)

File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/src/pretix/src/pretix/presale/utils.py" in wrap
  158.                     response = func(request=request, *args, **kwargs)

File "/src/pretix/src/pretix/presale/utils.py" in wrap
  158.                     response = func(request=request, *args, **kwargs)

File "/usr/local/lib/python3.7/site-packages/django/views/decorators/csrf.py" in wrapped_view
  54.         return view_func(*args, **kwargs)

File "/usr/local/lib/python3.7/site-packages/django/views/decorators/http.py" in inner
  40.             return func(request, *args, **kwargs)

File "/usr/local/lib/python3.7/contextlib.py" in inner
  74.                 return func(*args, **kwds)

File "/src/pretix/src/pretix/plugins/stripe/views.py" in webhook
  174.             return func(request.event, event_json, objid, None)

File "/src/pretix/src/pretix/plugins/stripe/views.py" in paymentintent_webhook
  390.             defaults={'order': rso.payment.order, 'payment': rso.payment}
```

I believe they occur when a user still has an event-specific webhook URL set up and either a charge from a different platform goes through the account or a charge webhook arrives before a payment intent webhook. Therefore, this is a proposed change to the webhook logic.

@pc-coholic as you've written the current logic, I'd like you to review this and think if the new logic makes sense ;)