### PR TITLE
Solve some Docker Setup scaling issues

### DIFF
--- a/deployment/docker/nginx.conf
+++ b/deployment/docker/nginx.conf
@@ -4,7 +4,7 @@ pid /var/run/nginx.pid;
 daemon off;
 
 events {
-	worker_connections 768;
+	worker_connections 4096;
 }
 
 http {
@@ -39,7 +39,7 @@ http {
 	include /etc/nginx/conf.d/*.conf;
 
     server {
-        listen 80 default_server;
+        listen 80 backlog=4096 default_server;
         listen [::]:80 ipv6only=on default_server;
         server_name _;
         index index.php index.html;

--- a/doc/admin/installation/docker_smallscale.rst
+++ b/doc/admin/installation/docker_smallscale.rst
@@ -182,6 +182,7 @@ named ``/etc/systemd/system/pretix.service`` with the following content::
         -v /var/pretix-data:/data \
         -v /etc/pretix:/etc/pretix \
         -v /var/run/redis:/var/run/redis \
+        --sysctl net.core.somaxconn=4096
         pretix/standalone:stable all
     ExecStop=/usr/bin/docker stop %n
 


### PR DESCRIPTION
Currently the first Scaling Problem you run into while hosting the Small Scale Docker Setup is the sysctl Setting of maximum parallel Socket Connections which defaults to 128.

This means after 128 parallel connections the nginx starts replying with 502 Errors.

If you increate this Limit the next Problem will be the 768 Worker Connections of nginx.

To solve both of these Issues this Pullrequest sets them both to a Value of 4096.