### PR TITLE
Add register_event_fonts signal

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -35,7 +35,7 @@ from reportlab.platypus import Paragraph
 
 from pretix.base.i18n import language
 from pretix.base.invoice import ThumbnailingImageReader
-from pretix.base.models import Order, OrderPosition
+from pretix.base.models import Event, Order, OrderPosition
 from pretix.base.settings import PERSON_NAME_SCHEMES
 from pretix.base.signals import layout_text_variables
 from pretix.base.templatetags.money import money_filter
@@ -375,13 +375,13 @@ class Renderer:
             self.bg_pdf = None
 
     @classmethod
-    def _register_fonts(cls):
+    def _register_fonts(cls, event: Event=None):
         pdfmetrics.registerFont(TTFont('Open Sans', finders.find('fonts/OpenSans-Regular.ttf')))
         pdfmetrics.registerFont(TTFont('Open Sans I', finders.find('fonts/OpenSans-Italic.ttf')))
         pdfmetrics.registerFont(TTFont('Open Sans B', finders.find('fonts/OpenSans-Bold.ttf')))
         pdfmetrics.registerFont(TTFont('Open Sans B I', finders.find('fonts/OpenSans-BoldItalic.ttf')))
 
-        for family, styles in get_fonts().items():
+        for family, styles in get_fonts(event).items():
             pdfmetrics.registerFont(TTFont(family, finders.find(styles['regular']['truetype'])))
             if 'italic' in styles:
                 pdfmetrics.registerFont(TTFont(family + ' I', finders.find(styles['italic']['truetype'])))

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -560,7 +560,7 @@ class EventSettingsForm(SettingsForm):
             del self.fields['frontpage_subevent_ordering']
             del self.fields['event_list_type']
         self.fields['primary_font'].choices += [
-            (a, {"title": a, "data": v}) for a, v in get_fonts().items()
+            (a, {"title": a, "data": v}) for a, v in get_fonts(self.event).items()
         ]
 
 

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -6,7 +6,7 @@
 {% load formset_tags %}
 {% block custom_header %}
     {{ block.super }}
-    <link type="text/css" rel="stylesheet" href="{% url "control:pdf.css" %}">
+    <link type="text/css" rel="stylesheet" href="{% url "control:pdf.css" organizer=request.organizer.slug event=request.event.slug %}">
 {% endblock %}
 {% block inside %}
     <h1>{% trans "General settings" %}</h1>

--- a/src/pretix/control/templates/pretixcontrol/pdf/index.html
+++ b/src/pretix/control/templates/pretixcontrol/pdf/index.html
@@ -8,7 +8,7 @@
     {% compress css %}
         <link type="text/css" rel="stylesheet" href="{% static "pretixcontrol/scss/pdfeditor.css" %}">
     {% endcompress %}
-    <link type="text/css" rel="stylesheet" href="{% url "control:pdf.css" %}">
+    <link type="text/css" rel="stylesheet" href="{% url "control:pdf.css" organizer=request.organizer.slug event=request.event.slug %}">
 {% endblock %}
 {% block content %}
     <h1>

--- a/src/pretix/control/views/pdf.py
+++ b/src/pretix/control/views/pdf.py
@@ -213,7 +213,7 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx['fonts'] = get_fonts()
+        ctx['fonts'] = get_fonts(self.request.event)
         ctx['pdf'] = self.get_current_background()
         ctx['variables'] = self.get_variables()
         ctx['layout'] = json.dumps(self.get_current_layout())
@@ -228,7 +228,7 @@ class FontsCSSView(TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx['fonts'] = get_fonts()
+        ctx['fonts'] = get_fonts(self.request.event if 'event' in self.request else None)
         return ctx
 
 

--- a/src/pretix/plugins/ticketoutputpdf/signals.py
+++ b/src/pretix/plugins/ticketoutputpdf/signals.py
@@ -18,7 +18,7 @@ from pretix.plugins.ticketoutputpdf.models import (
     TicketLayout, TicketLayoutItem,
 )
 from pretix.presale.style import (  # NOQA: legacy import
-    get_fonts, register_fonts,
+    get_fonts, register_event_fonts, register_fonts,
 )
 
 

--- a/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
+++ b/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
@@ -57,7 +57,7 @@ class PdfTicketOutput(BaseTicketOutput):
         return self.event._ticketoutputpdf_cache_default_layout
 
     def _register_fonts(self):
-        Renderer._register_fonts()
+        Renderer._register_fonts(self.event)
 
     def _draw_page(self, layout: TicketLayout, op: OrderPosition, order: Order):
         buffer = BytesIO()

--- a/src/pretix/plugins/ticketoutputpdf/views.py
+++ b/src/pretix/plugins/ticketoutputpdf/views.py
@@ -234,7 +234,7 @@ class LayoutEditorView(BaseEditorView):
         return static('pretixpresale/pdf/ticket_default_a4.pdf')
 
     def generate(self, op: OrderPosition, override_layout=None, override_background=None):
-        Renderer._register_fonts()
+        Renderer._register_fonts(self.request.event)
 
         buffer = BytesIO()
         if override_background:


### PR DESCRIPTION
This adds a copycat signal `register_event_fonts`, that behaves the same as `register_fonts` - except that it scopes to individual events.

It works for server-local PDF generation and webfont usage - however it will not work in our apps. I am not sure, if using a font that is not bundled with the apps will break device-local PDF-generation or not.

I guess, we could add a warning in the PDF-editor regarding this...