### PR TITLE
Fix when CSRF cookies on login missing

### DIFF
--- a/src/pretix/control/views/auth.py
+++ b/src/pretix/control/views/auth.py
@@ -17,6 +17,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.http import is_safe_url
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView
 from django_otp import match_token
 
@@ -53,7 +54,7 @@ def process_login(request, user, keep_logged_in):
             return redirect(request.GET.get("next"))
         return redirect(reverse('control:index'))
 
-
+@ensure_csrf_cookie
 def login(request):
     """
     Render and process a most basic login form. Takes an URL as GET


### PR DESCRIPTION
For some reason, I did not get a CSRF token cookie set when visiting the login screen during local development of the google oauth backend mentioned in my other PR. Adding this decorator made sure I could log in as I would finally receive the cookies.