### PR TITLE
Sendmail plugin: Allow to attach a file to emails

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -231,7 +231,7 @@ def mail(email: Union[str, Sequence[str]], subject: str, template: Union[str, La
             attach_tickets=attach_tickets,
             attach_ical=attach_ical,
             user=user.pk if user else None,
-            attach_cached_files=[cf.id for cf in attach_cached_files] if attach_cached_files else [],
+            attach_cached_files=[(cf.id if isinstance(cf, CachedFile) else cf) for cf in attach_cached_files] if attach_cached_files else [],
         )
 
         if invoices:

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -29,6 +29,8 @@ class MailForm(forms.Form):
             ".pptx", ".ppt", ".doc", ".xlsx", ".xls", ".jfif", ".heic", ".heif", ".pages",
             ".bmp", ".tif", ".tiff"
         ),
+        help_text=_('Sending an attachment increases the chance of your email not arriving or being sorted into spam folders. We recommend only using PDFs '
+                    'of no more than 2 MB in size.'),
         max_size=10 * 1024 * 1024
     )  # TODO i18n
     items = forms.ModelMultipleChoiceField(

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -7,6 +7,7 @@ from i18nfield.forms import I18nFormField, I18nTextarea, I18nTextInput
 from pretix.base.email import get_available_placeholders
 from pretix.base.forms import PlaceholderValidator
 from pretix.base.models import CheckinList, Item, Order, SubEvent
+from pretix.control.forms import ExtFileField
 from pretix.control.forms.widgets import Select2, Select2Multiple
 
 
@@ -20,6 +21,16 @@ class MailForm(forms.Form):
     sendto = forms.MultipleChoiceField()  # overridden later
     subject = forms.CharField(label=_("Subject"))
     message = forms.CharField(label=_("Message"))
+    attachment = ExtFileField(
+        label=_("Attachment"),
+        required=False,
+        ext_whitelist=(
+            ".png", ".jpg", ".gif", ".jpeg", ".pdf", ".txt", ".docx", ".gif", ".svg",
+            ".pptx", ".ppt", ".doc", ".xlsx", ".xls", ".jfif", ".heic", ".heif", ".pages",
+            ".bmp", ".tif", ".tiff"
+        ),
+        max_size=10 * 1024 * 1024
+    )  # TODO i18n
     items = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple(
             attrs={'class': 'scrolling-multiple-choice'}

--- a/src/pretix/plugins/sendmail/tasks.py
+++ b/src/pretix/plugins/sendmail/tasks.py
@@ -89,7 +89,8 @@ def send_mails(event: Event, user: int, subject: dict, message: dict, orders: li
                         email_context,
                         event,
                         locale=o.locale,
-                        order=o
+                        order=o,
+                        attach_cached_files=attachments
                     )
                     o.log_action(
                         'pretix.plugins.sendmail.order.email.sent',

--- a/src/pretix/plugins/sendmail/tasks.py
+++ b/src/pretix/plugins/sendmail/tasks.py
@@ -10,7 +10,8 @@ from pretix.celery_app import app
 
 @app.task(base=ProfiledEventTask, acks_late=True)
 def send_mails(event: Event, user: int, subject: dict, message: dict, orders: list, items: list,
-               recipients: str, filter_checkins: bool, not_checked_in: bool, checkin_lists: list) -> None:
+               recipients: str, filter_checkins: bool, not_checked_in: bool, checkin_lists: list,
+               attachments: list = None) -> None:
     failures = []
     user = User.objects.get(pk=user) if user else None
     orders = Order.objects.filter(pk__in=orders, event=event)
@@ -61,7 +62,8 @@ def send_mails(event: Event, user: int, subject: dict, message: dict, orders: li
                             event,
                             locale=o.locale,
                             order=o,
-                            position=p
+                            position=p,
+                            attach_cached_files=attachments
                         )
                         o.log_action(
                             'pretix.plugins.sendmail.order.email.sent.attendee',

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -5,7 +5,7 @@
 {% block content %}
     <h1>{% trans "Send out emails" %}</h1>
     {% block inner %}
-        <form class="form-horizontal" method="post" action="">
+        <form class="form-horizontal" method="post" action="" enctype="multipart/form-data">
             {% csrf_token %}
             {% bootstrap_field form.recipients layout='horizontal' %}
             {% bootstrap_field form.sendto layout='horizontal' %}
@@ -32,6 +32,7 @@
             </div>
             {% bootstrap_field form.subject layout='horizontal' %}
             {% bootstrap_field form.message layout='horizontal' %}
+            {% bootstrap_field form.attachment layout='horizontal' %}
             {% if request.method == "POST" %}
             <fieldset>
             <legend>{% trans "E-mail preview" %}</legend>

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -143,6 +143,7 @@ class SenderView(EventPermissionRequiredMixin, FormView):
             cf = CachedFile.objects.create(
                 expires=now() + timedelta(days=1),
                 date=now(),
+                filename=attachment.name,
                 type=attachment.content_type,
             )
             cf.file.save(attachment.name, attachment.file)


### PR DESCRIPTION
This allows to attach a file to emails send out by the sendmail plugin.

Current limitations:
- only allows for 1 attachment
- the attachment is the same for all languages