### PR TITLE
Fix BaseDataShredder class documentation

### DIFF
--- a/doc/development/api/shredder.rst
+++ b/doc/development/api/shredder.rst
@@ -35,9 +35,9 @@ The shredder class
 
 .. class:: pretix.base.shredder.BaseDataShredder
 
-   The central object of each invoice renderer is the subclass of ``BaseInvoiceRenderer``.
+   The central object of each data shredder is the subclass of ``BaseDataShredder``.
 
-   .. py:attribute:: BaseInvoiceRenderer.event
+   .. py:attribute:: BaseDataShredder.event
 
       The default constructor sets this property to the event we are currently
       working for.


### PR DESCRIPTION
The `BaseDataShredder` documentation contains two references to `BaseInvoiceRenderer`, probably due to a minor copy/paste mistake from `doc/development/api/invoice.html`.

See https://docs.pretix.eu/en/latest/development/api/shredder.html#pretix.base.shredder.BaseDataShredder