### PR TITLE
Comparison for file extensions should be case insensitive

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -900,7 +900,7 @@ class QuestionAnswer(models.Model):
 
     @property
     def is_image(self):
-        return any(self.file.name.endswith(e) for e in ('.jpg', '.png', '.gif', '.tiff', '.bmp', '.jpeg'))
+        return any(self.file.name.lower().endswith(e) for e in ('.jpg', '.png', '.gif', '.tiff', '.bmp', '.jpeg'))
 
     @property
     def file_name(self):

--- a/src/pretix/control/forms/__init__.py
+++ b/src/pretix/control/forms/__init__.py
@@ -79,7 +79,7 @@ class ClearableBasenameFileInput(forms.ClearableFileInput):
 
         @property
         def is_img(self):
-            return any(self.file.name.endswith(e) for e in ('.jpg', '.jpeg', '.png', '.gif'))
+            return any(self.file.name.lower().endswith(e) for e in ('.jpg', '.jpeg', '.png', '.gif'))
 
         def __str__(self):
             return os.path.basename(self.file.name).split('.', 1)[-1]

--- a/src/pretix/control/views/orderimport.py
+++ b/src/pretix/control/views/orderimport.py
@@ -29,7 +29,7 @@ class ImportView(EventPermissionRequiredMixin, TemplateView):
                 'event': request.event.slug,
                 'organizer': request.organizer.slug,
             }))
-        if not request.FILES['file'].name.endswith('.csv'):
+        if not request.FILES['file'].name.lower().endswith('.csv'):
             messages.error(request, _('Please only upload CSV files.'))
             return redirect(reverse('control:event.orders.import', kwargs={
                 'event': request.event.slug,


### PR DESCRIPTION
This takes care for situations when buyers upload files with capital letters in the extension (like .JPG); I suppose this is common on Windows OS.

I found this first when buyers uploaded images to questions that ended with .JPG. I browsed the code and found that this is in orders.py

I looked further and found two other places that looked similar. 

As I currently don't have a working python setup I was unable to test this change locally. I would be grateful if a reviewer could test it. 
If this is not possible, please let me know and I'll setup a VM with a python environment.