### PR TITLE
Add convenience redirect …/event/(org)/ => …/organizer/(org)/

### DIFF
--- a/src/pretix/control/urls.py
+++ b/src/pretix/control/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.views.generic.base import RedirectView
 
 from pretix.control.views import (
     auth, checkin, dashboards, event, geo, global_settings, item, main, oauth,
@@ -303,4 +304,5 @@ urlpatterns = [
         url(r'^checkinlists/(?P<list>\d+)/delete$', checkin.CheckinListDelete.as_view(),
             name='event.orders.checkinlists.delete'),
     ])),
+    url(r'^event/(?P<organizer>[^/]+)/$', RedirectView.as_view(pattern_name='control:organizer'), name='event.organizerredirect'),
 ]

--- a/src/tests/control/test_events.py
+++ b/src/tests/control/test_events.py
@@ -55,6 +55,10 @@ class EventsTest(SoupTest):
         self.assertNotIn("31C3", tabletext)
         self.assertNotIn("MRMCD14", tabletext)
 
+    def test_convenience_organizer_redirect(self):
+        resp = self.client.get('/control/event/%s/' % (self.orga1.slug))
+        self.assertRedirects(resp, '/control/organizer/%s/' % (self.orga1.slug))
+
     def test_quick_setup_later(self):
         with scopes_disabled():
             self.event1.quotas.create(name='foo', size=2)


### PR DESCRIPTION
Calling https://pretix.eu/control/event/uberspace/ (obtained by stripping the event name off) currently yields a 404. This implementes a redirect to https://pretix.eu/control/organizer/uberspace/ instead.