### PR TITLE
PayPal: Show payment ID on paid invoices

### DIFF
--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -536,10 +536,12 @@ class Paypal(BasePaymentProvider):
     def render_invoice_text(self, order: Order, payment: OrderPayment) -> str:
         if order.status == Order.STATUS_PAID:
             if payment.info_data.get('id', None):
-                return '{}\r\n{}: {}'.format(
+                return '{}\r\n{}: {}\r\n{}: {}'.format(
                     _('The payment for this invoice has already been received.'),
                     _('PayPal payment ID'),
-                    payment.info_data['id']
+                    payment.info_data['id'],
+                    _('PayPal sale ID'),
+                    payment.info_data['transactions'][0]['related_resources'][0]['sale']['id']
                 )
             else:
                 return super().render_invoice_text(order, payment)

--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -536,13 +536,20 @@ class Paypal(BasePaymentProvider):
     def render_invoice_text(self, order: Order, payment: OrderPayment) -> str:
         if order.status == Order.STATUS_PAID:
             if payment.info_data.get('id', None):
-                return '{}\r\n{}: {}\r\n{}: {}'.format(
-                    _('The payment for this invoice has already been received.'),
-                    _('PayPal payment ID'),
-                    payment.info_data['id'],
-                    _('PayPal sale ID'),
-                    payment.info_data['transactions'][0]['related_resources'][0]['sale']['id']
-                )
+                try:
+                    return '{}\r\n{}: {}\r\n{}: {}'.format(
+                        _('The payment for this invoice has already been received.'),
+                        _('PayPal payment ID'),
+                        payment.info_data['id'],
+                        _('PayPal sale ID'),
+                        payment.info_data['transactions'][0]['related_resources'][0]['sale']['id']
+                    )
+                except (KeyError, IndexError):
+                    return '{}\r\n{}: {}'.format(
+                        _('The payment for this invoice has already been received.'),
+                        _('PayPal payment ID'),
+                        payment.info_data['id']
+                    )
             else:
                 return super().render_invoice_text(order, payment)
 


### PR DESCRIPTION
This is a PoC for displaying the PaymentID on paid invoices for PayPal.

Technically, this is just calling the `render_invoice_text` also on paid invoices, which we didn't before.

If this change is any good, we should probably also look into implementing similar printouts for Stripe and Mollie.