### PR TITLE
Shredder: Only force download for tax-relevant data

### DIFF
--- a/src/pretix/base/services/shredder.py
+++ b/src/pretix/base/services/shredder.py
@@ -73,16 +73,19 @@ def shred(event: Event, fileid: str, confirm_code: str) -> None:
         indexdata = json.loads(zipfile.read('index.json').decode())
     if indexdata['organizer'] != event.organizer.slug or indexdata['event'] != event.slug:
         raise ShredError(_("This file is from a different event."))
-    if indexdata['confirm_code'] != confirm_code:
-        raise ShredError(_("The confirm code you entered was incorrect."))
-    if event.logentry_set.filter(datetime__gte=parse(indexdata['time'])):
-        raise ShredError(_("Something happened in your event after the export, please try again."))
-
+    shredders = []
     for s in indexdata['shredders']:
         shredder = known_shredders.get(s)
         if not shredder:
             continue
+        shredders.append(shredder)
+    if any(shredder.require_download_confirmation for shredder in shredders):
+        if indexdata['confirm_code'] != confirm_code:
+            raise ShredError(_("The confirm code you entered was incorrect."))
+    if event.logentry_set.filter(datetime__gte=parse(indexdata['time'])):
+        raise ShredError(_("Something happened in your event after the export, please try again."))
 
+    for shredder in shredders:
         shredder.shred_data()
 
     cf.file.delete(save=False)

--- a/src/pretix/base/shredder.py
+++ b/src/pretix/base/shredder.py
@@ -82,6 +82,14 @@ class BaseDataShredder:
         return False
 
     @property
+    def require_download_confirmation(self):
+        """
+        Indicates whether the data of this shredder needs to be downloaded, before it is actually shredded. By default
+        this value is equal to the tax relevant flag.
+        """
+        return self.tax_relevant
+
+    @property
     def verbose_name(self) -> str:
         """
         A human-readable name for what this shredder removes. This should be short but self-explanatory.

--- a/src/pretix/control/templates/pretixcontrol/shredder/download.html
+++ b/src/pretix/control/templates/pretixcontrol/shredder/download.html
@@ -11,12 +11,16 @@
           method="post" class="form-horizontal" data-asynctask>
         {% csrf_token %}
         <fieldset>
-            <legend>{% trans "Step 1: Download data" %}</legend>
+            {% if download_on_shred %}
+                <legend>{% trans "Step 1: Download data" %}</legend>
+            {% else %}
+                <legend>{% trans "(Optional) Step 1: Download data" %}</legend>
+            {% endif %}
             <p>
                 {% blocktrans trimmed %}
                     You are about to permanently delete data from the server, even though you might be required to
                     keep
-                    some of this data on file. You should therefore download the following file and store it in a safe
+                    some of this data on file. You can therefore download the following file and store it in a safe
                     place:
                 {% endblocktrans %}
             </p>
@@ -27,18 +31,7 @@
             </p>
         </fieldset>
         <fieldset>
-            <legend>{% trans "Step 2: Confirm download" %}</legend>
-            <p>
-                {% blocktrans trimmed %}
-                    In the downloaded file, there is a text file named "CONFIRM_CODE.txt" with a six-character code.
-                    Please enter this code here to confirm that you successfully downloaded the file.
-                {% endblocktrans %}
-            </p>
-            <input type="text" class="form-control" name="confirm_code" required placeholder="{% trans "Confirmation code" %}">
-            <br>
-        </fieldset>
-        <fieldset>
-            <legend>{% trans "Step 3: Confirm deletion" %}</legend>
+            <legend>{% trans "Step 2: Confirm deletion" %}</legend>
             <p>
                 {% blocktrans trimmed with event=request.event.name slug=request.event.slug %}
                 Please re-check that you are fully certain that you want to delete the selected categories of data from the event <strong>{{ event }}</strong>.
@@ -46,7 +39,21 @@
                 {% endblocktrans %}
             </p>
             <input type="text" class="form-control" name="slug" required placeholder="{% trans "Event short name" %}">
+            <br>
         </fieldset>
+        {% if download_on_shred %}
+            <fieldset>
+                <legend>{% trans "Step 3: Confirm download" %}</legend>
+                <p>
+                    {% blocktrans trimmed %}
+                        In the downloaded file, there is a text file named "CONFIRM_CODE.txt" with a six-character code.
+                        Please enter this code here to confirm that you successfully downloaded the file.
+                    {% endblocktrans %}
+                </p>
+                <input type="text" class="form-control" name="confirm_code" required placeholder="{% trans "Confirmation code" %}">
+                <br>
+            </fieldset>
+        {% endif %}
         <input type="hidden" name="file" value="{{ file.pk }}">
         <div class="form-group submit-group">
             <button type="submit" class="btn btn-primary btn-save">


### PR DESCRIPTION
Using this PR, I'd like to start the discussion on a potential solution to #1758. At our association we process a lot of personal data in Pretix, which is done by many volunteers. We try to take good care of personal data of our members, however when executing the data shred process all this personal data has to be downloaded to personal computers, resulting in a loss of control.

I've currently left the download file generating in, depending on how we'd like this to work I can adjust and expand the implementation.

Please let me know what you think. 