### PR TITLE
Improve global order filters

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -111,6 +111,13 @@ class OrderFilterForm(FilterForm):
             (Order.STATUS_EXPIRED, _('Expired')),
             (Order.STATUS_PENDING + Order.STATUS_EXPIRED, _('Pending or expired')),
             (Order.STATUS_CANCELED, _('Canceled')),
+            ('cp', _('Canceled (or with paid fee)')),
+            ('pa', _('Approval pending')),
+            ('overpaid', _('Overpaid')),
+            ('underpaid', _('Underpaid')),
+            ('pendingpaid', _('Pending (but fully paid)')),
+            ('testmode', _('Test mode')),
+            ('rc', _('Cancellation requested')),
         ),
         required=False,
     )
@@ -165,6 +172,46 @@ class OrderFilterForm(FilterForm):
                 qs = qs.filter(status__in=[Order.STATUS_PENDING, Order.STATUS_EXPIRED])
             elif s in ('p', 'n', 'e', 'c', 'r'):
                 qs = qs.filter(status=s)
+            elif s == 'overpaid':
+                qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
+                qs = qs.filter(
+                    Q(~Q(status=Order.STATUS_CANCELED) & Q(pending_sum_t__lt=0))
+                    | Q(Q(status=Order.STATUS_CANCELED) & Q(pending_sum_rc__lt=0))
+                )
+            elif s == 'rc':
+                qs = qs.filter(
+                    cancellation_requests__isnull=False
+                )
+            elif s == 'pendingpaid':
+                qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
+                qs = qs.filter(
+                    Q(status__in=(Order.STATUS_EXPIRED, Order.STATUS_PENDING)) & Q(pending_sum_t__lte=0)
+                    & Q(require_approval=False)
+                )
+            elif s == 'underpaid':
+                qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
+                qs = qs.filter(
+                    status=Order.STATUS_PAID,
+                    pending_sum_t__gt=0
+                )
+            elif s == 'pa':
+                qs = qs.filter(
+                    status=Order.STATUS_PENDING,
+                    require_approval=True
+                )
+            elif s == 'testmode':
+                qs = qs.filter(
+                    testmode=True
+                )
+            elif s == 'cp':
+                s = OrderPosition.objects.filter(
+                    order=OuterRef('pk')
+                )
+                qs = qs.annotate(
+                    has_pc=Exists(s)
+                ).filter(
+                    Q(status=Order.STATUS_PAID, has_pc=False) | Q(status=Order.STATUS_CANCELED)
+                )
 
         if fdata.get('ordering'):
             qs = qs.order_by(self.get_order_by())
@@ -202,27 +249,6 @@ class EventOrderFilterForm(OrderFilterForm):
     )
     answer = forms.CharField(
         required=False
-    )
-    status = forms.ChoiceField(
-        label=_('Order status'),
-        choices=(
-            ('', _('All orders')),
-            (Order.STATUS_PAID, _('Paid (or canceled with paid fee)')),
-            (Order.STATUS_PENDING, _('Pending')),
-            ('o', _('Pending (overdue)')),
-            (Order.STATUS_PENDING + Order.STATUS_PAID, _('Pending or paid')),
-            (Order.STATUS_EXPIRED, _('Expired')),
-            (Order.STATUS_PENDING + Order.STATUS_EXPIRED, _('Pending or expired')),
-            (Order.STATUS_CANCELED, _('Canceled')),
-            ('cp', _('Canceled (or with paid fee)')),
-            ('pa', _('Approval pending')),
-            ('overpaid', _('Overpaid')),
-            ('underpaid', _('Underpaid')),
-            ('pendingpaid', _('Pending (but fully paid)')),
-            ('testmode', _('Test mode')),
-            ('rc', _('Cancellation requested')),
-        ),
-        required=False,
     )
 
     def __init__(self, *args, **kwargs):
@@ -300,47 +326,6 @@ class EventOrderFilterForm(OrderFilterForm):
                 )
                 qs = qs.annotate(has_answer=Exists(answers)).filter(has_answer=True)
 
-        if fdata.get('status') == 'overpaid':
-            qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
-            qs = qs.filter(
-                Q(~Q(status=Order.STATUS_CANCELED) & Q(pending_sum_t__lt=0))
-                | Q(Q(status=Order.STATUS_CANCELED) & Q(pending_sum_rc__lt=0))
-            )
-        elif fdata.get('status') == 'rc':
-            qs = qs.filter(
-                cancellation_requests__isnull=False
-            )
-        elif fdata.get('status') == 'pendingpaid':
-            qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
-            qs = qs.filter(
-                Q(status__in=(Order.STATUS_EXPIRED, Order.STATUS_PENDING)) & Q(pending_sum_t__lte=0)
-                & Q(require_approval=False)
-            )
-        elif fdata.get('status') == 'underpaid':
-            qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
-            qs = qs.filter(
-                status=Order.STATUS_PAID,
-                pending_sum_t__gt=0
-            )
-        elif fdata.get('status') == 'pa':
-            qs = qs.filter(
-                status=Order.STATUS_PENDING,
-                require_approval=True
-            )
-        elif fdata.get('status') == 'testmode':
-            qs = qs.filter(
-                testmode=True
-            )
-        elif fdata.get('status') == 'cp':
-            s = OrderPosition.objects.filter(
-                order=OuterRef('pk')
-            )
-            qs = qs.annotate(
-                has_pc=Exists(s)
-            ).filter(
-                Q(status=Order.STATUS_PAID, has_pc=False) | Q(status=Order.STATUS_CANCELED)
-            )
-
         return qs
 
 
@@ -363,28 +348,6 @@ class OrderSearchFilterForm(OrderFilterForm):
         )
     )
 
-    status = forms.ChoiceField(
-        label=_('Order status'),
-        choices=(
-            ('', _('All orders')),
-            (Order.STATUS_PAID, _('Paid (or canceled with paid fee)')),
-            (Order.STATUS_PENDING, _('Pending')),
-            ('o', _('Pending (overdue)')),
-            (Order.STATUS_PENDING + Order.STATUS_PAID, _('Pending or paid')),
-            (Order.STATUS_EXPIRED, _('Expired')),
-            (Order.STATUS_PENDING + Order.STATUS_EXPIRED, _('Pending or expired')),
-            (Order.STATUS_CANCELED, _('Canceled')),
-            ('cp', _('Canceled (or with paid fee)')),
-            ('pa', _('Approval pending')),
-            ('overpaid', _('Overpaid')),
-            ('underpaid', _('Underpaid')),
-            ('pendingpaid', _('Pending (but fully paid)')),
-            ('testmode', _('Test mode')),
-            ('rc', _('Cancellation requested')),
-        ),
-        required=False,
-    )
-
     def __init__(self, *args, **kwargs):
         request = kwargs.pop('request')
         super().__init__(*args, **kwargs)
@@ -402,47 +365,6 @@ class OrderSearchFilterForm(OrderFilterForm):
 
         if fdata.get('organizer'):
             qs = qs.filter(event__organizer=fdata.get('organizer'))
-
-        if fdata.get('status') == 'overpaid':
-            qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
-            qs = qs.filter(
-                Q(~Q(status=Order.STATUS_CANCELED) & Q(pending_sum_t__lt=0))
-                | Q(Q(status=Order.STATUS_CANCELED) & Q(pending_sum_rc__lt=0))
-            )
-        elif fdata.get('status') == 'rc':
-            qs = qs.filter(
-                cancellation_requests__isnull=False
-            )
-        elif fdata.get('status') == 'pendingpaid':
-            qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
-            qs = qs.filter(
-                Q(status__in=(Order.STATUS_EXPIRED, Order.STATUS_PENDING)) & Q(pending_sum_t__lte=0)
-                & Q(require_approval=False)
-            )
-        elif fdata.get('status') == 'underpaid':
-            qs = Order.annotate_overpayments(qs, refunds=False, results=False, sums=True)
-            qs = qs.filter(
-                status=Order.STATUS_PAID,
-                pending_sum_t__gt=0
-            )
-        elif fdata.get('status') == 'pa':
-            qs = qs.filter(
-                status=Order.STATUS_PENDING,
-                require_approval=True
-            )
-        elif fdata.get('status') == 'testmode':
-            qs = qs.filter(
-                testmode=True
-            )
-        elif fdata.get('status') == 'cp':
-            s = OrderPosition.objects.filter(
-                order=OuterRef('pk')
-            )
-            qs = qs.annotate(
-                has_pc=Exists(s)
-            ).filter(
-                Q(status=Order.STATUS_PAID, has_pc=False) | Q(status=Order.STATUS_CANCELED)
-            )
 
         return qs
 

--- a/src/pretix/control/templates/pretixcontrol/search/orders.html
+++ b/src/pretix/control/templates/pretixcontrol/search/orders.html
@@ -73,7 +73,24 @@
                         {% endif %}
                     </td>
                     <td>{{ o.datetime|date:"SHORT_DATETIME_FORMAT" }}</td>
-                    <td class="text-right flip">{{ o.total|money:o.event.currency }}</td>
+                    <td class="text-right flip">
+                        {% if o.has_cancellation_request %}
+                            <span class="label label-warning">{% trans "CANCELLATION REQUESTED" %}</span>
+                        {% endif %}
+                        {% if o.has_external_refund or o.has_pending_refund %}
+                            <span class="label label-danger">{% trans "REFUND PENDING" %}</span>
+                        {% elif o.has_pending_refund %}
+                            <span class="label label-warning">{% trans "REFUND PENDING" %}</span>
+                        {% endif %}
+                        {% if o.is_overpaid %}
+                            <span class="label label-warning">{% trans "OVERPAID" %}</span>
+                        {% elif o.is_underpaid  %}
+                            <span class="label label-danger">{% trans "UNDERPAID" %}</span>
+                        {% elif o.is_pending_with_full_payment %}
+                            <span class="label label-danger">{% trans "FULLY PAID" %}</span>
+                        {% endif %}
+                        {{ o.total|money:o.event.currency }}
+                    </td>
                     <td class="text-right flip">{% include "pretixcontrol/orders/fragment_order_status.html" with order=o %}</td>
                 </tr>
             {% empty %}


### PR DESCRIPTION
Basically, copy/paste from the order search.

Perhaps just pay specifically attention if this works as intended (`.using()`-statement in conjunction with the annotation: 

https://github.com/pretix/pretix/blob/4b01c42f3193f8083d106139c56e20798b7bef1b/src/pretix/control/views/search.py#L33-L34