### PR TITLE
Send widget_data when opening waiting list

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -220,9 +220,9 @@ Vue.component('availbox', {
         },
         waiting_list_url: function () {
             if (this.item.has_variations) {
-                return this.$root.target_url + 'w/' + widget_id + '/waitinglist/?item=' + this.item.id + '&var=' + this.variation.id;
+                return this.$root.target_url + 'w/' + widget_id + '/waitinglist/?item=' + this.item.id + '&var=' + this.variation.id + '&widget_data=' + escape(this.$root.widget_data_json);
             } else {
-                return this.$root.target_url + 'w/' + widget_id + '/waitinglist/?item=' + this.item.id;
+                return this.$root.target_url + 'w/' + widget_id + '/waitinglist/?item=' + this.item.id + '&widget_data=' + escape(this.$root.widget_data_json);
             }
         }
     }


### PR DESCRIPTION
Currently the waiting list button of the widget does not send the widget_data to the server. Meaning that after successfully registering in the waitinglist, the cart session will not contain the widget data.

We'd like the widget data to be available, as this is the way we pass meta data of the user to the pretix application. Our plugin will save additional information in the database depending on the widget data in the cart session.