### PR TITLE
Bump libsass-version to 0.20.*

### DIFF
--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -15,7 +15,7 @@ reportlab>=3.5.18*
 PyPDF2==1.26.*
 Pillow==7.*
 django-libsass==0.8
-libsass==0.19.2  # Bump when https://github.com/sass/libsass/issues/3053 is fixed
+libsass==0.20.*
 django-otp==0.7.*,>=0.7.5
 python-u2flib-server==4.*
 webauthn==0.4.*

--- a/src/setup.py
+++ b/src/setup.py
@@ -104,7 +104,7 @@ setup(
         'Pillow==7.*',
         'PyPDF2==1.26.*',
         'django-libsass==0.8',
-        'libsass==0.19.2',  # Bump when https://github.com/sass/libsass/issues/3053 is fixed
+        'libsass==0.20.*',
         'django-otp==0.7.*,>=0.7.5',
         'webauthn==0.4.*',
         'python-u2flib-server==4.*',


### PR DESCRIPTION
libsass 0.19.2 fails to install under latest OS X Catalina. As https://github.com/sass/libsass/issues/3053 seems to be fixed, bump to current version 0.20.*