### PR TITLE
Send signal on checkin

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -22,6 +22,12 @@ There are multiple signals that will be sent out in the ordering cycle:
 .. automodule:: pretix.base.signals
    :members: validate_cart, validate_cart_addons, validate_order, order_fee_calculation, order_paid, order_placed, order_canceled, order_expired, order_modified, order_changed, order_approved, order_denied, order_fee_type_name, allow_ticket_download, order_split, order_gracefully_delete, invoice_line_text
 
+Checkins
+""""""""
+
+.. automodule:: pretix.base.signals
+   :members: position_checked_in
+
 Frontend
 --------
 

--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -22,8 +22,8 @@ There are multiple signals that will be sent out in the ordering cycle:
 .. automodule:: pretix.base.signals
    :members: validate_cart, validate_cart_addons, validate_order, order_fee_calculation, order_paid, order_placed, order_canceled, order_expired, order_modified, order_changed, order_approved, order_denied, order_fee_type_name, allow_ticket_download, order_split, order_gracefully_delete, invoice_line_text
 
-Checkins
-""""""""
+Check-ins
+"""""""""
 
 .. automodule:: pretix.base.signals
    :members: checkin_created

--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -26,7 +26,8 @@ Checkins
 """"""""
 
 .. automodule:: pretix.base.signals
-   :members: position_checked_in
+   :members: checkin_created
+
 
 Frontend
 --------

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 from pretix.base.models import (
     Checkin, CheckinList, Order, OrderPosition, Question, QuestionOption,
 )
-from pretix.base.signals import order_placed, position_checked_in
+from pretix.base.signals import checkin_created, order_placed
 
 
 class CheckInError(Exception):
@@ -143,7 +143,7 @@ def perform_checkin(op: OrderPosition, clist: CheckinList, given_answers: dict, 
                 'datetime': dt,
                 'list': clist.pk
             }, user=user, auth=auth)
-            position_checked_in.send(op.order.event, checkin=ci)
+            checkin_created.send(op.order.event, checkin=ci)
     else:
         if not force:
             raise CheckInError(
@@ -173,4 +173,4 @@ def order_placed(sender, **kwargs):
         for cl in cls:
             if cl.all_products or op.item_id in {i.pk for i in cl.limit_products.all()}:
                 ci = Checkin.objects.create(position=op, list=cl, auto_checked_in=True)
-                position_checked_in.send(event, checkin=ci)
+                checkin_created.send(event, checkin=ci)

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -405,12 +405,13 @@ the deletion of the order.
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
 
-position_checked_in = EventPluginSignal(
+checkin_created = EventPluginSignal(
     providing_args=["checkin"],
 )
 """
-This signal is sent out every time an order position is marked as checked in. The checkin
-object is given as the first argument
+This signal is sent out every time a checkin is created (i.e. an order position is marked as
+cheked in). It is not send if the position was already checked in and is force-checked-in a second time.
+The checkin object is given as the first argument
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -409,9 +409,9 @@ checkin_created = EventPluginSignal(
     providing_args=["checkin"],
 )
 """
-This signal is sent out every time a checkin is created (i.e. an order position is marked as
-cheked in). It is not send if the position was already checked in and is force-checked-in a second time.
-The checkin object is given as the first argument
+This signal is sent out every time a check-in is created (i.e. an order position is marked as
+checked in). It is not send if the position was already checked in and is force-checked-in a second time.
+The check-in object is given as the first argument
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -405,6 +405,16 @@ the deletion of the order.
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
 
+position_checked_in = EventPluginSignal(
+    providing_args=["checkin"],
+)
+"""
+This signal is sent out every time an order position is marked as checked in. The checkin
+object is given as the first argument
+
+As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
+"""
+
 logentry_display = EventPluginSignal(
     providing_args=["logentry"]
 )

--- a/src/pretix/control/views/checkin.py
+++ b/src/pretix/control/views/checkin.py
@@ -14,6 +14,7 @@ from pytz import UTC
 from pretix.base.channels import get_all_sales_channels
 from pretix.base.models import Checkin, Order, OrderPosition
 from pretix.base.models.checkin import CheckinList
+from pretix.base.signals import position_checked_in
 from pretix.control.forms.checkin import CheckinListForm
 from pretix.control.forms.filter import CheckInFilterForm
 from pretix.control.permissions import EventPermissionRequiredMixin
@@ -124,6 +125,7 @@ class CheckInListShow(EventPermissionRequiredMixin, PaginationMixin, ListView):
                         'list': self.list.pk,
                         'web': True
                     }, user=request.user)
+                    position_checked_in.send(op.order.event, checkin=ci)
 
             messages.success(request, _('The selected tickets have been marked as checked in.'))
 

--- a/src/pretix/control/views/checkin.py
+++ b/src/pretix/control/views/checkin.py
@@ -14,7 +14,7 @@ from pytz import UTC
 from pretix.base.channels import get_all_sales_channels
 from pretix.base.models import Checkin, Order, OrderPosition
 from pretix.base.models.checkin import CheckinList
-from pretix.base.signals import position_checked_in
+from pretix.base.signals import checkin_created
 from pretix.control.forms.checkin import CheckinListForm
 from pretix.control.forms.filter import CheckInFilterForm
 from pretix.control.permissions import EventPermissionRequiredMixin
@@ -125,7 +125,7 @@ class CheckInListShow(EventPermissionRequiredMixin, PaginationMixin, ListView):
                         'list': self.list.pk,
                         'web': True
                     }, user=request.user)
-                    position_checked_in.send(op.order.event, checkin=ci)
+                    checkin_created.send(op.order.event, checkin=ci)
 
             messages.success(request, _('The selected tickets have been marked as checked in.'))
 


### PR DESCRIPTION
Plugins might need this signal to trigger own processes when a user is checked in. One example might be sending a greeting email or activating features on-site. This PR sends a signal when creating a new checkin.

I have two questions regarding this change:
1. Do you think the signal should also be send if a user is force-checked-in? (https://github.com/pretix/pretix/blob/master/src/pretix/base/services/checkin.py#L152)
2. Does the signal need to be added to the documentation on other places?