### PR TITLE
Ask only for VAT ID if company is inside EU

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -314,6 +314,24 @@ var form_handlers = function (el) {
         dependency.closest('.form-group').find('input[name=' + dependency.attr("name") + ']').on("dp.change", update);
     });
 
+    $("input[name$=vat_id]").each(function () {
+        var dependent = $(this),
+            dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
+            dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),
+            update = function (ev) {
+                if (dependency_id_is_business_1.length && !dependency_id_is_business_1.prop("checked")) {
+                    dependent.closest(".form-group").hide();
+                } else if (dependent.attr('data-countries-in-eu').split(',').includes(dependency_country.val())) {
+                    dependent.closest(".form-group").show();
+                } else {
+                    dependent.closest(".form-group").hide();
+                }
+            };
+        update();
+        dependency_country.on("change", update);
+        dependency_id_is_business_1.on("change", update);
+    });
+
     $("select[name$=state]:not([data-static])").each(function () {
         var dependent = $(this),
             counter = 0,

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -314,7 +314,7 @@ var form_handlers = function (el) {
         dependency.closest('.form-group').find('input[name=' + dependency.attr("name") + ']').on("dp.change", update);
     });
 
-    $("input[name$=vat_id]").each(function () {
+    $("input[name$=vat_id][data-countries-in-eu]").each(function () {
         var dependent = $(this),
             dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
             dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -293,7 +293,7 @@ $(function () {
         dependency.closest('.form-group, form').find('input[name=' + dependency.attr("name") + ']').on("dp.change", update);
     });
 
-    $("input[name$=vat_id]").each(function () {
+    $("input[name$=vat_id][data-countries-in-eu]").each(function () {
         var dependent = $(this),
             dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
             dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -293,6 +293,24 @@ $(function () {
         dependency.closest('.form-group, form').find('input[name=' + dependency.attr("name") + ']').on("dp.change", update);
     });
 
+    $("input[name$=vat_id]").each(function () {
+        var dependent = $(this),
+            dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
+            dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),
+            update = function (ev) {
+                if (dependency_id_is_business_1.length && !dependency_id_is_business_1.prop("checked")) {
+                    dependent.closest(".form-group").hide();
+                } else if (dependent.attr('data-countries-in-eu').split(',').includes(dependency_country.val())) {
+                    dependent.closest(".form-group").show();
+                } else {
+                    dependent.closest(".form-group").hide();
+                }
+            };
+        update();
+        dependency_country.on("change", update);
+        dependency_id_is_business_1.on("change", update);
+    });
+
     $("select[name$=state]").each(function () {
         var dependent = $(this),
             counter = 0,

--- a/src/pretix/urls.py
+++ b/src/pretix/urls.py
@@ -18,7 +18,7 @@ base_patterns = [
     url(r'^metrics$', metrics.serve_metrics,
         name='metrics'),
     url(r'^csp_report/$', csp.csp_report, name='csp.report'),
-    url(r'^js_helpers/states/$', js_helpers.states, name='js_helpers.stats'),
+    url(r'^js_helpers/states/$', js_helpers.states, name='js_helpers.states'),
     url(r'^api/v1/', include(('pretix.api.urls', 'pretixapi'), namespace='api-v1')),
     url(r'^api/$', RedirectView.as_view(url='/api/v1/'), name='redirect-api-version')
 ]


### PR DESCRIPTION
To avoid confusion in a reverse charge setting we don't want to ask companies that are not in the European Union for the VAD ID. Maybe it would be better, to make this a setting, but I don't have a good idea how to do it.