### PR TITLE
Fix #1521 -- External authenticated users cannot delete events

### DIFF
--- a/src/pretix/base/forms/auth.py
+++ b/src/pretix/base/forms/auth.py
@@ -197,6 +197,7 @@ class ReauthForm(forms.Form):
         self.request = request
         self.user = user
         self.backend = backend
+        self.backend.url = backend.authentication_url(self.request)
         super().__init__(*args, **kwargs)
         for k, f in backend.login_form_fields.items():
             self.fields[k] = f

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.conf import settings
-from django.contrib.auth.hashers import check_password
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, validate_email
 from django.db.models import Q

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1436,11 +1436,6 @@ class EventDeleteForm(forms.Form):
         'pw_current_wrong': _("The password you entered was not correct."),
         'slug_wrong': _("The slug you entered was not correct."),
     }
-    user_pw = forms.CharField(
-        max_length=255,
-        label=_("Your password"),
-        widget=forms.PasswordInput()
-    )
     slug = forms.CharField(
         max_length=255,
         label=_("Event slug"),
@@ -1448,18 +1443,7 @@ class EventDeleteForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
-        self.user = kwargs.pop('user')
         super().__init__(*args, **kwargs)
-
-    def clean_user_pw(self):
-        user_pw = self.cleaned_data.get('user_pw')
-        if not check_password(user_pw, self.user.password):
-            raise forms.ValidationError(
-                self.error_messages['pw_current_wrong'],
-                code='pw_current_wrong',
-            )
-
-        return user_pw
 
     def clean_slug(self):
         slug = self.cleaned_data.get('slug')

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1433,7 +1433,6 @@ class WidgetCodeForm(forms.Form):
 
 class EventDeleteForm(forms.Form):
     error_messages = {
-        'pw_current_wrong': _("The password you entered was not correct."),
         'slug_wrong': _("The slug you entered was not correct."),
     }
     slug = forms.CharField(

--- a/src/pretix/control/templates/pretixcontrol/event/delete.html
+++ b/src/pretix/control/templates/pretixcontrol/event/delete.html
@@ -24,12 +24,6 @@
                 {% endblocktrans %}
             </p>
             {% bootstrap_field form.slug layout="inline" %}
-            <p>
-                {% blocktrans trimmed with slug=request.event.slug %}
-                    Also, to make sure it's really you, please enter your user password here:
-                {% endblocktrans %}
-            </p>
-            {% bootstrap_field form.user_pw layout="inline" %}
 
             <div class="form-group submit-group">
                 <button type="submit" class="btn btn-danger btn-save">

--- a/src/pretix/control/templates/pretixcontrol/shredder/download.html
+++ b/src/pretix/control/templates/pretixcontrol/shredder/download.html
@@ -40,12 +40,12 @@
         <fieldset>
             <legend>{% trans "Step 3: Confirm deletion" %}</legend>
             <p>
-                {% blocktrans trimmed with event=request.event.name %}
+                {% blocktrans trimmed with event=request.event.name slug=request.event.slug %}
                 Please re-check that you are fully certain that you want to delete the selected categories of data from the event <strong>{{ event }}</strong>.
-                    In this case, please enter your user password here:
+                    To confirm you really want this, please type out the event's short name ("{{ slug }}") here:
                 {% endblocktrans %}
             </p>
-            <input type="password" class="form-control" name="password" required placeholder="{% trans "Your password" %}">
+            <input type="text" class="form-control" name="slug" required placeholder="{% trans "Event short name" %}">
         </fieldset>
         <input type="hidden" name="file" value="{{ file.pk }}">
         <div class="form-group submit-group">

--- a/src/pretix/control/templates/pretixcontrol/user/reauth.html
+++ b/src/pretix/control/templates/pretixcontrol/user/reauth.html
@@ -9,7 +9,7 @@
         <h3>{% trans "Welcome back!" %}</h3>
         <p>
             {% if form.backend.url %}
-                {% blocktrans trimmed with verbose_name=form.backend.verbose_name %}We just want to make sure it's really you. Please re-authenticate with '{{ verbose_name}}'.{% endblocktrans %}
+                {% blocktrans trimmed with login_provider=form.backend.verbose_name %}We just want to make sure it's really you. Please re-authenticate with '{{ login_provider }}'.{% endblocktrans %}
             {% else %}
                 {% trans "We just want to make sure it's really you. Please re-enter your password to continue." %}
             {% endif %}

--- a/src/pretix/control/templates/pretixcontrol/user/reauth.html
+++ b/src/pretix/control/templates/pretixcontrol/user/reauth.html
@@ -8,7 +8,11 @@
         {% csrf_token %}
         <h3>{% trans "Welcome back!" %}</h3>
         <p>
-            {% trans "We just want to make sure it's really you. Please re-enter your password to continue." %}
+            {% if form.backend.url %}
+                {% blocktrans trimmed with verbose_name=form.backend.verbose_name %}We just want to make sure it's really you. Please re-authenticate with '{{ verbose_name}}'.{% endblocktrans %}
+            {% else %}
+                {% trans "We just want to make sure it's really you. Please re-enter your password to continue." %}
+            {% endif %}
         </p>
         {% bootstrap_form form %}
         <input class="form-control" id="webauthn-response" name="webauthn"
@@ -23,9 +27,15 @@
             </small></p>
         {% endif %}
         <div class="form-group text-right flip">
-            <button type="submit" class="btn btn-primary btn-block">
-                {% trans "Continue" %}
-            </button>
+            {% if form.backend.url %}
+                <a href="{{ form.backend.url }}" class="btn btn-primary btn-block">
+                    {% trans "Continue" %}
+                </a>
+            {% else %}
+                <button type="submit" class="btn btn-primary btn-block">
+                    {% trans "Continue" %}
+                </button>
+            {% endif %}
             <a href="{% url "control:auth.logout" %}" class="btn btn-link btn-block">
                 {% trans "Log in as someone else" %}
             </a>

--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -44,6 +44,7 @@ from pretix.control.forms.event import (
     TicketSettingsForm, WidgetCodeForm,
 )
 from pretix.control.permissions import EventPermissionRequiredMixin
+from pretix.control.views.user import RecentAuthenticationRequiredMixin
 from pretix.helpers.database import rolledback_transaction
 from pretix.multidomain.urlreverse import get_domain
 from pretix.plugins.stripe.payment import StripeSettingsHolder
@@ -824,7 +825,7 @@ class EventLive(EventPermissionRequiredMixin, TemplateView):
         })
 
 
-class EventDelete(EventPermissionRequiredMixin, FormView):
+class EventDelete(RecentAuthenticationRequiredMixin, EventPermissionRequiredMixin, FormView):
     permission = 'can_change_event_settings'
     template_name = 'pretixcontrol/event/delete.html'
     form_class = EventDeleteForm
@@ -837,7 +838,6 @@ class EventDelete(EventPermissionRequiredMixin, FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs['user'] = self.request.user
         kwargs['event'] = self.request.event
         return kwargs
 

--- a/src/pretix/control/views/shredder.py
+++ b/src/pretix/control/views/shredder.py
@@ -13,6 +13,7 @@ from pretix.base.services.shredder import export, shred
 from pretix.base.shredder import ShredError, shred_constraints
 from pretix.base.views.tasks import AsyncAction
 from pretix.control.permissions import EventPermissionRequiredMixin
+from pretix.control.views.user import RecentAuthenticationRequiredMixin
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class ShredderMixin:
         )
 
 
-class StartShredView(EventPermissionRequiredMixin, ShredderMixin, TemplateView):
+class StartShredView(RecentAuthenticationRequiredMixin, EventPermissionRequiredMixin, ShredderMixin, TemplateView):
     permission = 'can_change_orders'
     template_name = 'pretixcontrol/shredder/index.html'
 
@@ -37,7 +38,7 @@ class StartShredView(EventPermissionRequiredMixin, ShredderMixin, TemplateView):
         return ctx
 
 
-class ShredDownloadView(EventPermissionRequiredMixin, ShredderMixin, TemplateView):
+class ShredDownloadView(RecentAuthenticationRequiredMixin, EventPermissionRequiredMixin, ShredderMixin, TemplateView):
     permission = 'can_change_orders'
     template_name = 'pretixcontrol/shredder/download.html'
 
@@ -48,7 +49,7 @@ class ShredDownloadView(EventPermissionRequiredMixin, ShredderMixin, TemplateVie
         return ctx
 
 
-class ShredExportView(EventPermissionRequiredMixin, ShredderMixin, AsyncAction, View):
+class ShredExportView(RecentAuthenticationRequiredMixin, EventPermissionRequiredMixin, ShredderMixin, AsyncAction, View):
     permission = 'can_change_orders'
     task = export
     known_errortypes = ['ShredError']
@@ -77,7 +78,7 @@ class ShredExportView(EventPermissionRequiredMixin, ShredderMixin, AsyncAction, 
         return self.do(self.request.event.id, request.POST.getlist("shredder"))
 
 
-class ShredDoView(EventPermissionRequiredMixin, ShredderMixin, AsyncAction, View):
+class ShredDoView(RecentAuthenticationRequiredMixin, EventPermissionRequiredMixin, ShredderMixin, AsyncAction, View):
     permission = 'can_change_orders'
     task = shred
     known_errortypes = ['ShredError']
@@ -103,7 +104,7 @@ class ShredDoView(EventPermissionRequiredMixin, ShredderMixin, AsyncAction, View
         if constr:
             return self.error(ShredError(self.get_error_url()))
 
-        if not self.request.user.check_password(request.POST.get("password")):
-            return self.error(ShredError(_("The current password you entered was not correct.")))
+        if request.event.slug != request.POST.get("slug"):
+            return self.error(ShredError(_("The current slug you entered was not correct.")))
 
         return self.do(self.request.event.id, request.POST.get("file"), request.POST.get("confirm_code"))

--- a/src/pretix/control/views/shredder.py
+++ b/src/pretix/control/views/shredder.py
@@ -105,6 +105,6 @@ class ShredDoView(RecentAuthenticationRequiredMixin, EventPermissionRequiredMixi
             return self.error(ShredError(self.get_error_url()))
 
         if request.event.slug != request.POST.get("slug"):
-            return self.error(ShredError(_("The current slug you entered was not correct.")))
+            return self.error(ShredError(_("The slug you entered was not correct.")))
 
         return self.do(self.request.event.id, request.POST.get("file"), request.POST.get("confirm_code"))

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 from decimal import Decimal
 
 import pytz
@@ -1553,8 +1554,10 @@ class EventDeletionTest(SoupTest):
         self.client.login(email='dummy@dummy.dummy', password='dummy')
 
     def test_delete_allowed(self):
+        session = self.client.session
+        session['pretix_auth_login_time'] = int(time.time())
+        session.save()
         self.client.post('/control/event/ccc/30c3/delete/', {
-            'user_pw': 'dummy',
             'slug': '30c3'
         })
 

--- a/src/tests/control/test_permissions.py
+++ b/src/tests/control/test_permissions.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 
 import pytest
@@ -354,6 +355,9 @@ def test_correct_event_permission_all_events(perf_patch, client, env, perm, url,
     t.save()
     t.members.add(env[1])
     client.login(email='dummy@dummy.dummy', password='dummy')
+    session = client.session
+    session['pretix_auth_login_time'] = int(time.time())
+    session.save()
     response = client.get('/control/event/dummy/dummy/' + url)
     assert response.status_code == code
 
@@ -367,6 +371,9 @@ def test_correct_event_permission_limited(perf_patch, client, env, perm, url, co
     t.members.add(env[1])
     t.limit_events.add(env[0])
     client.login(email='dummy@dummy.dummy', password='dummy')
+    session = client.session
+    session['pretix_auth_login_time'] = int(time.time())
+    session.save()
     response = client.get('/control/event/dummy/dummy/' + url)
     assert response.status_code == code
 
@@ -419,5 +426,7 @@ def test_correct_organizer_permission(perf_patch, client, env, perm, url, code):
     t.save()
     t.members.add(env[1])
     client.login(email='dummy@dummy.dummy', password='dummy')
+    client.session['pretix_auth_login_time'] = int(time.time())
+    client.session.save()
     response = client.get('/control/' + url)
     assert response.status_code == code

--- a/src/tests/control/test_shredders.py
+++ b/src/tests/control/test_shredders.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import time
 from io import BytesIO
 from zipfile import ZipFile
 
@@ -35,6 +36,9 @@ class EventShredderTest(SoupTest):
         )
 
         self.client.login(email='dummy@dummy.dummy', password='dummy')
+        session = self.client.session
+        session['pretix_auth_login_time'] = int(time.time()) * 2
+        session.save()
 
     def test_shred_simple(self):
         doc = self.get_doc('/control/event/%s/%s/shredder/' % (self.orga1.slug, self.event1.slug))
@@ -60,7 +64,7 @@ class EventShredderTest(SoupTest):
         doc = self.post_doc('/control/event/%s/%s/shredder/shred' % (self.orga1.slug, self.event1.slug), {
             'confirm_code': indexdata['confirm_code'],
             'file': doc.select("input[name=file]")[0].attrs['value'],
-            'password': 'dummy'
+            'slug': self.event1.slug
         })
         assert doc.select('.alert-success')
         self.order.refresh_from_db()


### PR DESCRIPTION
Adds possibility for reauthenticating backends with authentication_url auth method. Additionally replaces all seperate password checks with recent authentication required.