### PR TITLE
Allow creating question with dependency_question=None

### DIFF
--- a/src/pretix/api/serializers/item.py
+++ b/src/pretix/api/serializers/item.py
@@ -287,8 +287,8 @@ class QuestionSerializer(I18nAwareModelSerializer):
         if value:
             if value.type not in (Question.TYPE_CHOICE, Question.TYPE_BOOLEAN, Question.TYPE_CHOICE_MULTIPLE):
                 raise ValidationError('Question dependencies can only be set to boolean or choice questions.')
-        if value == self.instance:
-            raise ValidationError('A question cannot depend on itself.')
+            if value == self.instance:
+                raise ValidationError('A question cannot depend on itself.')
         return value
 
     def validate(self, data):


### PR DESCRIPTION
When creating a new question via the API and sending
```
  "dependency_question": null,
```
which even the pretix documentation does[1], the API responded with a 400 Bad Request error. This was caused by the serializer checking that the dependency value is not the same as `self.instance`. However `self.instance` is `None` is the object is created not updated[2]. I moved the check inside the section that checked that `value` is not `None` and added recursion tests.

[1]: https://docs.pretix.eu/en/latest/api/resources/questions.html#post--api-v1-organizers-(organizer)-events-(event)-questions-
[2]: https://www.django-rest-framework.org/api-guide/serializers/#accessing-the-initial-data-and-instance