### PR TITLE
Remove 'no selection' from addon products bulletList

### DIFF
--- a/src/pretix/presale/forms/checkout.py
+++ b/src/pretix/presale/forms/checkout.py
@@ -262,7 +262,11 @@ class AddOnsForm(forms.Form):
                     continue
 
             if i.has_variations:
-                choices = [('', _('no selection'), '')]
+                if self.iao.min_count == 1 and self.iao.max_count == 1:
+                    choices = []
+                else:
+                    choices = [('', _('no selection'), '')]
+
                 for v in i.available_variations:
                     cached_availability = v.check_quotas(subevent=subevent, _cache=quota_cache)
                     if self.event.settings.hide_sold_out and cached_availability[0] < Quota.AVAILABILITY_RESERVED:


### PR DESCRIPTION
In the case exacly one addon product has to be choosen by the user the artifical option "no selection" is not required. By this modification the UI experience is improved.
![A](https://user-images.githubusercontent.com/222388/69014778-30fb4100-098e-11ea-93f1-f15df8bf9afe.png)
![B](https://user-images.githubusercontent.com/222388/69014780-335d9b00-098e-11ea-8e09-28b229895fe6.png)

