### PR TITLE
Force-escape all PDF values on the renderer level

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -314,7 +314,7 @@ def variables_from_questions(sender, *args, **kwargs):
 
 def _get_attendee_name_part(key, op, order, ev):
     if isinstance(key, tuple):
-        return ' '.join(_get_attendee_name_part(c[0], op, order, ev) for c in key)
+        return ' '.join(p for p in [_get_attendee_name_part(c[0], op, order, ev) for c in key] if p)
     return op.attendee_name_parts.get(key, '')
 
 


### PR DESCRIPTION
We want unescaped values for the checkin apps.

- [x] Check that this actually does the right thing in our apps
- [x] Check that no customers use HTML tags in production
- [x] adjust signal listener in pretix-shipping