### PR TITLE
Add order_gracefully_delete signal

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -20,7 +20,7 @@ Order events
 There are multiple signals that will be sent out in the ordering cycle:
 
 .. automodule:: pretix.base.signals
-   :members: validate_cart, validate_cart_addons, validate_order, order_fee_calculation, order_paid, order_placed, order_canceled, order_expired, order_modified, order_changed, order_approved, order_denied, order_fee_type_name, allow_ticket_download, order_split
+   :members: validate_cart, validate_cart_addons, validate_order, order_fee_calculation, order_paid, order_placed, order_canceled, order_expired, order_modified, order_changed, order_approved, order_denied, order_fee_type_name, allow_ticket_download, order_split, order_gracefully_delete
 
 Frontend
 --------

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -39,6 +39,7 @@ from pretix.base.models import User
 from pretix.base.reldate import RelativeDateWrapper
 from pretix.base.services.locking import NoLockManager
 from pretix.base.settings import PERSON_NAME_SCHEMES
+from pretix.base.signals import order_gracefully_delete
 
 from .base import LockModel, LoggedModel
 from .event import Event, SubEvent
@@ -220,6 +221,7 @@ class Order(LockModel, LoggedModel):
         OrderPosition.all.filter(order=self, addon_to__isnull=False).delete()
         OrderPosition.all.filter(order=self).delete()
         OrderFee.all.filter(order=self).delete()
+        order_gracefully_delete.send(self.event, order=self)
         self.refunds.all().delete()
         self.payments.all().delete()
         self.event.cache.delete('complain_testmode_orders')

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -391,6 +391,20 @@ as the first argument.
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
 
+order_gracefully_delete = EventPluginSignal(
+    providing_args=["order"]
+)
+"""
+This signal is sent out every time a test-mode order is being deleted. The order object
+is given as the first argument.
+
+Any plugin receiving this signals is supposed to perform any cleanup necessary at this
+point, so that the underlying oder has no more external constraints that would inhibit
+the deletion of the order.
+
+As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
+"""
+
 logentry_display = EventPluginSignal(
     providing_args=["logentry"]
 )


### PR DESCRIPTION
Since we are starting to have more and more plugins which have reference orders and can thus inhibit deletion of test-mode orders, I'd like to propose a new `order_gracefully_delete` signal.

It will get send out as part of the `gracefully_delete()` and gives plugins an opportunity to remove all external dependencies when necessary.

This is probably cleaner than having a bunch of checks in `gracefully_delete()` to see if a specific plugin is installed/enabled.

Thoughts?