### PR TITLE
Send checkin list mapping in event_copy_data signal

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -622,8 +622,10 @@ class Event(EventMixin, LoggedModel):
             q.dependency_question = question_map[q.dependency_question_id]
             q.save(update_fields=['dependency_question'])
 
+        checkin_list_map = {}
         for cl in other.checkin_lists.filter(subevent__isnull=True).prefetch_related('limit_products'):
             items = list(cl.limit_products.all())
+            checkin_list_map[cl.pk] = cl
             cl.pk = None
             cl.event = self
             cl.save()
@@ -678,7 +680,7 @@ class Event(EventMixin, LoggedModel):
         event_copy_data.send(
             sender=self, other=other,
             tax_map=tax_map, category_map=category_map, item_map=item_map, variation_map=variation_map,
-            question_map=question_map
+            question_map=question_map, checkin_list_map=checkin_list_map
         )
 
     def get_payment_providers(self, cached=False) -> dict:

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -482,7 +482,7 @@ As with all event-plugin signals, the ``sender`` keyword argument will contain t
 """
 
 event_copy_data = EventPluginSignal(
-    providing_args=["other", "tax_map", "category_map", "item_map", "question_map", "variation_map"]
+    providing_args=["other", "tax_map", "category_map", "item_map", "question_map", "variation_map", "checkin_list_map"]
 )
 """
 This signal is sent out when a new event is created as a clone of an existing event, i.e.
@@ -494,9 +494,9 @@ but you might need to modify that data.
 
 The ``sender`` keyword argument will contain the event of the **new** event. The ``other``
 keyword argument will contain the event to **copy from**. The keyword arguments
-``tax_map``, ``category_map``, ``item_map``, ``question_map``, and ``variation_map`` contain
-mappings from object IDs in the original event to objects in the new event of the respective
-types.
+``tax_map``, ``category_map``, ``item_map``, ``question_map``, ``variation_map`` and
+``checkin_list_map`` contain mappings from object IDs in the original event to objects
+in the new event of the respective types.
 """
 
 item_copy_data = EventPluginSignal(


### PR DESCRIPTION
The signal already sends a map of tax, category, item etc ids to their new items but not for checkin lists.