### PR TITLE
Fix event settings form considered changed even if unchanged

### DIFF
--- a/src/pretix/base/reldate.py
+++ b/src/pretix/base/reldate.py
@@ -273,6 +273,11 @@ class RelativeDateTimeField(forms.MultiValueField):
                 minutes_before=None
             ))
 
+    def has_changed(self, initial, data):
+        if initial is None:
+            initial = self.widget.decompress(initial)
+        return super().has_changed(initial, data)
+
     def clean(self, value):
         if value[0] == 'absolute' and not value[1]:
             raise ValidationError(self.error_messages['incomplete'])

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -44,7 +44,7 @@ from i18nfield.strings import LazyI18nString
 from pytz import timezone
 from tests.base import SoupTest, extract_form_fields
 
-from pretix.base.models import Event, Order, Organizer, Team, User
+from pretix.base.models import Event, LogEntry, Order, Organizer, Team, User
 from pretix.testutils.mock import mocker_context
 
 
@@ -258,6 +258,12 @@ class EventsTest(SoupTest):
         assert doc.select("[name=date_to_0]")[0]['value'] == "2013-12-30"
         assert doc.select("[name=date_to_1]")[0]['value'] == "17:00:00"
         assert doc.select("[name=settings-max_items_per_order]")[0]['value'] == "12"
+
+    def test_unchanged_settings_do_not_create_logentry(self):
+        doc = self.get_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug))
+        self.post_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug),
+                      extract_form_fields(doc.select('.container-fluid form')[0]))
+        assert not LogEntry.objects.exists()
 
     def test_settings_timezone(self):
         doc = self.get_doc('/control/event/%s/%s/settings/' % (self.orga1.slug, self.event1.slug))


### PR DESCRIPTION
As discussed, when not having changed anything in the event settings form, pretix still creates a LogEntry that a change has been made, even though there is code to prevent that.

I found a way to correct that for a use of `RelativeDateTime`, but `has_changed()` is still True for the field `checkout_email_helptext`. That's an I18nText, so maybe @raphaelm can have a look at that?! :innocent: 