### PR TITLE
Allow to create vouchers for *all* products

### DIFF
--- a/src/pretix/api/serializers/voucher.py
+++ b/src/pretix/api/serializers/voucher.py
@@ -54,7 +54,8 @@ class VoucherSerializer(I18nAwareModelSerializer):
 
         Voucher.clean_item_properties(
             full_data, self.context.get('event'),
-            full_data.get('quota'), full_data.get('item'), full_data.get('variation')
+            full_data.get('quota'), full_data.get('item'), full_data.get('variation'),
+            block_quota=full_data.get('block_quota')
         )
         Voucher.clean_subevent(
             full_data, self.context.get('event')

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -175,8 +175,6 @@ def filter_available(qs, channel='web', voucher=None, allow_addons=False):
             q &= Q(pk=voucher.item_id)
         elif voucher.quota_id:
             q &= Q(quotas__in=[voucher.quota_id])
-        else:
-            return qs.none()
     if not voucher or not voucher.show_hidden_items:
         q &= Q(hide_without_voucher=False)
 

--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -109,9 +109,10 @@ class VoucherForm(I18nModelForm):
                     'event': instance.event.slug,
                     'organizer': instance.event.organizer.slug,
                 }),
-                'data-placeholder': ''
+                'data-placeholder': _('All products')
             }
         )
+        self.fields['itemvar'].required = False
         self.fields['itemvar'].widget.choices = self.fields['itemvar'].choices
 
         if self.instance.event.seating_plan or self.instance.event.subevents.filter(seating_plan__isnull=False).exists():
@@ -123,9 +124,6 @@ class VoucherForm(I18nModelForm):
                 initial=self.instance.seat.seat_guid if self.instance.seat else '',
                 help_text=str(self.instance.seat) if self.instance.seat else '',
             )
-            self.fields['itemvar'].required = False
-        else:
-            self.fields['itemvar'].required = True
 
     def clean(self):
         data = super().clean()
@@ -165,7 +163,8 @@ class VoucherForm(I18nModelForm):
         Voucher.clean_item_properties(
             data, self.instance.event,
             self.instance.quota, self.instance.item, self.instance.variation,
-            seats_given=data.get('seat') or data.get('seats')
+            seats_given=data.get('seat') or data.get('seats'),
+            block_quota=data.get('block_quota')
         )
         if not self.instance.show_hidden_items and (
             (self.instance.quota and all(i.hide_without_voucher for i in self.instance.quota.items.all()))

--- a/src/tests/api/test_permissions.py
+++ b/src/tests/api/test_permissions.py
@@ -75,7 +75,7 @@ event_permission_sub_urls = [
     ('delete', 'can_change_event_settings', 'taxrules/1/', 404),
     ('get', 'can_view_vouchers', 'vouchers/', 200),
     ('get', 'can_view_vouchers', 'vouchers/1/', 404),
-    ('post', 'can_change_vouchers', 'vouchers/', 400),
+    ('post', 'can_change_vouchers', 'vouchers/', 201),
     ('put', 'can_change_vouchers', 'vouchers/1/', 404),
     ('patch', 'can_change_vouchers', 'vouchers/1/', 404),
     ('delete', 'can_change_vouchers', 'vouchers/1/', 404),

--- a/src/tests/api/test_vouchers.py
+++ b/src/tests/api/test_vouchers.py
@@ -251,8 +251,12 @@ def create_voucher(token_client, organizer, event, data, expected_failure=False)
 def test_voucher_require_item(token_client, organizer, event, item):
     create_voucher(
         token_client, organizer, event,
-        data={},
+        data={'block_quota': True},
         expected_failure=True
+    )
+    create_voucher(
+        token_client, organizer, event,
+        data={},
     )
 
 

--- a/src/tests/base/test_models.py
+++ b/src/tests/base/test_models.py
@@ -718,6 +718,14 @@ class VoucherTestCase(BaseQuotaTestCase):
         self.assertFalse(v.applies_to(self.var1.item, self.var2))
 
     @classscope(attr='o')
+    def test_voucher_applicability_all(self):
+        v = Voucher.objects.create(event=self.event)
+        self.assertTrue(v.applies_to(self.item1))
+        self.assertTrue(v.applies_to(self.var1.item))
+        self.assertTrue(v.applies_to(self.var1.item, self.var1))
+        self.assertTrue(v.applies_to(self.var1.item, self.var2))
+
+    @classscope(attr='o')
     def test_voucher_applicability_variation_through_quota(self):
         self.quota.variations.add(self.var1)
         self.quota.items.add(self.var1.item)


### PR DESCRIPTION
This was requested to allow e.g. a global 20% discount across all (sub)events. Of course, it's not really useful once you have products that require a voucher, but there are enough people using pretix without this constraint.