### PR TITLE
Two more things to escape in the PDF renderer

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -405,9 +405,9 @@ class Renderer:
         if not o['content']:
             return '(error)'
         if o['content'] == 'other':
-            return o['text'].replace("\n", "<br/>\n")
+            return escape(o['text']).replace("\n", "<br/>\n")
         elif o['content'].startswith('meta:'):
-            return ev.meta_data.get(o['content'][5:]) or ''
+            return escape(ev.meta_data.get(o['content'][5:])) or ''
         elif o['content'] in self.variables:
             try:
                 return self.variables[o['content']]['evaluate'](op, order, ev)

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -288,7 +288,7 @@ def variables_from_questions(sender, *args, **kwargs):
         if not a:
             return ""
         else:
-            return str(a).replace("\n", "<br/>\n")
+            return escape(str(a)).replace("\n", "<br/>\n")
 
     d = {}
     for q in sender.questions.all():


### PR DESCRIPTION
I'd also think the better place to escape the values of variables would be in the same `get_text_content` method so that everything is localised there. This would require moving all the `.replace("\n", "<br/>\n")` there too, it would in my eyes be an improvement though, as the knowledge about the PDF renderer needing HTML to be escaped and newlines to be converted to `<br/>` would be in `get_text_content` and there only.

I can prepare a corresponding pull request if this is an idea which would work for you.