### PR TITLE
Fix iCal export for full-day events (DTEND is non-inclusive)

### DIFF
--- a/src/pretix/presale/ical.py
+++ b/src/pretix/presale/ical.py
@@ -46,7 +46,9 @@ def get_ical(events):
             if event.settings.show_times:
                 vevent.add('dtend').value = ev.date_to.astimezone(tz)
             else:
-                vevent.add('dtend').value = ev.date_to.astimezone(tz).date()
+                # with full-day events date_to in pretix is included (e.g. last day)
+                # whereas dtend in vcalendar is non-inclusive => add one day for export
+                vevent.add('dtend').value = ev.date_to.astimezone(tz).date() + datetime.timedelta(days=1) 
 
         descr = []
         descr.append(_('Tickets: {url}').format(url=url))

--- a/src/pretix/presale/ical.py
+++ b/src/pretix/presale/ical.py
@@ -48,7 +48,7 @@ def get_ical(events):
             else:
                 # with full-day events date_to in pretix is included (e.g. last day)
                 # whereas dtend in vcalendar is non-inclusive => add one day for export
-                vevent.add('dtend').value = ev.date_to.astimezone(tz).date() + datetime.timedelta(days=1) 
+                vevent.add('dtend').value = ev.date_to.astimezone(tz).date() + datetime.timedelta(days=1)
 
         descr = []
         descr.append(_('Tickets: {url}').format(url=url))

--- a/src/tests/presale/test_event.py
+++ b/src/tests/presale/test_event.py
@@ -1172,7 +1172,7 @@ class EventIcalDownloadTest(EventTestMixin, SoupTest):
         self.event.save()
         ical = self.client.get('/%s/%s/ical/' % (self.orga.slug, self.event.slug)).content.decode()
         self.assertIn('DTSTART;VALUE=DATE:%s' % self.event.date_from.strftime('%Y%m%d'), ical, 'incorrect start date')
-        self.assertIn('DTEND;VALUE=DATE:%s' % self.event.date_to.strftime('%Y%m%d'), ical, 'incorrect end date')
+        self.assertIn('DTEND;VALUE=DATE:%s' % (self.event.date_to + datetime.timedelta(days=1)).strftime('%Y%m%d'), ical, 'incorrect end date')
 
     def test_no_date_to(self):
         self.event.settings.timezone = 'Asia/Tokyo'
@@ -1202,7 +1202,7 @@ class EventIcalDownloadTest(EventTestMixin, SoupTest):
         self.event.save()
         ical = self.client.get('/%s/%s/ical/' % (self.orga.slug, self.event.slug)).content.decode()
         self.assertIn('DTSTART;VALUE=DATE:20131227', ical, 'incorrect start date')
-        self.assertIn('DTEND;VALUE=DATE:20131229', ical, 'incorrect end date')
+        self.assertIn('DTEND;VALUE=DATE:20131230', ical, 'incorrect end date')
 
     def test_subevent_required(self):
         self.event.has_subevents = True
@@ -1226,7 +1226,7 @@ class EventIcalDownloadTest(EventTestMixin, SoupTest):
         self.event.settings.show_times = False
         ical = self.client.get('/%s/%s/ical/%d/' % (self.orga.slug, self.event.slug, se1.pk)).content.decode()
         self.assertIn('DTSTART;VALUE=DATE:20141226', ical, 'incorrect start date')
-        self.assertIn('DTEND;VALUE=DATE:20141228', ical, 'incorrect end date')
+        self.assertIn('DTEND;VALUE=DATE:20141229', ical, 'incorrect end date')
         self.assertIn('SUMMARY:%s' % se1.name, ical, 'incorrect correct summary')
         self.assertIn('LOCATION:Heeeeeere', ical, 'incorrect location')
 


### PR DESCRIPTION
in pretix, end-date is inclusive (last day) whereas in ics end-date is non-inclusive. Add 1 day to end-date for full-day events in ical-export