### PR TITLE
Add option to hide the price of free products

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -550,6 +550,7 @@ class EventSettingsSerializer(serializers.Serializer):
         'show_variations_expanded',
         'hide_sold_out',
         'meta_noindex',
+        'hide_free_prices',
         'redirect_to_checkout_directly',
         'frontpage_subevent_ordering',
         'frontpage_text',

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -716,6 +716,16 @@ DEFAULTS = {
             label=_('Ask search engines not to index the ticket shop'),
         )
     },
+    'hide_free_prices': {
+        'default': 'False',
+        'type': bool,
+        'serializer_class': serializers.BooleanField,
+        'form_class': forms.BooleanField,
+        'form_kwargs': dict(
+            label=_("Hide price of free products"),
+            help_text=_("Do not show the price of a product if it is free"),
+        )
+    },
     'show_variations_expanded': {
         'default': 'False',
         'type': bool,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -456,6 +456,7 @@ class EventSettingsForm(SettingsForm):
         'show_variations_expanded',
         'hide_sold_out',
         'meta_noindex',
+        'hide_free_prices',
         'redirect_to_checkout_directly',
         'frontpage_subevent_ordering',
         'frontpage_text',

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -128,6 +128,7 @@
                 {% bootstrap_field sform.show_variations_expanded layout="control" %}
                 {% bootstrap_field sform.hide_sold_out layout="control" %}
                 {% bootstrap_field sform.meta_noindex layout="control" %}
+                {% bootstrap_field sform.hide_free_prices layout="control" %}
                 {% if sform.frontpage_subevent_ordering %}
                     {% bootstrap_field sform.frontpage_subevent_ordering layout="control" %}
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -94,9 +94,13 @@
             <div class="count">&nbsp;</div>
             <div class="singleprice price">
                 {% if event.settings.display_net_prices %}
-                    {{ line.net_price|money:event.currency }}
+                    {% if not event.settings.hide_free_prices or line.net_price > 0 %}
+                        {{ line.net_price|money:event.currency }}
+                    {% endif %}
                 {% else %}
-                    {{ line.price|money:event.currency }}
+                    {% if not event.settings.hide_free_prices or line.price > 0 %}
+                        {{ line.price|money:event.currency }}
+                    {% endif %}
                 {% endif %}
             </div>
         {% else %}
@@ -143,32 +147,40 @@
             </div>
             <div class="singleprice price">
                 {% if event.settings.display_net_prices %}
-                    {{ line.net_price|money:event.currency }}
+                    {% if not event.settings.hide_free_prices or line.net_price > 0 %}
+                        {{ line.net_price|money:event.currency }}
+                    {% endif %}
                 {% else %}
-                    {{ line.price|money:event.currency }}
+                    {% if not event.settings.hide_free_prices or line.price > 0 %}
+                        {{ line.price|money:event.currency }}
+                    {% endif %}
                 {% endif %}
             </div>
         {% endif %}
         <div class="totalprice price">
             {% if event.settings.display_net_prices %}
-                <strong>{{ line.net_total|money:event.currency }}</strong>
-                {% if line.tax_rate and line.total %}
-                    <br />
-                    <small>
-                        {% blocktrans trimmed with rate=line.tax_rate|floatformat:-2 taxname=line.tax_rule.name|default:s_taxes %}
-                            <strong>plus</strong> {{ rate }}% {{ taxname }}
-                        {% endblocktrans %}
-                    </small>
+                {% if not event.settings.hide_free_prices or line.net_total > 0 %}
+                    <strong>{{ line.net_total|money:event.currency }}</strong>
+                    {% if line.tax_rate and line.total %}
+                        <br />
+                        <small>
+                            {% blocktrans trimmed with rate=line.tax_rate|floatformat:-2 taxname=line.tax_rule.name|default:s_taxes %}
+                                <strong>plus</strong> {{ rate }}% {{ taxname }}
+                            {% endblocktrans %}
+                        </small>
+                    {% endif %}
                 {% endif %}
             {% else %}
-                <strong>{{ line.total|money:event.currency }}</strong>
-                {% if line.tax_rate and line.total %}
-                    <br />
-                    <small>
-                        {% blocktrans trimmed with rate=line.tax_rate|floatformat:-2 taxname=line.tax_rule.name|default:s_taxes %}
-                            incl. {{ rate }}% {{ taxname }}
-                        {% endblocktrans %}
-                    </small>
+                {% if not event.settings.hide_free_prices or line.total > 0 %}
+                    <strong>{{ line.total|money:event.currency }}</strong>
+                    {% if line.tax_rate and line.total %}
+                        <br />
+                        <small>
+                            {% blocktrans trimmed with rate=line.tax_rate|floatformat:-2 taxname=line.tax_rule.name|default:s_taxes %}
+                                incl. {{ rate }}% {{ taxname }}
+                            {% endblocktrans %}
+                        </small>
+                    {% endif %}
                 {% endif %}
             {% endif %}
         </div>
@@ -198,24 +210,28 @@
         </div>
         <div class="col-md-3 col-xs-6 col-md-offset-5 price">
             {% if event.settings.display_net_prices %}
-                <strong>{{ fee.net_value|money:event.currency }}</strong>
-                {% if fee.tax_rate %}
-                    <br />
-                    <small>
-                        {% blocktrans trimmed with rate=fee.tax_rate|floatformat:-2 taxname=fee.tax_rule.name|default:s_taxes %}
-                            <strong>plus</strong> {{ rate }}% {{ taxname }}
-                        {% endblocktrans %}
-                    </small>
+                {% if not event.settings.hide_free_prices or fee.net_value > 0 %}
+                    <strong>{{ fee.net_value|money:event.currency }}</strong>
+                    {% if fee.tax_rate %}
+                        <br />
+                        <small>
+                            {% blocktrans trimmed with rate=fee.tax_rate|floatformat:-2 taxname=fee.tax_rule.name|default:s_taxes %}
+                                <strong>plus</strong> {{ rate }}% {{ taxname }}
+                            {% endblocktrans %}
+                        </small>
+                    {% endif %}
                 {% endif %}
             {% else %}
-                <strong>{{ fee.value|money:event.currency }}</strong>
-                {% if fee.tax_rate %}
-                    <br />
-                    <small>
-                        {% blocktrans trimmed with rate=fee.tax_rate|floatformat:-2 taxname=fee.tax_rule.name|default:s_taxes %}
-                            incl. {{ rate }}% {{ taxname }}
-                        {% endblocktrans %}
-                    </small>
+                {% if not event.settings.hide_free_prices or line.price > 0 %}
+                    <strong>{{ fee.value|money:event.currency }}</strong>
+                    {% if fee.tax_rate %}
+                        <br />
+                        <small>
+                            {% blocktrans trimmed with rate=fee.tax_rate|floatformat:-2 taxname=fee.tax_rule.name|default:s_taxes %}
+                                incl. {{ rate }}% {{ taxname }}
+                            {% endblocktrans %}
+                        </small>
+                    {% endif %}
                 {% endif %}
             {% endif %}
         </div>
@@ -223,24 +239,26 @@
     </div>
 {% endfor %}
 {% if event.settings.display_net_prices and cart.tax_total %}
-    <div class="row cart-row total">
-        <div class="col-md-4 col-xs-6">
-            <strong>{% trans "Net total" %}</strong>
+    {% if not event.settings.hide_free_prices or cart.net_total > 0 %}
+        <div class="row cart-row total">
+            <div class="col-md-4 col-xs-6">
+                <strong>{% trans "Net total" %}</strong>
+            </div>
+            <div class="col-md-3 col-xs-6 col-md-offset-5 price">
+                {{ cart.net_total|money:event.currency }}
+            </div>
+            <div class="clearfix"></div>
         </div>
-        <div class="col-md-3 col-xs-6 col-md-offset-5 price">
-            {{ cart.net_total|money:event.currency }}
+        <div class="row cart-row">
+            <div class="col-md-4 col-xs-6">
+                <strong>{% trans "Taxes" %}</strong>
+            </div>
+            <div class="col-md-3 col-xs-6 col-md-offset-5 price">
+                {{ cart.tax_total|money:event.currency }}
+            </div>
+            <div class="clearfix"></div>
         </div>
-        <div class="clearfix"></div>
-    </div>
-    <div class="row cart-row">
-        <div class="col-md-4 col-xs-6">
-            <strong>{% trans "Taxes" %}</strong>
-        </div>
-        <div class="col-md-3 col-xs-6 col-md-offset-5 price">
-            {{ cart.tax_total|money:event.currency }}
-        </div>
-        <div class="clearfix"></div>
-    </div>
+    {% endif %}
 {% endif %}
 <div class="row cart-row total">
     <div class="product">
@@ -249,28 +267,30 @@
     <div class="count hidden-xs hidden-sm">
         <strong>{{ cart.itemcount }}</strong>
     </div>
-    <div class="col-md-3 col-xs-6 col-md-offset-3 price">
-        <strong>{{ cart.total|money:event.currency }}</strong>
+    {% if not event.settings.hide_free_prices or cart.total > 0 %}
+        <div class="col-md-3 col-xs-6 col-md-offset-3 price">
+            <strong>{{ cart.total|money:event.currency }}</strong>
 
-        {% if editable and vouchers_exist and not cart.all_with_voucher %}
-            <br>
-            <a class="js-only apply-voucher-toggle" href="#">
-                <span class="fa fa-tag"></span> {% trans "Redeem a voucher" %}
-            </a>
-            <form action="{% eventurl event "presale:event.cart.voucher" cart_namespace=cart_namespace|default_if_none:"" %}"
-                  data-asynctask-headline="{% trans "We're applying this voucher to your cart..." %}"
-                  method="post" data-asynctask class="apply-voucher">
-                {% csrf_token %}
-                <div class="input-group">
-                    <input type="text" class="form-control" name="voucher" placeholder="{% trans "Voucher code" %}">
-                    <span class="input-group-btn">
-                        <button class="btn btn-primary" type="submit">
-                            <span class="fa fa-check"></span>
-                        </button>
-                    </span>
-                </div>
-            </form>
-        {% endif %}
-    </div>
+            {% if editable and vouchers_exist and not cart.all_with_voucher %}
+                <br>
+                <a class="js-only apply-voucher-toggle" href="#">
+                    <span class="fa fa-tag"></span> {% trans "Redeem a voucher" %}
+                </a>
+                <form action="{% eventurl event "presale:event.cart.voucher" cart_namespace=cart_namespace|default_if_none:"" %}"
+                      data-asynctask-headline="{% trans "We're applying this voucher to your cart..." %}"
+                      method="post" data-asynctask class="apply-voucher">
+                    {% csrf_token %}
+                    <div class="input-group">
+                        <input type="text" class="form-control" name="voucher" placeholder="{% trans "Voucher code" %}">
+                        <span class="input-group-btn">
+                            <button class="btn btn-primary" type="submit">
+                                <span class="fa fa-check"></span>
+                            </button>
+                        </span>
+                    </div>
+                </form>
+            {% endif %}
+        </div>
+    {% endif %}
     <div class="clearfix"></div>
 </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -58,7 +58,11 @@
                             {% elif item.min_price != item.max_price %}
                                 {{ item.min_price|money:event.currency  }} – {{ item.max_price|money:event.currency  }}
                             {% elif not item.min_price and not item.max_price %}
-                                {% trans "FREE" context "price" %}
+                                {% if event.settings.hide_free_prices %}
+                                    &nbsp;
+                                {% else %}
+                                    {% trans "FREE" context "price" %}
+                                {% endif %}
                             {% else %}
                                 {{ item.min_price|money:event.currency }}
                             {% endif %}
@@ -113,8 +117,12 @@
                                             >
                                         </div>
                                     {% elif not var.display_price.gross %}
-                                        {% trans "FREE" context "price" %}
-                                        {% elif event.settings.display_net_prices %}
+                                        {% if event.settings.hide_free_prices %}
+                                            &nbsp;
+                                        {% else %}
+                                            {% trans "FREE" context "price" %}
+                                        {% endif %}
+                                    {% elif event.settings.display_net_prices %}
                                         {{ var.display_price.net|money:event.currency }}
                                     {% else %}
                                         {{ var.display_price.gross|money:event.currency }}
@@ -227,8 +235,12 @@
                                        step="any">
                             </div>
                         {% elif not item.display_price.gross %}
-                            {% trans "FREE" context "price" %}
-                            {% elif event.settings.display_net_prices %}
+                            {% if event.settings.hide_free_prices %}
+                                &nbsp;
+                            {% else %}
+                                {% trans "FREE" context "price" %}
+                            {% endif %}
+                        {% elif event.settings.display_net_prices %}
                             {{ item.display_price.net|money:event.currency }}
                         {% else %}
                             {{ item.display_price.gross|money:event.currency }}

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -77,7 +77,11 @@
                                                 from {{ minprice }}
                                             {% endblocktrans %}
                                         {% elif not item.min_price and not item.max_price %}
-                                            {% trans "FREE" context "price" %}
+                                            {% if event.settings.hide_free_prices %}
+                                                &nbsp;
+                                            {% else %}
+                                                {% trans "FREE" context "price" %}
+                                            {% endif %}
                                         {% else %}
                                             {{ item.min_price|money:event.currency }}
                                         {% endif %}
@@ -122,7 +126,11 @@
                                                                 step="any">
                                                     </div>
                                                 {% elif not var.display_price.gross %}
-                                                    {% trans "FREE" context "price" %}
+                                                    {% if event.settings.hide_free_prices %}
+                                                        &nbsp;
+                                                    {% else %}
+                                                        {% trans "FREE" context "price" %}
+                                                    {% endif %}
                                                 {% elif event.settings.display_net_prices %}
                                                     {{ var.display_price.net|money:event.currency }}
                                                 {% else %}
@@ -228,7 +236,11 @@
                                                     step="any">
                                         </div>
                                     {% elif not item.display_price.gross %}
-                                        {% trans "FREE" context "price" %}
+                                        {% if event.settings.hide_free_prices %}
+                                            &nbsp;
+                                        {% else %}
+                                            {% trans "FREE" context "price" %}
+                                        {% endif %}
                                     {% elif event.settings.display_net_prices %}
                                         {{ item.display_price.net|money:event.currency }}
                                     {% else %}


### PR DESCRIPTION
This PR adds a display setting to hide the price for products if they are free. A few questions that popped up for me:
- Should this hide the price if only some products are free or only if all products of the event are free?
- I currently assumed that if the price is zero, the tax is also 0. Is that a valid assumption or should I update the templates to also check that the tax is also 0?
- The setting uses the term "free product" / "the product is free". I also saw the use of "free price" for the "select what you want"-price. Should I change the name of the setting?

Note: this only removes the price from the checkout process, not from tickets/invoices.