### PR TITLE
New signal: ticketoutput_override_layout

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -77,4 +77,4 @@ Ticket designs
 """"""""""""""
 
 .. automodule:: pretix.base.signals
-   :members: layout_text_variables
+   :members: layout_text_variables, ticketoutput_override_layout

--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -77,4 +77,7 @@ Ticket designs
 """"""""""""""
 
 .. automodule:: pretix.base.signals
-   :members: layout_text_variables, ticketoutput_override_layout
+   :members: layout_text_variables
+
+.. automodule:: pretix.plugins.ticketoutputpdf.signals
+   :members: override_layout

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -589,18 +589,6 @@ The evaluate member will be called with the order position, order and event as a
 also be a subevent, if applicable.
 """
 
-ticketoutput_override_layout = EventPluginSignal(
-    providing_args=["position"]
-)
-"""
-This signal allows you to forcefully override the ticket layout that is being used to create the ticket PDF. Use with
-care, as this will render any specifically by the organizer selected templates useless.
-
-The ``position`` keyword argument will contain the ``OrderPosition`` which is being generated.
-
-As with all plugin signals, the ``sender`` keyword will contain the event.
-"""
-
 
 timeline_events = EventPluginSignal()
 """

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -589,6 +589,18 @@ The evaluate member will be called with the order position, order and event as a
 also be a subevent, if applicable.
 """
 
+ticketoutput_override_layout = EventPluginSignal(
+    providing_args=["position"]
+)
+"""
+This signal allows you to forcefully override the ticket layout that is being used to create the ticket PDF. Use with
+care, as this will render any specifically by the organizer selected templates useless.
+
+The ``position`` keyword argument will contain the ``OrderPosition`` which is being generated.
+
+As with all plugin signals, the ``sender`` keyword will contain the event.
+"""
+
 
 timeline_events = EventPluginSignal()
 """

--- a/src/pretix/plugins/ticketoutputpdf/signals.py
+++ b/src/pretix/plugins/ticketoutputpdf/signals.py
@@ -8,8 +8,9 @@ from django.utils.translation import ugettext_lazy as _
 
 from pretix.base.channels import get_all_sales_channels
 from pretix.base.signals import (  # NOQA: legacy import
-    event_copy_data, item_copy_data, layout_text_variables, logentry_display,
-    logentry_object_link, register_data_exporters, register_ticket_outputs,
+    EventPluginSignal, event_copy_data, item_copy_data, layout_text_variables,
+    logentry_display, logentry_object_link, register_data_exporters,
+    register_ticket_outputs,
 )
 from pretix.control.signals import item_forms
 from pretix.plugins.ticketoutputpdf.forms import TicketLayoutItemForm
@@ -122,3 +123,17 @@ def pdf_logentry_object_link(sender, logentry, **kwargs):
     }
     a_map['val'] = '<a href="{href}">{val}</a>'.format_map(a_map)
     return a_text.format_map(a_map)
+
+
+override_layout = EventPluginSignal(
+    providing_args=["position", "layout"]
+)
+"""
+This signal allows you to forcefully override the ticket layout that is being used to create the ticket PDF. Use with
+care, as this will render any specifically by the organizer selected templates useless.
+
+The ``position`` keyword argument will contain the ``OrderPosition`` which is being generated, the ``layout`` keyword
+argument will contain the layout which has been originally selected by the system.
+
+As with all plugin signals, the ``sender`` keyword will contain the event.
+"""

--- a/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
+++ b/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
@@ -79,7 +79,9 @@ class PdfTicketOutput(BaseTicketOutput):
         merger = PdfFileMerger()
         with language(order.locale):
             for op in order.positions_with_tickets:
-                layout = ticketoutput_override_layout.send(order.event, op) or self.layout_map.get(
+                layout = ticketoutput_override_layout.send_chained(
+                    order.event, 'layoutoverride', orderposition=op
+                ) or self.layout_map.get(
                     (op.item_id, order.sales_channel),
                     self.layout_map.get(
                         (op.item_id, 'web'),
@@ -97,7 +99,10 @@ class PdfTicketOutput(BaseTicketOutput):
 
     def generate(self, op):
         order = op.order
-        layout = ticketoutput_override_layout.send(order.event, op) or self.layout_map.get(
+
+        layout = ticketoutput_override_layout.send_chained(
+            order.event, 'layoutoverride', orderposition=op
+        ) or self.layout_map.get(
             (op.item_id, order.sales_channel),
             self.layout_map.get(
                 (op.item_id, 'web'),


### PR DESCRIPTION
New signal that allows plugins to override the layout that the PDF-ticketoutput is using.