### PR TITLE
Add eMail-Template for free approval orders

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -258,7 +258,7 @@ def approve_order(order, user=None, send_mail: bool=True, auth=None, force=False
     if send_mail:
         with language(order.locale):
             if order.total == Decimal('0.00'):
-                email_template = order.event.settings.mail_text_order_free
+                email_template = order.event.settings.mail_text_order_approved_free
                 email_subject = _('Order approved and confirmed: %(code)s') % {'code': order.code}
             else:
                 email_template = order.event.settings.mail_text_order_approved

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1422,6 +1422,19 @@ You can select a payment method and perform the payment here:
 Best regards,
 Your {event} team"""))
     },
+    'mail_text_order_approved_free': {
+        'type': LazyI18nString,
+        'default': LazyI18nString.from_gettext(gettext_noop("""Hello,
+
+we approved your order for {event} and will be happy to welcome you
+at our event. As you only ordered free products, no payment is required.
+
+You can change your order details and view the status of your order at
+{url}
+
+Best regards,
+Your {event} team"""))
+    },
     'mail_text_order_denied': {
         'type': LazyI18nString,
         'default': LazyI18nString.from_gettext(gettext_noop("""Hello,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -929,6 +929,13 @@ class MailSettingsForm(SettingsForm):
         required=False,
         widget=I18nTextarea,
         help_text=_("This will only be sent out for non-free orders. Free orders will receive the free order "
+                    "template from below instead."),
+    )
+    mail_text_order_approved_free = I18nFormField(
+        label=_("Approved free order"),
+        required=False,
+        widget=I18nTextarea,
+        help_text=_("This will only be sent out for free orders. Non-free orders will receive the free order "
                     "template from above instead."),
     )
     mail_text_order_denied = I18nFormField(
@@ -978,6 +985,7 @@ class MailSettingsForm(SettingsForm):
         'mail_text_order_placed_attendee': ['event', 'order', 'position'],
         'mail_text_order_placed_require_approval': ['event', 'order'],
         'mail_text_order_approved': ['event', 'order'],
+        'mail_text_order_approved_free': ['event', 'order'],
         'mail_text_order_denied': ['event', 'order', 'comment'],
         'mail_text_order_paid': ['event', 'order', 'payment_info'],
         'mail_text_order_paid_attendee': ['event', 'order', 'position'],

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -935,7 +935,7 @@ class MailSettingsForm(SettingsForm):
         label=_("Approved free order"),
         required=False,
         widget=I18nTextarea,
-        help_text=_("This will only be sent out for free orders. Non-free orders will receive the free order "
+        help_text=_("This will only be sent out for free orders. Non-free orders will receive the non-free order "
                     "template from above instead."),
     )
     mail_text_order_denied = I18nFormField(

--- a/src/pretix/control/templates/pretixcontrol/event/mail.html
+++ b/src/pretix/control/templates/pretixcontrol/event/mail.html
@@ -74,7 +74,7 @@
                     {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_download_tickets_reminder items="mail_days_download_reminder,mail_text_download_reminder,mail_send_download_reminder_attendee,mail_text_download_reminder_attendee,mail_sales_channel_download_reminder" exclude="mail_days_download_reminder,mail_send_download_reminder_attendee,mail_sales_channel_download_reminder" %}
 
                     {% blocktrans asvar title_require_approval %}Order approval process{% endblocktrans %}
-                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_denied" %}
+                    {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_approved_free,mail_text_order_denied" %}
                 </div>
             </fieldset>
             <fieldset>


### PR DESCRIPTION
Z#2361977 requires a dedicated approval email for free orders, as they cannot repurpose the existing "Free Order" eMail-template.

I don't expect any issues merging this for a function POV.

However, in order to not annoy our hosted customers from Germany, we should probably deploy it only once the German translations for this have been merged, too.

Casus Knacksus @raphaelm: Is this something, we can merge and deploy without writing a migration, which duplicates the existing `mail_text_order_free` into the new `mail_text_order_approved_free` for existing events in order to conserve the current mail templates?