### PR TITLE
Docker: use the healthcheck endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,7 @@ RUN chmod +x /usr/local/bin/pretix && \
 USER pretixuser
 VOLUME ["/etc/pretix", "/data"]
 EXPOSE 80
+HEALTHCHECK --interval=1m --timeout=2m \
+  CMD curl -fSs http://localhost/healthcheck/ || exit 1
 ENTRYPOINT ["pretix"]
 CMD ["all"]


### PR DESCRIPTION
This adds a `HEALTHCHECK` (https://docs.docker.com/engine/reference/builder/#healthcheck) directive to the Dockerfile. It uses the /healthcheck/ endpoint documented here: https://docs.pretix.eu/en/latest/admin/maintainance.html#uptime-monitoring

For an example of another project using this, check out the `synapse` Matrix homeserver: https://github.com/matrix-org/synapse/blob/develop/docker/Dockerfile#L81