### PR TITLE
Do not validate event creation form on back button

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/events/create_base.html
+++ b/src/pretix/control/templates/pretixcontrol/events/create_base.html
@@ -20,7 +20,7 @@
                 </button>
                 {% if wizard.steps.prev %}
                     <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}"
-                            class="btn btn-default btn-lg pull-left flip">
+                            class="btn btn-default btn-lg pull-left flip" formnovalidate>
                         {% trans "Back" %}
                     </button>
                 {% endif %}


### PR DESCRIPTION
`django-formtool`s `SessionWizardView`does not store the entered form if "wizard_goto_step" is used[1]. Therefore it is not needed to validate the data, which currently lead to confusion when we tried to create an event but wanted to change things in the previous step.

[1]: https://django-formtools.readthedocs.io/en/latest/wizard.html#formtools.wizard.views.WizardView.render_goto_step