### PR TITLE
Install pretix into system-site-packages in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
 COPY deployment/docker/production_settings.py /pretix/src/production_settings.py
 COPY src /pretix/src
 
+RUN cd /pretix/src && pip3 install .
+
 RUN chmod +x /usr/local/bin/pretix && \
     rm /etc/nginx/sites-enabled/default && \
     cd /pretix/src && \


### PR DESCRIPTION
The Dockerfile does not actually install pretix into the python system-site-packages, which causes problems when trying to subsequently install plugins which depend on pretix.