### PR TITLE
Send widget_data in voucher redeem request.

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -722,6 +722,7 @@ Vue.component('pretix-widget-event-form', {
         + '<input class="pretix-widget-voucher-input" type="text" v-model="$parent.voucher" name="voucher" placeholder="'+strings.voucher_code+'">'
         + '</div>'
         + '<input type="hidden" name="subevent" :value="$root.subevent" />'
+        + '<input type="hidden" name="widget_data" :value="$root.widget_data_json" />'
         + '<input type="hidden" name="locale" value="' + lang + '" />'
         + '<div class="pretix-widget-voucher-button-wrap">'
         + '<button @click="$parent.redeem">' + strings.redeem + '</button>'


### PR DESCRIPTION
When the checkout process on mobile starts with redeeming a voucher the widget data is not sent. This change adds a hidden field which sends adds the widget data in de GET request, similar to the pretix-button variant of the widget. See [src/pretix/static/pretixpresale/js/widget/widget.js#1047](https://github.com/pretix/pretix/blob/359c46b8e28c8c5e61bedceb6c1723f5ce313b79/src/pretix/static/pretixpresale/js/widget/widget.js#L1047) for reference.