### PR TITLE
Render remaining badges onto new page even if it doesn't fill the page

### DIFF
--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -173,6 +173,9 @@ def render_pdf(event, positions, opt):
             render_page(pagebuffer)
             pagebuffer.clear()
 
+    if pagebuffer:
+        render_page(pagebuffer)
+
     output_pdf_writer.addMetadata({
         '/Title': 'Badges',
         '/Creator': 'pretix',

--- a/src/tests/plugins/badges/test_pdf.py
+++ b/src/tests/plugins/badges/test_pdf.py
@@ -68,3 +68,17 @@ def test_generate_pdf(env):
     assert ftype == 'application/pdf'
     pdf = PdfFileReader(BytesIO(buf))
     assert pdf.numPages == 2
+
+@pytest.mark.django_db
+def test_generate_pdf_multi(env):
+    event, order, shirt = env
+    event.badge_layouts.create(name="Default", default=True)
+    e = BadgeExporter(event)
+    fname, ftype, buf = e.render({
+        'items': [shirt.pk],
+        'rendering': 'a4_a6l',
+        'include_pending': True
+    })
+    assert ftype == 'application/pdf'
+    pdf = PdfFileReader(BytesIO(buf))
+    assert pdf.numPages == 1


### PR DESCRIPTION
When the number of badges was not a multiple of the badges per page, the last few badges were not rendered. This PR produces badge pdfs where the last page has some empty slots.