### PR TITLE
Option to hide date-block on frontpage

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -532,6 +532,7 @@ class EventSettingsSerializer(serializers.Serializer):
         'checkout_email_helptext',
         'presale_has_ended_text',
         'voucher_explanation_text',
+        'show_dates_on_frontpage',
         'show_date_to',
         'show_times',
         'show_items_outside_presale_period',

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -668,6 +668,17 @@ DEFAULTS = {
             label=_("Default language"),
         )
     },
+    'show_dates_on_frontpage': {
+        'default': 'True',
+        'type': bool,
+        'serializer_class': serializers.BooleanField,
+        'form_class': forms.BooleanField,
+        'form_kwargs': dict(
+            label=_("Show event times and dates on the ticket shop"),
+            help_text=_("If disabled, no date or time will be shown on the ticket shop's front page. This settings "
+                        "does however not affect the display in other locations."),
+        )
+    },
     'show_date_to': {
         'default': 'True',
         'type': bool,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -439,6 +439,7 @@ class EventSettingsForm(SettingsForm):
         'checkout_email_helptext',
         'presale_has_ended_text',
         'voucher_explanation_text',
+        'show_dates_on_frontpage',
         'show_date_to',
         'show_times',
         'show_items_outside_presale_period',

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -121,6 +121,7 @@
             </fieldset>
             <fieldset>
                 <legend>{% trans "Display" %}</legend>
+                {% bootstrap_field sform.show_dates_on_frontpage layout="control" %}
                 {% bootstrap_field sform.show_date_to layout="control" %}
                 {% bootstrap_field sform.show_times layout="control" %}
                 {% bootstrap_field sform.show_quota_left layout="control" %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -130,7 +130,7 @@
     {% if event_logo and request.event.settings.logo_show_title and not subevent %}
         <h2 class="content-header">
             {{ event.name }}
-            {% if not event.has_subevents %}
+            {% if event.settings.show_dates_on_frontpage and not event.has_subevents %}
                 <small>{{ event.get_date_range_display }}</small>
             {% endif %}
         </h2>

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -174,44 +174,46 @@
                         </p>
                     </div>
                 {% endif %}
-                <div class="info-row">
-                    <span class="fa fa-clock-o fa-fw"></span>
-                    <p>
-                        {{ ev.get_date_range_display }}
-                        {% if event.settings.show_times %}
-                            <br>
-                            {% blocktrans trimmed with time=ev.date_from|date:"TIME_FORMAT" %}
-                                Begin: {{ time }}
-                            {% endblocktrans %}
-                            {% if event.settings.show_date_to and ev.date_to %}
+                {% if ev.settings.show_dates_on_frontpage %}
+                    <div class="info-row">
+                        <span class="fa fa-clock-o fa-fw"></span>
+                        <p>
+                            {{ ev.get_date_range_display }}
+                            {% if event.settings.show_times %}
                                 <br>
-                                {% blocktrans trimmed with time=ev.date_to|date:"TIME_FORMAT" %}
-                                    End: {{ time }}
+                                {% blocktrans trimmed with time=ev.date_from|date:"TIME_FORMAT" %}
+                                    Begin: {{ time }}
                                 {% endblocktrans %}
+                                {% if event.settings.show_date_to and ev.date_to %}
+                                    <br>
+                                    {% blocktrans trimmed with time=ev.date_to|date:"TIME_FORMAT" %}
+                                        End: {{ time }}
+                                    {% endblocktrans %}
+                                {% endif %}
                             {% endif %}
-                        {% endif %}
-                        {% if ev.date_admission %}
+                            {% if ev.date_admission %}
+                                <br>
+                                {% if ev.date_admission|date:"SHORT_DATE_FORMAT" == ev.date_from|date:"SHORT_DATE_FORMAT" %}
+                                    {% blocktrans trimmed with time=ev.date_admission|date:"TIME_FORMAT" %}
+                                        Admission: {{ time }}
+                                    {% endblocktrans %}
+                                {% else %}
+                                    {% blocktrans trimmed with datetime=ev.date_admission|date:"SHORT_DATETIME_FORMAT" %}
+                                        Admission: {{ datetime }}
+                                    {% endblocktrans %}
+                                {% endif %}
+                            {% endif %}
                             <br>
-                            {% if ev.date_admission|date:"SHORT_DATE_FORMAT" == ev.date_from|date:"SHORT_DATE_FORMAT" %}
-                                {% blocktrans trimmed with time=ev.date_admission|date:"TIME_FORMAT" %}
-                                    Admission: {{ time }}
-                                {% endblocktrans %}
+                            {% if subevent %}
+                                <a href="{% eventurl event "presale:event.ical.download" subevent=subevent.pk %}">
                             {% else %}
-                                {% blocktrans trimmed with datetime=ev.date_admission|date:"SHORT_DATETIME_FORMAT" %}
-                                    Admission: {{ datetime }}
-                                {% endblocktrans %}
+                                <a href="{% eventurl event "presale:event.ical.download" %}">
                             {% endif %}
-                        {% endif %}
-                        <br>
-                        {% if subevent %}
-                            <a href="{% eventurl event "presale:event.ical.download" subevent=subevent.pk %}">
-                        {% else %}
-                            <a href="{% eventurl event "presale:event.ical.download" %}">
-                        {% endif %}
-                            {% trans "Add to Calendar" %}
-                        </a>
-                    </p>
-                </div>
+                                {% trans "Add to Calendar" %}
+                            </a>
+                        </p>
+                    </div>
+                {% endif %}
 
             </div>
 

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -66,19 +66,23 @@
                     <td>
                         <a href="{{ url }}">{{ e.name }}</a>
                     </td>
-                    <td>
-                        {{ e.daterange|default:e.get_date_range_display }}
-                        {% if e.settings.show_times and not e.has_subevents %}
-                            {% timezone e.tzname %}
-                                <br><small class="text-muted">
-                                    {{ e.date_from|date:"TIME_FORMAT" }}
-                                    {% if e.settings.show_date_to and e.date_to and e.date_to.date == e.date_from.date %}
-                                        – {{ e.date_to|date:"TIME_FORMAT" }}
-                                    {% endif %}
-                                </small>
-                            {% endtimezone %}
-                        {% endif %}
-                    </td>
+                    {% if e.settings.show_dates_on_frontpage %}
+                        <td>
+                            {{ e.daterange|default:e.get_date_range_display }}
+                            {% if e.settings.show_times and not e.has_subevents %}
+                                {% timezone e.tzname %}
+                                    <br><small class="text-muted">
+                                        {{ e.date_from|date:"TIME_FORMAT" }}
+                                        {% if e.settings.show_date_to and e.date_to and e.date_to.date == e.date_from.date %}
+                                            – {{ e.date_to|date:"TIME_FORMAT" }}
+                                        {% endif %}
+                                    </small>
+                                {% endtimezone %}
+                            {% endif %}
+                        </td>
+                    {% else %}
+                        <td>&nbsp;</td>
+                    {% endif %}
                     <td>
                         {% if e.has_subevents %}
                             <span class="label label-default">{% trans "Event series" %}</span>


### PR DESCRIPTION
When enabled, the date-block will be completely removed from the ticketshop start page and the (public) organizer list view.

In the backend, the date-block is always displayed, no matter the setting.