### PR TITLE
Refactor primary color to settings variable

### DIFF
--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -114,7 +114,7 @@ class TemplateBasedMailRenderer(BaseHTMLMailRenderer):
             'site_url': settings.SITE_URL,
             'body': body_md,
             'subject': str(subject),
-            'color': '#8E44B3',
+            'color': settings.PRETIX_PRIMARY_COLOR,
             'rtl': get_language() in settings.LANGUAGES_RTL
         }
         if self.event:

--- a/src/pretix/base/services/notifications.py
+++ b/src/pretix/base/services/notifications.py
@@ -91,7 +91,7 @@ def send_notification_mail(notification: Notification, user: User):
     ctx = {
         'site': settings.PRETIX_INSTANCE_NAME,
         'site_url': settings.SITE_URL,
-        'color': '#8E44B3',
+        'color': settings.PRETIX_PRIMARY_COLOR,
         'notification': notification,
         'settings_url': build_absolute_uri(
             'control:user.settings.notifications',

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1580,7 +1580,7 @@ Your {event} team"""))
         'type': bool
     },
     'primary_color': {
-        'default': '#8E44B3',
+        'default': settings.PRETIX_PRIMARY_COLOR,
         'type': str,
     },
     'theme_color_success': {

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -126,6 +126,7 @@ PRETIX_ADMIN_AUDIT_COMMENTS = config.getboolean('pretix', 'audit_comments', fall
 PRETIX_OBLIGATORY_2FA = config.getboolean('pretix', 'obligatory_2fa', fallback=False)
 PRETIX_SESSION_TIMEOUT_RELATIVE = 3600 * 3
 PRETIX_SESSION_TIMEOUT_ABSOLUTE = 3600 * 12
+PRETIX_PRIMARY_COLOR = '#8E44B3'
 
 SITE_URL = config.get('pretix', 'url', fallback='http://localhost')
 if SITE_URL.endswith('/'):


### PR DESCRIPTION
Thought about making it a variable for `pretix.cfg`, but as the color would need to be changed in many CSS places, too, I considered it more of a constant.