### PR TITLE
Fix #1127 -- Set loglevel from configfile

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -97,6 +97,9 @@ Example::
 
 ``csp_log``
     Log violations of the Content Security Policy (CSP). Defaults to ``on``.
+    
+``loglevel``
+    Set console and file loglevel (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR`` or ``CRITICAL``). Defaults to ``INFO``.
 
 Locale settings
 ---------------

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -561,7 +561,7 @@ MESSAGE_TAGS = {
 }
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
-loglevel = 'DEBUG' if DEBUG else 'INFO'
+loglevel = 'DEBUG' if DEBUG else config.get('pretix', 'loglevel', fallback='INFO')
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Introduce [pretix]:loglevel configuration option. This allows the loglevel to be set. Valid values are: DEBUG, INFO, WARNING, ERROR and CRITICAL.

Fixes #1127