### PR TITLE
Refactor quota calculation

### DIFF
--- a/src/pretix/api/views/item.py
+++ b/src/pretix/api/views/item.py
@@ -20,6 +20,7 @@ from pretix.base.models import (
     CartPosition, Item, ItemAddOn, ItemBundle, ItemCategory, ItemVariation,
     Question, QuestionOption, Quota,
 )
+from pretix.base.services.quotas import QuotaAvailability
 from pretix.helpers.dicts import merge_dicts
 
 with scopes_disabled():
@@ -533,14 +534,17 @@ class QuotaViewSet(ConditionalListView, viewsets.ModelViewSet):
     def availability(self, request, *args, **kwargs):
         quota = self.get_object()
 
-        avail = quota.availability()
+        q = QuotaAvailability()
+        q.queue(quota)
+        q.compute()
+        avail = q.results[quota]
 
         data = {
-            'paid_orders': quota.count_paid_orders(),
-            'pending_orders': quota.count_pending_orders(),
-            'blocking_vouchers': quota.count_blocking_vouchers(),
-            'cart_positions': quota.count_in_cart(),
-            'waiting_list': quota.count_waiting_list_pending(),
+            'paid_orders': q.count_paid_orders[quota],
+            'pending_orders': q.count_pending_orders[quota],
+            'blocking_vouchers': q.count_vouchers[quota],
+            'cart_positions': q.count_cart[quota],
+            'waiting_list': q.count_pending_orders[quota],
             'available_number': avail[1],
             'available': avail[0] == Quota.AVAILABILITY_OK,
             'total_size': quota.size,

--- a/src/pretix/api/views/item.py
+++ b/src/pretix/api/views/item.py
@@ -534,17 +534,17 @@ class QuotaViewSet(ConditionalListView, viewsets.ModelViewSet):
     def availability(self, request, *args, **kwargs):
         quota = self.get_object()
 
-        q = QuotaAvailability()
-        q.queue(quota)
-        q.compute()
-        avail = q.results[quota]
+        qa = QuotaAvailability()
+        qa.queue(quota)
+        qa.compute()
+        avail = qa.results[quota]
 
         data = {
-            'paid_orders': q.count_paid_orders[quota],
-            'pending_orders': q.count_pending_orders[quota],
-            'blocking_vouchers': q.count_vouchers[quota],
-            'cart_positions': q.count_cart[quota],
-            'waiting_list': q.count_pending_orders[quota],
+            'paid_orders': qa.count_paid_orders[quota],
+            'pending_orders': qa.count_pending_orders[quota],
+            'blocking_vouchers': qa.count_vouchers[quota],
+            'cart_positions': qa.count_cart[quota],
+            'waiting_list': qa.count_pending_orders[quota],
             'available_number': avail[1],
             'available': avail[0] == Quota.AVAILABILITY_OK,
             'total_size': quota.size,

--- a/src/pretix/base/exporters/orderlist.py
+++ b/src/pretix/base/exporters/orderlist.py
@@ -518,20 +518,20 @@ class QuotaListExporter(ListExporter):
         yield headers
 
         quotas = list(self.event.quotas.all())
-        q = QuotaAvailability(full_results=True)
-        q.queue(*quotas)
-        q.compute()
+        qa = QuotaAvailability(full_results=True)
+        qa.queue(*quotas)
+        qa.compute()
 
         for quota in quotas:
-            avail = q.results[quota]
+            avail = qa.results[quota]
             row = [
                 quota.name,
                 _('Infinite') if quota.size is None else quota.size,
-                q.count_paid_orders[quota],
-                q.count_pending_orders[quota],
-                q.count_vouchers[quota],
-                q.count_cart[quota],
-                q.count_waitinglist[quota],
+                qa.count_paid_orders[quota],
+                qa.count_pending_orders[quota],
+                qa.count_vouchers[quota],
+                qa.count_cart[quota],
+                qa.count_waitinglist[quota],
                 _('Infinite') if avail[1] is None else avail[1]
             ]
             yield row

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -214,8 +214,10 @@ class EventMixin:
         vars_reserved = set()
         items_gone = set()
         vars_gone = set()
+
+        r = self.getattr('_quota_cache', {})
         for q in self.active_quotas:
-            res = q.availability(allow_cache=True)
+            res = r[q] if q in r else q.availability(allow_cache=True)
 
             if res[0] == Quota.AVAILABILITY_OK:
                 if q.active_items:

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -215,7 +215,7 @@ class EventMixin:
         items_gone = set()
         vars_gone = set()
 
-        r = self.getattr('_quota_cache', {})
+        r = getattr(self, '_quota_cache', {})
         for q in self.active_quotas:
             res = r[q] if q in r else q.availability(allow_cache=True)
 

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1393,10 +1393,10 @@ class Quota(LoggedModel):
 
         if _cache is not None and self.pk in _cache:
             return _cache[self.pk]
-        q = QuotaAvailability(count_waitinglist=count_waitinglist, early_out=False)
-        q.queue(self)
-        q.compute(now_dt=now_dt)
-        res = q.results[self]
+        qa = QuotaAvailability(count_waitinglist=count_waitinglist, early_out=False)
+        qa.queue(self)
+        qa.compute(now_dt=now_dt)
+        res = qa.results[self]
 
         if _cache is not None:
             _cache[self.pk] = res

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1392,10 +1392,9 @@ class Quota(LoggedModel):
 
         if _cache is not None and self.pk in _cache:
             return _cache[self.pk]
-        now_dt = now_dt or now()
         q = QuotaAvailability(count_waitinglist=count_waitinglist, early_out=False)
         q.queue(self)
-        q.compute()
+        q.compute(now_dt=now_dt)
         res = q.results[self]
 
         if _cache is not None:

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1348,6 +1348,7 @@ class Quota(LoggedModel):
             self.event.cache.clear()
 
     def save(self, *args, **kwargs):
+        # This is *not* called when the db-level cache is upated, since we use bulk_update there
         clear_cache = kwargs.pop('clear_cache', True)
         super().save(*args, **kwargs)
         if self.event and clear_cache:

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -25,6 +25,7 @@ from pretix.base.reldate import RelativeDateWrapper
 from pretix.base.services.checkin import _save_answers
 from pretix.base.services.locking import LockTimeoutException, NoLockManager
 from pretix.base.services.pricing import get_price
+from pretix.base.services.quotas import QuotaAvailability
 from pretix.base.services.tasks import ProfiledEventTask
 from pretix.base.settings import PERSON_NAME_SCHEMES
 from pretix.base.signals import validate_cart_addons
@@ -728,10 +729,13 @@ class CartManager:
 
     def _get_quota_availability(self):
         quotas_ok = defaultdict(int)
+        qa = QuotaAvailability()
+        qa.queue(*[k for k, v in self._quota_diff.items() if v > 0])
+        qa.compute(now_dt=self.now_dt)
         for quota, count in self._quota_diff.items():
             if count <= 0:
                 quotas_ok[quota] = 0
-            avail = quota.availability(self.now_dt)
+            avail = qa.results[quota]
             if avail[1] is not None and avail[1] < count:
                 quotas_ok[quota] = min(count, avail[1])
             else:

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -735,6 +735,7 @@ class CartManager:
         for quota, count in self._quota_diff.items():
             if count <= 0:
                 quotas_ok[quota] = 0
+                break
             avail = qa.results[quota]
             if avail[1] is not None and avail[1] < count:
                 quotas_ok[quota] = min(count, avail[1])

--- a/src/pretix/base/services/quotas.py
+++ b/src/pretix/base/services/quotas.py
@@ -1,15 +1,300 @@
+import sys
+from collections import Counter, defaultdict
 from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Max, Q
+from django.db.models import Count, F, Func, Max, Q, Sum
 from django.dispatch import receiver
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
-from pretix.base.models import Event, LogEntry
+from pretix.base.models import (
+    CartPosition, Event, LogEntry, Order, OrderPosition, Quota, Voucher,
+    WaitingListEntry,
+)
 from pretix.celery_app import app
 
-from ..signals import periodic_task
+from ..signals import periodic_task, quota_availability
+
+
+class QuotaAvailability:
+    """
+    This special object allows so tompute the availability of quotas and inspect their results.
+    Initialize, add quotas with .queue(quota), compute with .compute() and access results.
+    """
+
+    def __init__(self, count_waitinglist=True, ignore_closed=False, full_results=False, early_out=True):
+        self._queue = []
+        self._count_waitinglist = count_waitinglist
+        self._ignore_closed = ignore_closed
+        self._full_results = full_results
+        self._item_to_quota = defaultdict(list)
+        self._var_to_quota = defaultdict(list)
+        self._early_out = True
+        self._quota_objects = {}
+        self.results = {}
+        self.count_paid_orders = defaultdict(int)
+        self.count_pending_orders = defaultdict(int)
+        self.count_vouchers = defaultdict(int)
+        self.count_waitinglist = defaultdict(int)
+        self.count_cart = defaultdict(int)
+
+        self.sizes = {}
+
+    def queue(self, *quota):
+        self._queue += quota
+
+    def compute(self, now_dt=None):
+        now_dt = now_dt or now()
+        quotas = list(self._queue)
+        quotas_original = list(self._queue)
+        self._queue.clear()
+
+        self._compute(quotas, now_dt)
+
+        for q in quotas_original:
+            for recv, resp in quota_availability.send(sender=q.event, quota=quotas_original, result=self.results[q],
+                                                      count_waitinglist=self.count_waitinglist):
+                self.results[q] = resp
+
+        self._close(quotas)
+        self._write_cache(quotas, now_dt)
+
+    def _write_cache(self, quotas, now_dt):
+        events = {q.event for q in quotas}
+        for e in events:
+            e.cache.delete('item_quota_cache')
+        for q in quotas:
+            rewrite_cache = self._count_waitinglist and (
+                not q.cache_is_hot(now_dt) or self.results[q][0] > q.cached_availability_state
+            )
+            if rewrite_cache:
+                q.cached_availability_state = self.results[q][0]
+                q.cached_availability_number = self.results[q][1]
+                q.cached_availability_time = now_dt
+                if q.size is None:
+                    q.cached_availability_paid_orders = q.count_paid_orders[self]
+                q.save(
+                    update_fields=[
+                        'cached_availability_state', 'cached_availability_number', 'cached_availability_time',
+                        'cached_availability_paid_orders'
+                    ],
+                    clear_cache=False,
+                    using='default'
+                )
+
+    def _close(self, quotas):
+        for q in quotas:
+            if self.results[q][0] <= Quota.AVAILABILITY_ORDERED and q.close_when_sold_out and not q.closed:
+                q.closed = True
+                q.save(update_fields=['closed'])
+                q.log_action('pretix.event.quota.closed')
+
+    def _compute(self, quotas, now_dt):
+        # Quotas we want to look at now
+        self.sizes.update({q: q.size for q in quotas})
+
+        # Some helpful caches
+        self._quota_objects.update({q.pk: q for q in quotas})
+
+        # Compute result for closed or unlimited
+        self._compute_early_outs(quotas)
+
+        if self._early_out:
+            if not self._full_results:
+                quotas = [q for q in quotas if q not in self.results]
+                if not quotas:
+                    return
+
+        size_left = Counter({q: (sys.maxsize if s is None else s) for q, s in self.sizes.items()})
+
+        # Fetch which quotas belong to which items and variations
+        q_items = Quota.items.through.objects.filter(
+            quota_id__in=[q.pk for q in quotas]
+        ).values('quota_id', 'item_id')
+        for m in q_items:
+            self._item_to_quota[m['item_id']].append(self._quota_objects[m['quota_id']])
+
+        q_vars = Quota.variations.through.objects.filter(
+            quota_id__in=[q.pk for q in quotas]
+        ).values('quota_id', 'itemvariation_id')
+        for m in q_vars:
+            self._var_to_quota[m['itemvariation_id']].append(self._quota_objects[m['quota_id']])
+
+        self._compute_orders(quotas, q_items, q_vars, size_left)
+
+        if not self._full_results:
+            quotas = [q for q in quotas if q not in self.results]
+            if not quotas:
+                return
+
+        self._compute_vouchers(quotas, q_items, q_vars, size_left, now_dt)
+
+        if not self._full_results:
+            quotas = [q for q in quotas if q not in self.results]
+            if not quotas:
+                return
+
+        self._compute_carts(quotas, q_items, q_vars, size_left, now_dt)
+
+        if self._count_waitinglist:
+            if not self._full_results:
+                quotas = [q for q in quotas if q not in self.results]
+                if not quotas:
+                    return
+
+            self._compute_waitinglist(quotas, q_items, q_vars, size_left)
+
+        for q in quotas:
+            if q not in self.results and size_left[q] > 0:
+                self.results[q] = Quota.AVAILABILITY_OK, size_left[q]
+
+    def _compute_orders(self, quotas, q_items, q_vars, size_left):
+        events = {q.event_id for q in quotas}
+        subevents = {q.subevent_id for q in quotas}
+        seq = Q(subevent_id__in=subevents)
+        if None in subevents:
+            seq |= Q(subevent__isnull=True)
+        op_lookup = OrderPosition.objects.filter(
+            order__status__in=[Order.STATUS_PAID, Order.STATUS_PENDING],
+            order__event_id__in=events,
+        ).filter(seq).filter(
+            Q(
+                Q(variation_id__isnull=True) &
+                Q(item_id__in={i['item_id'] for i in q_items if self._quota_objects[i['quota_id']] in quotas})
+            ) | Q(
+                variation_id__in={i['itemvariation_id'] for i in q_vars if self._quota_objects[i['quota_id']] in quotas})
+        ).order_by().values('order__status', 'item_id', 'subevent_id', 'variation_id').annotate(c=Count('*'))
+        for line in sorted(op_lookup, key=lambda li: li['order__status'], reverse=True):  # p before n
+            if line['variation_id']:
+                qs = self._var_to_quota[line['variation_id']]
+            else:
+                qs = self._item_to_quota[line['item_id']]
+            for q in qs:
+                if q.subevent_id == line['subevent_id']:
+                    size_left[q] -= line['c']
+                    if line['order__status'] == Order.STATUS_PAID:
+                        self.count_paid_orders[q] += line['c']
+                    elif line['order__status'] == Order.STATUS_PENDING:
+                        self.count_pending_orders[q] += line['c']
+                    if size_left[q] <= 0 and q not in self.results:
+                        if line['order__status'] == Order.STATUS_PAID:
+                            self.results[q] = Quota.AVAILABILITY_GONE, 0
+                        else:
+                            self.results[q] = Quota.AVAILABILITY_ORDERED, 0
+
+    def _compute_vouchers(self, quotas, q_items, q_vars, size_left, now_dt):
+        events = {q.event_id for q in quotas}
+        if 'sqlite3' in settings.DATABASES['default']['ENGINE']:
+            func = 'MAX'
+        else:  # NOQA
+            func = 'GREATEST'
+
+        # Count blocking vouchers
+        subevents = {q.subevent_id for q in quotas}
+        seq = Q(subevent_id__in=subevents)
+        if None in subevents:
+            seq |= Q(subevent__isnull=True)
+        v_lookup = Voucher.objects.filter(
+            Q(event_id__in=events) &
+            seq &
+            Q(block_quota=True) &
+            Q(Q(valid_until__isnull=True) | Q(valid_until__gte=now_dt)) &
+            Q(
+                Q(
+                    Q(variation_id__isnull=True) &
+                    Q(item_id__in={i['item_id'] for i in q_items if self._quota_objects[i['quota_id']] in quotas})
+                ) | Q(
+                    variation_id__in={i['itemvariation_id'] for i in q_vars if
+                                      self._quota_objects[i['quota_id']] in quotas}
+                ) | Q(
+                    quota_id__in=[q.pk for q in quotas]
+                )
+            )
+        ).order_by().values('subevent_id', 'item_id', 'quota_id', 'variation_id').annotate(
+            free=Sum(Func(F('max_usages') - F('redeemed'), 0, function=func))
+        )
+        for line in v_lookup:
+            if line['variation_id']:
+                qs = self._var_to_quota[line['itemvariation_id']]
+            elif line['item_id']:
+                qs = self._item_to_quota[line['item_id']]
+            else:
+                qs = [self._quota_objects[line['quota_id']]]
+            for q in qs:
+                if q.subevent_id == line['subevent_id']:
+                    size_left[q] -= line['free']
+                    self.count_vouchers[q] += line['free']
+                    if q not in self.results and size_left[q] <= 0:
+                        self.results[q] = Quota.AVAILABILITY_ORDERED, 0
+
+    def _compute_carts(self, quotas, q_items, q_vars, size_left, now_dt):
+        events = {q.event_id for q in quotas}
+        subevents = {q.subevent_id for q in quotas}
+        seq = Q(subevent_id__in=subevents)
+        if None in subevents:
+            seq |= Q(subevent__isnull=True)
+        cart_lookup = CartPosition.objects.filter(
+            Q(event_id__in=events) &
+            seq &
+            Q(expires__gte=now_dt) &
+            Q(
+                Q(voucher__isnull=True)
+                | Q(voucher__block_quota=False)
+                | Q(voucher__valid_until__lt=now_dt)
+            ) &
+            Q(
+                Q(variation_id__isnull=True) &
+                Q(item_id__in={i['item_id'] for i in q_items if self._quota_objects[i['quota_id']] in quotas})
+            ) | Q(
+                variation_id__in={i['itemvariation_id'] for i in q_vars if self._quota_objects[i['quota_id']] in quotas})
+        ).order_by().values('item_id', 'subevent_id', 'variation_id').annotate(c=Count('*'))
+        for line in cart_lookup:
+            if line['variation_id']:
+                qs = self._var_to_quota[line['variation_id']]
+            else:
+                qs = self._item_to_quota[line['item_id']]
+            for q in qs:
+                if q.subevent_id == line['subevent_id']:
+                    size_left[q] -= line['c']
+                    self.count_cart += line['c']
+                    if q not in self.results and size_left[q] <= 0:
+                        self.results[q] = Quota.AVAILABILITY_RESERVED, 0
+
+    def _compute_waitinglist(self, quotas, q_items, q_vars, size_left):
+        events = {q.event_id for q in quotas}
+        subevents = {q.subevent_id for q in quotas}
+        seq = Q(subevent_id__in=subevents)
+        if None in subevents:
+            seq |= Q(subevent__isnull=True)
+        w_lookup = WaitingListEntry.objects.filter(
+            Q(event_id__in=events) &
+            Q(voucher__isnull=True) &
+            seq &
+            Q(
+                Q(variation_id__isnull=True) &
+                Q(item_id__in={i['item_id'] for i in q_items if self._quota_objects[i['quota_id']] in quotas})
+            ) | Q(variation_id__in={i['itemvariation_id'] for i in q_vars if
+                                    self._quota_objects[i['quota_id']] in quotas})
+        ).order_by().values('item_id', 'subevent_id', 'variation_id').annotate(c=Count('*'))
+        for line in w_lookup:
+            if line['variation_id']:
+                qs = self._var_to_quota[line['variation_id']]
+            else:
+                qs = self._item_to_quota[line['item_id']]
+            for q in qs:
+                if q.subevent_id == line['subevent_id']:
+                    size_left[q] -= line['c']
+                    self.count_waitinglist[q] += line['c']
+                    if q not in self.results and size_left[q] <= 0:
+                        self.results[q] = Quota.AVAILABILITY_ORDERED, 0
+
+    def _compute_early_outs(self, quotas):
+        for q in quotas:
+            if q.closed and not self._ignore_closed:
+                self.results[q] = Quota.AVAILABILITY_ORDERED, 0
+            elif q.size is None:
+                self.results[q] = Quota.AVAILABILITY_OK, None
 
 
 @receiver(signal=periodic_task)

--- a/src/pretix/base/services/quotas.py
+++ b/src/pretix/base/services/quotas.py
@@ -55,7 +55,7 @@ class QuotaAvailability:
         self._compute(quotas, now_dt)
 
         for q in quotas_original:
-            for recv, resp in quota_availability.send(sender=q.event, quota=quotas_original, result=self.results[q],
+            for recv, resp in quota_availability.send(sender=q.event, quota=q, result=self.results[q],
                                                       count_waitinglist=self.count_waitinglist):
                 self.results[q] = resp
 

--- a/src/pretix/control/templates/pretixcontrol/items/quotas.html
+++ b/src/pretix/control/templates/pretixcontrol/items/quotas.html
@@ -59,7 +59,7 @@
                         </td>
                         <td>
                             <ul>
-                                {% for item in q.items.all %}
+                                {% for item in cached_items%}
                                     {% if not item.has_variations %}
                                         <li><a href="{% url "control:event.item" organizer=request.event.organizer.slug event=request.event.slug item=item.id %}">{{ item }}</a></li>
                                     {% endif %}
@@ -74,7 +74,7 @@
                             <td>{{ q.subevent.name }} – {{ q.subevent.get_date_range_display }}</td>
                         {% endif %}
                         <td>{% if q.size == None %}Unlimited{% else %}{{ q.size }}{% endif %}</td>
-                        <td>{% include "pretixcontrol/items/fragment_quota_availability.html" with availability=q.availability closed=q.closed %}</td>
+                        <td>{% include "pretixcontrol/items/fragment_quota_availability.html" with availability=q.cached_avail closed=q.closed %}</td>
                         <td class="text-right flip">
                             <a href="{% url "control:event.items.quotas.edit" organizer=request.event.organizer.slug event=request.event.slug quota=q.id %}" class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>
                             <a href="{% url "control:event.items.quotas.add" organizer=request.event.organizer.slug event=request.event.slug %}?copy_from={{ q.id }}"

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -667,11 +667,11 @@ class QuotaList(PaginationMixin, ListView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()
 
-        q = QuotaAvailability()
-        q.queue(*ctx['quotas'])
-        q.compute()
+        qa = QuotaAvailability()
+        qa.queue(*ctx['quotas'])
+        qa.compute()
         for quota in ctx['quotas']:
-            q.cached_avail = q.results[quota]
+            qa.cached_avail = qa.results[quota]
 
         return ctx
 
@@ -733,30 +733,30 @@ class QuotaView(ChartContainingView, DetailView):
     def get_context_data(self, *args, **kwargs):
         ctx = super().get_context_data()
 
-        q = QuotaAvailability(full_results=True)
-        q.queue(self.object)
-        q.compute()
-        ctx['avail'] = q.results[self.object]
+        qa = QuotaAvailability(full_results=True)
+        qa.queue(self.object)
+        qa.compute()
+        ctx['avail'] = qa.results[self.object]
 
         data = [
             {
                 'label': gettext('Paid orders'),
-                'value': q.count_paid_orders[self.object],
+                'value': qa.count_paid_orders[self.object],
                 'sum': True,
             },
             {
                 'label': gettext('Pending orders'),
-                'value': q.count_pending_orders[self.object],
+                'value': qa.count_pending_orders[self.object],
                 'sum': True,
             },
             {
                 'label': gettext('Vouchers and waiting list reservations'),
-                'value': q.count_vouchers[self.object],
+                'value': qa.count_vouchers[self.object],
                 'sum': True,
             },
             {
                 'label': gettext('Current user\'s carts'),
-                'value': q.count_cart[self.object],
+                'value': qa.count_cart[self.object],
                 'sum': True,
             },
         ]
@@ -772,7 +772,7 @@ class QuotaView(ChartContainingView, DetailView):
         })
         data.append({
             'label': gettext('Waiting list (pending)'),
-            'value': q.count_waitinglist[self.object],
+            'value': qa.count_waitinglist[self.object],
             'sum': False,
         })
 

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -31,6 +31,7 @@ from pretix.base.models import (
 )
 from pretix.base.models.event import SubEvent
 from pretix.base.models.items import ItemAddOn, ItemBundle, ItemMetaValue
+from pretix.base.services.quotas import QuotaAvailability
 from pretix.base.services.tickets import invalidate_cache
 from pretix.base.signals import quota_availability
 from pretix.control.forms.item import (
@@ -643,9 +644,7 @@ class QuotaList(PaginationMixin, ListView):
     template_name = 'pretixcontrol/items/quotas.html'
 
     def get_queryset(self):
-        qs = Quota.objects.filter(
-            event=self.request.event
-        ).prefetch_related(
+        qs = self.request.event.quotas.prefetch_related(
             Prefetch(
                 "items",
                 queryset=Item.objects.annotate(
@@ -654,12 +653,27 @@ class QuotaList(PaginationMixin, ListView):
                 to_attr="cached_items"
             ),
             "variations",
-            "variations__item"
+            "variations__item",
+            Prefetch(
+                "subevent",
+                queryset=self.request.event.subevents.all()
+            )
         )
         if self.request.GET.get("subevent", "") != "":
             s = self.request.GET.get("subevent", "")
             qs = qs.filter(subevent_id=s)
         return qs
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data()
+
+        q = QuotaAvailability()
+        q.queue(*ctx['quotas'])
+        q.compute()
+        for quota in ctx['quotas']:
+            q.cached_avail = q.results[quota]
+
+        return ctx
 
 
 class QuotaCreate(EventPermissionRequiredMixin, CreateView):
@@ -719,28 +733,30 @@ class QuotaView(ChartContainingView, DetailView):
     def get_context_data(self, *args, **kwargs):
         ctx = super().get_context_data()
 
-        avail = self.object.availability()
-        ctx['avail'] = avail
+        q = QuotaAvailability(full_results=True)
+        q.queue(self.object)
+        q.compute()
+        ctx['avail'] = q.results[self.object]
 
         data = [
             {
                 'label': gettext('Paid orders'),
-                'value': self.object.count_paid_orders(),
+                'value': q.count_paid_orders[self.object],
                 'sum': True,
             },
             {
                 'label': gettext('Pending orders'),
-                'value': self.object.count_pending_orders(),
+                'value': q.count_pending_orders[self.object],
                 'sum': True,
             },
             {
                 'label': gettext('Vouchers and waiting list reservations'),
-                'value': self.object.count_blocking_vouchers(),
+                'value': q.count_vouchers[self.object],
                 'sum': True,
             },
             {
                 'label': gettext('Current user\'s carts'),
-                'value': self.object.count_in_cart(),
+                'value': q.count_cart[self.object],
                 'sum': True,
             },
         ]
@@ -756,14 +772,14 @@ class QuotaView(ChartContainingView, DetailView):
         })
         data.append({
             'label': gettext('Waiting list (pending)'),
-            'value': self.object.count_waiting_list_pending(),
+            'value': q.count_waitinglist[self.object],
             'sum': False,
         })
 
         if self.object.size is not None:
             data.append({
                 'label': gettext('Currently for sale'),
-                'value': avail[1],
+                'value': ctx['avail'][1],
                 'sum': False,
                 'strong': True
             })
@@ -786,7 +802,17 @@ class QuotaView(ChartContainingView, DetailView):
         ctx['has_ignore_vouchers'] = Voucher.objects.filter(
             Q(allow_ignore_quota=True) &
             Q(Q(valid_until__isnull=True) | Q(valid_until__gte=now())) &
-            Q(Q(self.object._position_lookup) | Q(quota=self.object)) &
+            Q(
+                (
+                    (  # Orders for items which do not have any variations
+                        Q(variation__isnull=True) &
+                        Q(item_id__in=Quota.items.through.objects.filter(quota_id=self.object.pk).values_list('item_id', flat=True))
+                    ) | (  # Orders for items which do have any variations
+                        Q(variation__in=Quota.variations.through.objects.filter(quota_id=self.object.pk).values_list(
+                            'itemvariation_id', flat=True))
+                    )
+                ) | Q(quota=self.object)
+            ) &
             Q(redeemed__lt=F('max_usages'))
         ).exists()
         if self.object.closed:

--- a/src/pretix/control/views/subevents.py
+++ b/src/pretix/control/views/subevents.py
@@ -24,6 +24,7 @@ from pretix.base.models.items import (
     ItemVariation, Quota, SubEventItem, SubEventItemVariation,
 )
 from pretix.base.reldate import RelativeDate, RelativeDateWrapper
+from pretix.base.services.quotas import QuotaAvailability
 from pretix.control.forms.checkin import CheckinListForm
 from pretix.control.forms.filter import SubEventFilterForm
 from pretix.control.forms.item import QuotaForm
@@ -69,19 +70,27 @@ class SubEventList(EventPermissionRequiredMixin, PaginationMixin, ListView):
         ctx = super().get_context_data(**kwargs)
         ctx['filter_form'] = self.filter_form
 
+        quotas = []
         for s in ctx['subevents']:
             s.first_quotas = s.first_quotas[:4]
-            for q in s.first_quotas:
-                q.cached_avail = (
-                    (q.cached_availability_state, q.cached_availability_number)
-                    if q.cached_availability_time is not None
-                    else q.availability(allow_cache=True)
+            quotas += list(s.first_quotas)
+
+        qa = QuotaAvailability(early_out=False)
+        for q in quotas:
+            if q.cached_availability_time is None or q.cached_availability_paid_orders is None:
+                qa.queue(q)
+        qa.compute()
+
+        for q in quotas:
+            q.cached_avail = (
+                qa.results[q] if q in qa.results
+                else (q.cached_availability_state, q.cached_availability_number)
+            )
+            if q.size is not None:
+                q.percent_paid = min(
+                    100,
+                    round(q.cached_availability_paid_orders / q.size * 100) if q.size > 0 else 100
                 )
-                if q.size is not None:
-                    q.percent_paid = min(
-                        100,
-                        round(q.cached_availability_paid_orders / q.size * 100) if q.size > 0 else 100
-                    )
         return ctx
 
     @cached_property

--- a/src/pretix/control/views/subevents.py
+++ b/src/pretix/control/views/subevents.py
@@ -68,6 +68,7 @@ class SubEventList(EventPermissionRequiredMixin, PaginationMixin, ListView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx['filter_form'] = self.filter_form
+
         for s in ctx['subevents']:
             s.first_quotas = s.first_quotas[:4]
             for q in s.first_quotas:

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -18,6 +18,7 @@ from pretix.base.i18n import language
 from pretix.base.models import (
     Event, EventMetaValue, SubEvent, SubEventMetaValue,
 )
+from pretix.base.services.quotas import QuotaAvailability
 from pretix.helpers.daterange import daterange
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.presale.ical import get_ical
@@ -272,7 +273,21 @@ def add_subevents_for_days(qs, before, after, ebd, timezones, event=None, cart_n
     ).order_by(
         'date_from'
     )
+    quotas_to_compute = []
     for se in qs:
+        if se.presale_is_running:
+            quotas_to_compute += [
+                q for q in se.active_quotas
+                if not q.cache_is_hot(now() + timedelta(seconds=5))
+            ]
+
+    if quotas_to_compute:
+        q = QuotaAvailability()
+        q.queue(*quotas_to_compute)
+        q.compute()
+    for se in qs:
+        if quotas_to_compute:
+            se._quota_cache = q.results
         kwargs = {'subevent': se.pk}
         if cart_namespace:
             kwargs['cart_namespace'] = cart_namespace

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -282,12 +282,12 @@ def add_subevents_for_days(qs, before, after, ebd, timezones, event=None, cart_n
             ]
 
     if quotas_to_compute:
-        q = QuotaAvailability()
-        q.queue(*quotas_to_compute)
-        q.compute()
+        qa = QuotaAvailability()
+        qa.queue(*quotas_to_compute)
+        qa.compute()
     for se in qs:
         if quotas_to_compute:
-            se._quota_cache = q.results
+            se._quota_cache = qa.results
         kwargs = {'subevent': se.pk}
         if cart_namespace:
             kwargs['cart_namespace'] = cart_namespace


### PR DESCRIPTION
This PR refactors quota computation. Instead of methods on the ``Quota`` method, there's now a dedicated ``QuotaAvailability`` for this task. The difference is that the new code is designed to calculate the capacity for multiple quotas *at once*.

Simply speaking, instead of a ``SELECT COUNT(*) FROM orders WHERE event = x AND item = y``, the code now does a ``SELECT COUNT(*), event, item FROM orders GROUP BY event, item`` and then interprets the result Python-side.

This is intended to **massively** speed up many of our critical code paths that are currently slow for some relevant edge cases, such as:

- The list of (sub)events in the shop
- The list of products in an event on the shop frontpage
- The list of (sub)events in the backend
- The list of quotas in the backend
- The backend dashboard
- Cart operations with multiple items

I very very strongly do not want to have this logic twice, so the old code was deleted. This leads to an (hopefully) insignificant slowdown during operations that only affect one quota, since the code is slightly less inefficient in this case (1-2 additional queries per quota, more python-level code to execute). These should be:

- Placing an order
- Marking expired orders as paid, extending expired orders, reactivating orders, …
- Waiting list operations
- Any loops that do not make active use of the new optimization

:fire: This might easily be the most dangerous PR I can remember, we cannot screw this up. Tests are passing, we need to do an extensive review, but I even think we should take a snapshot of the production DB and make sure all quotas have the same result with the old and the new code.