### PR TITLE
Support HERMA Namensetiketten 50x80mm (4412)

### DIFF
--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -109,6 +109,14 @@ OPTIONS = OrderedDict([
         'offsets': [93 * mm, 60 * mm],
         'pagesize': pagesizes.A4,
     }),
+    ('herma_50x80', {
+        'name': 'HERMA 50 x 80 mm (4412)',
+        'cols': 2,
+        'rows': 5,
+        'margins': [13.5 * mm, 17.5 * mm, 13.5 * mm, 17.5 * mm],
+        'offsets': [95 * mm, 55 * mm],
+        'pagesize': pagesizes.A4,
+    }),
 ])
 
 


### PR DESCRIPTION
https://www.herma.de/buero-zuhause/produkt/textil-namensetiketten-a4-special-4412/

I couldn't test it on real paper, but the output aligns perfectly with the template provided by HERMA: https://www.herma.de/fileadmin/Buero-Zuhause/downloads/Stanzvorlagen/4412_SV.pdf