### PR TITLE
Show "live issues" when event is already live

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/live.html
+++ b/src/pretix/control/templates/pretixcontrol/event/live.html
@@ -12,6 +12,18 @@
                 <p>
                     {% trans "Your shop is currently live. If you take it down, it will only be visible to you and your team." %}
                 </p>
+                {% if issues|length > 0 %}
+                    <div class="alert alert-warning">
+                        <p>
+                            {% trans "Your shop is already live, however the following issues would normally prevent your shop to go live:" %}
+                        </p>
+                        <ul>
+                            {% for issue in issues %}
+                                <li>{{ issue|safe }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
                 <form action="" method="post" class="text-right flip">
                     {% csrf_token %}
                     <input type="hidden" name="live" value="false">


### PR DESCRIPTION
Using the `event_live_issues` we can prevent an event from going live with all kinds of checks. However once it is set live, these issues are no longer showing. When changes are made to settings of the event, new live issues could arise. I'd like to show these live issues on the live page, so users can see them:
![scrot-2020-12-23T00:44:26+01:00](https://user-images.githubusercontent.com/904824/102943350-098f7580-44b8-11eb-85fb-c0eacd760651.png)

In our plugin we have added a custom `event_dashboard_widgets` based on the `shop_state_widget`, I've not included the widget in this MR, as I wasn't sure on whether you'd want to have it for all events. Let me know if you'd like for me to add the widget as well:
![scrot-2020-12-23T00:35:11+01:00](https://user-images.githubusercontent.com/904824/102943206-b1f10a00-44b7-11eb-8928-90a902676398.png)
