### PR TITLE
missing dot in docker command

### DIFF
--- a/doc/admin/installation/docker_smallscale.rst
+++ b/doc/admin/installation/docker_smallscale.rst
@@ -276,7 +276,7 @@ choice)::
 
 Then, go to that directory and build the image::
 
-    $ docker build -t mypretix
+    $ docker build . -t mypretix
 
 You can now use that image ``mypretix`` instead of ``pretix/standalone`` in your service file (see above). Be sure
 to re-build your custom image after you pulled ``pretix/standalone`` if you want to perform an update.


### PR DESCRIPTION
There is a missing dot in the docker command to create a custom build with plugins. Inserted that missing dot.
Should be `docker build . -t mypretix` instead of `docker build -t mypretix`