### PR TITLE
Subclass MultipleChoiceField to serialize to list

### DIFF
--- a/src/pretix/api/serializers/fields.py
+++ b/src/pretix/api/serializers/fields.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
 
-class MultipleChoiceField(serializers.MultipleChoiceField):
+class ListMultipleChoiceField(serializers.MultipleChoiceField):
     def to_internal_value(self, data):
         return list(super().to_internal_value(data))

--- a/src/pretix/api/serializers/fields.py
+++ b/src/pretix/api/serializers/fields.py
@@ -1,6 +1,29 @@
+from collections import OrderedDict
+
 from rest_framework import serializers
+
+
+def remove_duplicates_from_list(data):
+    return list(OrderedDict.fromkeys(data))
 
 
 class ListMultipleChoiceField(serializers.MultipleChoiceField):
     def to_internal_value(self, data):
-        return list(super().to_internal_value(data))
+        if isinstance(data, str) or not hasattr(data, '__iter__'):
+            self.fail('not_a_list', input_type=type(data).__name__)
+        if not self.allow_empty and len(data) == 0:
+            self.fail('empty')
+
+        internal_value_data = [
+            super(serializers.MultipleChoiceField, self).to_internal_value(item)
+            for item in data
+        ]
+
+        return remove_duplicates_from_list(internal_value_data)
+
+    def to_representation(self, value):
+        representation_data = [
+            self.choice_strings_to_values.get(str(item), item) for item in value
+        ]
+
+        return remove_duplicates_from_list(representation_data)

--- a/src/pretix/api/serializers/fields.py
+++ b/src/pretix/api/serializers/fields.py
@@ -1,0 +1,6 @@
+from rest_framework import serializers
+
+
+class MultipleChoiceField(serializers.MultipleChoiceField):
+    def to_internal_value(self, data):
+        return list(super().to_internal_value(data))

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -19,7 +19,7 @@ from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 from i18nfield.strings import LazyI18nString
 from rest_framework import serializers
 
-from pretix.api.serializers.fields import MultipleChoiceField
+from pretix.api.serializers.fields import ListMultipleChoiceField
 from pretix.api.serializers.i18n import I18nField
 from pretix.base.models.tax import TaxRule
 from pretix.base.reldate import (
@@ -640,7 +640,7 @@ DEFAULTS = {
     'locales': {
         'default': json.dumps([settings.LANGUAGE_CODE]),
         'type': list,
-        'serializer_class': MultipleChoiceField,
+        'serializer_class': ListMultipleChoiceField,
         'serializer_kwargs': dict(
             choices=settings.LANGUAGES,
             required=True,

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -19,6 +19,7 @@ from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 from i18nfield.strings import LazyI18nString
 from rest_framework import serializers
 
+from pretix.api.serializers.fields import MultipleChoiceField
 from pretix.api.serializers.i18n import I18nField
 from pretix.base.models.tax import TaxRule
 from pretix.base.reldate import (
@@ -639,7 +640,7 @@ DEFAULTS = {
     'locales': {
         'default': json.dumps([settings.LANGUAGE_CODE]),
         'type': list,
-        'serializer_class': serializers.MultipleChoiceField,
+        'serializer_class': MultipleChoiceField,
         'serializer_kwargs': dict(
             choices=settings.LANGUAGES,
             required=True,

--- a/src/tests/api/test_events.py
+++ b/src/tests/api/test_events.py
@@ -1032,6 +1032,32 @@ def test_patch_event_settings(token_client, organizer, event):
     )
     assert resp.status_code == 405
 
+    locales = event.settings.locales
+
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        {
+            'locales': event.settings.locales + ['de', 'de-informal'],
+        },
+        format='json'
+    )
+    assert resp.status_code == 200
+    assert set(resp.data['locales']) == set(locales + ['de', 'de-informal'])
+    event.settings.flush()
+    assert set(event.settings.locales) == set(locales + ['de', 'de-informal'])
+
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
+        {
+            'locales': locales,
+        },
+        format='json'
+    )
+    assert resp.status_code == 200
+    assert set(resp.data['locales']) == set(locales)
+    event.settings.flush()
+    assert set(event.settings.locales) == set(locales)
+
 
 @pytest.mark.django_db
 def test_patch_event_settings_validation(token_client, organizer, event):


### PR DESCRIPTION
The rest frameworks `serializers.MultipleChoiceField` `to_internal_value` functions returns a set instance[¹]. hierarkey did not like that which lead to internal server errors. Since the code generally assumes that the value of those fields is a list I subclassed MultipleChoiceField so that it now returns a `list` and added a test for that

[¹]: https://www.django-rest-framework.org/api-guide/fields/#multiplechoicefield