### PR TITLE
Add optional banktransfer code prefix

### DIFF
--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -1297,6 +1297,11 @@ class QuickSetupView(FormView):
                     form.cleaned_data['payment_banktransfer_%s' % f]
                 )
 
+            self.request.event.settings.set(
+                'payment_banktransfer_code_prefix',
+                form.cleaned_data['payment_banktransfer_code_prefix']
+            )
+
         if form.cleaned_data.get('payment_stripe__enabled', None):
             if 'pretix.plugins.stripe' not in plugins_active:
                 self.request.event.log_action('pretix.event.plugins.enabled', user=self.request.user,

--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -25,7 +25,9 @@ from pretix.control.permissions import (
 from pretix.control.views.organizer import OrganizerDetailViewMixin
 from pretix.plugins.banktransfer import csvimport, mt940import
 from pretix.plugins.banktransfer.models import BankImportJob, BankTransaction
-from pretix.plugins.banktransfer.tasks import process_banktransfers
+from pretix.plugins.banktransfer.tasks import (
+    get_prefix_event_map, process_banktransfers,
+)
 
 logger = logging.getLogger('pretix.plugins.banktransfer')
 
@@ -117,10 +119,11 @@ class ActionView(View):
             'status': 'ok',
         })
 
-    def _assign(self, trans, code):
+    def _assign(self, trans, organizer, code):
         try:
             if '-' in code:
-                trans.order = self.order_qs().get(code=code.rsplit('-', 1)[1], event__slug__iexact=code.rsplit('-', 1)[0])
+                event = get_prefix_event_map(organizer=organizer)[code.rsplit('-', 1)[0]]
+                trans.order = self.order_qs().get(code=code.rsplit('-', 1)[1], event=event)
             else:
                 trans.order = self.order_qs().get(code=code.rsplit('-', 1)[-1])
         except Order.DoesNotExist:
@@ -163,7 +166,7 @@ class ActionView(View):
 
             elif v.startswith('assign:') and trans.state in (BankTransaction.STATE_NOMATCH,
                                                              BankTransaction.STATE_DUPLICATE):
-                return self._assign(trans, v[7:])
+                return self._assign(trans, request.organizer, v[7:])
 
             elif v == 'retry' and trans.state in (BankTransaction.STATE_ERROR, BankTransaction.STATE_DUPLICATE):
                 return self._retry(trans)


### PR DESCRIPTION
Add an optional setting in the banktransfer plugin to change the code
prefix from the default value of the event slug to an arbitary string.

This does retain codes used in previous orders.

Work based on PR #1252 from @tynsh