### PR TITLE
Show checkbox if items per order limit is 1

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -146,7 +146,7 @@
                                     </div>
                                     {% elif var.cached_availability.0 == 100 %}
                                     <div class="col-md-2 col-xs-6 availability-box available">
-										{% if item.max_per_order == 1 %}
+										{% if item.order_max == 1 %}
                                             <label class="item-checkbox-label">
                                                 <input type="checkbox" value="1"
                                                        {% if not ev.presale_is_running %}disabled{% endif %}
@@ -260,7 +260,7 @@
                         </div>
                         {% elif item.cached_availability.0 == 100 %}
                         <div class="col-md-2 col-xs-6 availability-box available">
-							{% if item.max_per_order == 1 %}
+							{% if item.order_max == 1 %}
                                 <label class="item-checkbox-label">
                                     <input type="checkbox" value="1" {% if itemnum == 1 %}checked{% endif %}
                                            {% if not ev.presale_is_running %}disabled{% endif %}


### PR DESCRIPTION
If the "items per order" limit is 1 but the items to not have a limit set a number input field is shown instead of a checkbox. The new code is identical to that is already done in the `voucher.html`-template