### PR TITLE
Bumped oauthlib to ==3.1.*

### DIFF
--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -39,7 +39,7 @@ django-hijack>=2.1.10,<2.2.0
 jsonschema
 openpyxl
 django-oauth-toolkit==1.2.*
-oauthlib==2.1.*
+oauthlib==3.1.*
 django-jsonfallback>=2.1.2
 psycopg2-binary
 # Stripe

--- a/src/setup.py
+++ b/src/setup.py
@@ -145,7 +145,7 @@ setup(
         'django-hijack>=2.1.10,<2.2.0',
         'openpyxl',
         'django-oauth-toolkit==1.2.*',
-        'oauthlib==2.1.*',
+        'oauthlib==3.1.*',
         'urllib3==1.24.*',  # required by current requests
         'django-phonenumber-field==3.0.*',
         'phonenumberslite==8.10.*',

--- a/src/tests/api/test_oauth.py
+++ b/src/tests/api/test_oauth.py
@@ -478,7 +478,7 @@ def test_token_revoke_refresh_token(client, admin_user, organizer, application: 
         'grant_type': 'refresh_token',
     }, HTTP_AUTHORIZATION='Basic ' + base64.b64encode(
         ('%s:%s' % (application.client_id, application.client_secret)).encode()).decode())
-    assert resp.status_code == 401
+    assert resp.status_code == 400
 
 
 @pytest.mark.django_db
@@ -573,4 +573,4 @@ def test_user_revoke(client, admin_user, organizer, application: OAuthApplicatio
         'grant_type': 'refresh_token',
     }, HTTP_AUTHORIZATION='Basic ' + base64.b64encode(
         ('%s:%s' % (application.client_id, application.client_secret)).encode()).decode())
-    assert resp.status_code == 401
+    assert resp.status_code == 400


### PR DESCRIPTION
Over the holidays, I (very dirtily) hacked together a google oauth login backend (which, although secure, is not ready for release yet). To use the python libraries provided by google to handle the oauth flow, I needed to bump the oauthlib version.

As far as I can tell, this should not introduce any logic changes; however within the tests I noticed that newer oauthlibs return 400 Bad Request instead of 401 Unauthorized. I don't really know if the tests use the library wrong or if this behavior change is intentional. I fixed the tests to expect 400 Bad Request in a second commit, but somebody should probably look at that further. It should have no impact on the flow that's being tested here.