### PR TITLE
Allow to issue gift card refunds when cancelling whole events

### DIFF
--- a/src/pretix/base/services/cancelevent.py
+++ b/src/pretix/base/services/cancelevent.py
@@ -86,7 +86,7 @@ def cancel_event(self, event: Event, subevent: int, auto_refund: bool, keep_fee_
                  keep_fee_percentage: str, keep_fees: list=None, manual_refund: bool=False,
                  send: bool=False, send_subject: dict=None, send_message: dict=None,
                  send_waitinglist: bool=False, send_waitinglist_subject: dict={}, send_waitinglist_message: dict={},
-                 user: int=None):
+                 user: int=None, refund_as_giftcard: bool=False):
     send_subject = LazyI18nString(send_subject)
     send_message = LazyI18nString(send_message)
     send_waitinglist_subject = LazyI18nString(send_waitinglist_subject)
@@ -168,7 +168,8 @@ def cancel_event(self, event: Event, subevent: int, auto_refund: bool, keep_fee_
 
             try:
                 if auto_refund:
-                    _try_auto_refund(o.pk, manual_refund=manual_refund, allow_partial=True, source=OrderRefund.REFUND_SOURCE_ADMIN)
+                    _try_auto_refund(o.pk, manual_refund=manual_refund, allow_partial=True,
+                                     source=OrderRefund.REFUND_SOURCE_ADMIN, refund_as_giftcard=refund_as_giftcard)
             finally:
                 if send:
                     _send_mail(o, send_subject, send_message, subevent, refund_amount, user, o.positions.all())

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -555,20 +555,10 @@ class EventCancelForm(forms.Form):
                     'with different orders or issuing gift cards.')
     )
     refund_as_giftcard = forms.BooleanField(
-        label=_('Refund order value to a gift card instead'),
+        label=_('Refund order value to a gift card instead instead of the original payment method'),
         widget=forms.CheckboxInput(attrs={'data-display-dependency': '#id_auto_refund'}),
         initial=False,
         required=False,
-        help_text='{}'
-                  '<div class="alert alert-legal">'
-                  '<strong>{}:</strong> {}'
-                  '</div>'.format(
-            _('If checked, all refunds will be issued as gift cards instead of a payment to the original payment '
-              'method. When this functionality is used, you will need to explain your customers how to access it.'),
-            _('Warning'),
-            _('Depending on your location, refunding a customer with a gift card without their consent might be '
-              'illegal. If in doubt, consult a lawyer or refrain from issuing refunds on gift cards.')
-        )
     )
     keep_fee_fixed = forms.DecimalField(
         label=_("Keep a fixed cancellation fee"),

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -554,6 +554,22 @@ class EventCancelForm(forms.Form):
                     'manual refund to-do list. Do not check if you want to refund some of the orders by offsetting '
                     'with different orders or issuing gift cards.')
     )
+    refund_as_giftcard = forms.BooleanField(
+        label=_('Refund order value to a gift card instead'),
+        widget=forms.CheckboxInput(attrs={'data-display-dependency': '#id_auto_refund'}),
+        initial=False,
+        required=False,
+        help_text='{}'
+                  '<div class="alert alert-legal">'
+                  '<strong>{}:</strong> {}'
+                  '</div>'.format(
+            _('If checked, all refunds will be issued as gift cards instead of a payment to the original payment '
+              'method. When this functionality is used, you will need to explain your customers how to access it.'),
+            _('Warning'),
+            _('Depending on your location, refunding a customer with a gift card without their consent might be '
+              'illegal. If in doubt, consult a lawyer or refrain from issuing refunds on gift cards.')
+        )
+    )
     keep_fee_fixed = forms.DecimalField(
         label=_("Keep a fixed cancellation fee"),
         max_digits=10, decimal_places=2,

--- a/src/pretix/control/templates/pretixcontrol/orders/cancel.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/cancel.html
@@ -34,6 +34,7 @@
             <legend>{% trans "Refund options" %}</legend>
             {% bootstrap_field form.auto_refund layout="control" %}
             {% bootstrap_field form.manual_refund layout="control" %}
+            {% bootstrap_field form.refund_as_giftcard layout="control" %}
             {% bootstrap_field form.keep_fee_fixed layout="control" %}
             {% bootstrap_field form.keep_fee_percentage layout="control" %}
             {% bootstrap_field form.keep_fees layout="control" %}
@@ -43,6 +44,13 @@
             {% bootstrap_field form.send layout="control" %}
             {% bootstrap_field form.send_subject layout="horizontal" %}
             {% bootstrap_field form.send_message layout="horizontal" %}
+            <div class="alert alert-info" data-display-dependency="#id_refund_as_giftcard">
+                {% blocktrans trimmed %}
+                    Since you are refunding your customers orders to gift cards, you should explain to them how to
+                    access their giftcards. The easiest way to do this, is to include an explanation and a link to
+                    their order using the here provided email functionality.
+                {% endblocktrans %}
+            </div>
         </fieldset>
         <fieldset>
             <legend>{% trans "Waiting list" %}</legend>

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -2008,6 +2008,8 @@ class EventCancel(EventPermissionRequiredMixin, AsyncAction, FormView):
             self.request.event.pk,
             subevent=form.cleaned_data['subevent'].pk if form.cleaned_data.get('subevent') else None,
             auto_refund=form.cleaned_data.get('auto_refund'),
+            manual_refund=form.cleaned_data.get('manual_refund'),
+            refund_as_giftcard=form.cleaned_data.get('refund_as_giftcard'),
             keep_fee_fixed=form.cleaned_data.get('keep_fee_fixed'),
             keep_fee_percentage=form.cleaned_data.get('keep_fee_percentage'),
             keep_fees=form.cleaned_data.get('keep_fees'),


### PR DESCRIPTION
Also fixes missing `manual_refund`-property in call to cancellation-task.