### PR TITLE
Added combined radiob uttons for <name>_asked and <name>_required fields

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -571,6 +571,7 @@ class EventSettingsForm(SettingsForm):
                 label=asked_field.label,
                 help_text=asked_field.help_text,
                 required=True,
+                widget=forms.RadioSelect,
                 choices=[
                     # default key needs a value other than '' because with '' it would also overwrite even if combi-field is not transmitted
                     ('do_not_ask', _('Do not ask')),

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -106,17 +106,7 @@
                     </div>
                 </div>
                 {% bootstrap_field sform.order_email_asked_twice layout="control" %}
-                <div class="form-group">
-                    <label class="control-label col-md-3">
-                        {% trans "Phone number" %}
-                    </label>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.order_phone_asked layout="inline" form_group_class="" label=asked %}
-                    </div>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.order_phone_required layout="inline" form_group_class="" label=required %}
-                    </div>
-                </div>
+                {% bootstrap_field sform.order_phone_asked_required layout="control" %}
                 <div class="form-group">
                     <label class="control-label col-md-3">
                         {% trans "Name and address" %}
@@ -131,50 +121,12 @@
                 </div>
 
                 <h4>{% trans "Attendee data (once per admission ticket)" %}</h4>
-                <div class="form-group">
-                    <label class="control-label col-md-3">
-                        {% trans "Name" %}
-                    </label>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_names_asked layout="inline" form_group_class="" label=asked %}
-                    </div>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_names_required layout="inline" form_group_class="" label=required %}
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label class="control-label col-md-3">
-                        {% trans "E-mail" %}
-                    </label>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_emails_asked layout="inline" form_group_class="" label=asked %}
-                    </div>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_emails_required layout="inline" form_group_class="" label=required %}
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label class="control-label col-md-3">
-                        {% trans "Company" %}
-                    </label>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_company_asked layout="inline" form_group_class="" label=asked %}
-                    </div>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_company_required layout="inline" form_group_class="" label=required %}
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label class="control-label col-md-3">
-                        {% trans "Address" %}
-                    </label>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_addresses_asked layout="inline" form_group_class="" label=asked %}
-                    </div>
-                    <div class="col-md-3 form-field-boundary">
-                        {% bootstrap_field sform.attendee_addresses_required layout="inline" form_group_class="" label=required %}
-                    </div>
-                </div>
+
+                {% bootstrap_field sform.attendee_names_asked_required layout="control" %}
+                {% bootstrap_field sform.attendee_emails_asked_required layout="control" %}
+                {% bootstrap_field sform.attendee_company_asked_required layout="control" %}
+                {% bootstrap_field sform.attendee_addresses_asked_required layout="control" %}
+
                 <div class="form-group">
                     <label class="control-label col-md-3">
                         {% trans "Custom fields" %}


### PR DESCRIPTION
This is a UI/UX variant for the event settings. For each combination of _asked and _required fields, one ChoiceField is created and set. The more I look at it, I am torn and not so sure, whether this is the better UX – for me, the settings are easier to grasp with the table of checkboxes. But setting it to „Do not ask“ is more clear and understandable with the <select> than with unticking both boxes. Also one select is easier in the front-end as no logic is needed to keep the checkboxes in sync.

Currently the combined ChoiceField uses the label and help_text of its _asked-field. I am not sure, whether this is the best solution.