### PR TITLE
Ignore whitespace on typeahead queries

### DIFF
--- a/src/pretix/control/views/typeahead.py
+++ b/src/pretix/control/views/typeahead.py
@@ -132,7 +132,7 @@ def event_list(request):
 
 
 def nav_context_list(request):
-    query = request.GET.get('query', '')
+    query = request.GET.get('query', '').strip()
     organizer = request.GET.get('organizer', None)
 
     try:


### PR DESCRIPTION
Whitespace is often added when you copy/paste order or voucher codes