### PR TITLE
Expose help texts on questions' API

### DIFF
--- a/doc/api/resources/questions.rst
+++ b/doc/api/resources/questions.rst
@@ -88,7 +88,7 @@ dependency_value                      string                     An old version 
 
   The attribute ``print_on_invoice`` has been added.
 
-.. versionchanged:: 3.4.1
+.. versionchanged:: 3.5
 
   The attribute ``help_text`` has been added.
 

--- a/doc/api/resources/questions.rst
+++ b/doc/api/resources/questions.rst
@@ -18,6 +18,7 @@ Field                                 Type                       Description
 ===================================== ========================== =======================================================
 id                                    integer                    Internal ID of the question
 question                              multi-lingual string       The field label shown to the customer
+help_text                             multi-lingual string       The help text shown to the customer
 type                                  string                     The expected type of answer. Valid options:
 
                                                                  * ``N`` – number
@@ -87,6 +88,10 @@ dependency_value                      string                     An old version 
 
   The attribute ``print_on_invoice`` has been added.
 
+.. versionchanged:: 3.4.1
+
+  The attribute ``help_text`` has been added.
+
 Endpoints
 ---------
 
@@ -123,6 +128,7 @@ Endpoints
           {
             "id": 1,
             "question": {"en": "T-Shirt size"},
+            "help_text": {"en": "Choose your preferred t-shirt-size"},
             "type": "C",
             "required": false,
             "items": [1, 2],
@@ -193,6 +199,7 @@ Endpoints
       {
         "id": 1,
         "question": {"en": "T-Shirt size"},
+        "help_text": {"en": "Choose your preferred t-shirt-size"},
         "type": "C",
         "required": false,
         "items": [1, 2],
@@ -248,6 +255,7 @@ Endpoints
 
       {
         "question": {"en": "T-Shirt size"},
+        "help_text": {"en": "Choose your preferred t-shirt-size"},
         "type": "C",
         "required": false,
         "items": [1, 2],
@@ -282,6 +290,7 @@ Endpoints
       {
         "id": 1,
         "question": {"en": "T-Shirt size"},
+        "help_text": {"en": "Choose your preferred t-shirt-size"},
         "type": "C",
         "required": false,
         "items": [1, 2],
@@ -356,6 +365,7 @@ Endpoints
       {
         "id": 1,
         "question": {"en": "T-Shirt size"},
+        "help_text": {"en": "Choose your preferred t-shirt-size"},
         "type": "C",
         "required": false,
         "items": [1, 2],

--- a/src/pretix/api/serializers/item.py
+++ b/src/pretix/api/serializers/item.py
@@ -227,7 +227,7 @@ class QuestionSerializer(I18nAwareModelSerializer):
         model = Question
         fields = ('id', 'question', 'type', 'required', 'items', 'options', 'position',
                   'ask_during_checkin', 'identifier', 'dependency_question', 'dependency_values',
-                  'hidden', 'dependency_value', 'print_on_invoice')
+                  'hidden', 'dependency_value', 'print_on_invoice', 'help_text')
 
     def validate_identifier(self, value):
         Question._clean_identifier(self.context['event'], value, self.instance)

--- a/src/tests/api/test_items.py
+++ b/src/tests/api/test_items.py
@@ -1740,7 +1740,9 @@ def test_quota_availability(token_client, organizer, event, quota, item):
 
 @pytest.fixture
 def question(event, item):
-    q = event.questions.create(question="T-Shirt size", type="C", identifier="ABC")
+    q = event.questions.create(
+        question="T-Shirt size", type="C", identifier="ABC", help_text="This is an example question"
+    )
     q.items.add(item)
     q.options.create(answer="XL", identifier="LVETRWVU")
     return q
@@ -1759,6 +1761,7 @@ TEST_QUESTION_RES = {
     "dependency_question": None,
     "dependency_value": None,
     "dependency_values": [],
+    "help_text": {"en": "This is an example question"},
     "options": [
         {
             "id": 0,


### PR DESCRIPTION
Hi there! We are using the API to show the list of questions and I notice that the help text is missing, this PR adds that and adds a test for it as well :)