### PR TITLE
remove .csv from default filename in List Exporter

### DIFF
--- a/src/pretix/base/exporter.py
+++ b/src/pretix/base/exporter.py
@@ -111,7 +111,7 @@ class ListExporter(BaseExporter):
         raise NotImplementedError()  # noqa
 
     def get_filename(self):
-        return 'export.csv'
+        return 'export'
 
     def _render_csv(self, form_data, output_file=None, **kwargs):
         if output_file:


### PR DESCRIPTION
The file type suffix is appended here

https://github.com/pretix/pretix/blob/9fca3188b29df9b79e3adaa3aa20af3101231338/src/pretix/base/exporter.py#L121

so at the moment there are filenames like `export.csv.csv`.