### PR TITLE
Add option to export multiple choice answers in orderlists grouped

### DIFF
--- a/src/tests/api/test_exporters.py
+++ b/src/tests/api/test_exporters.py
@@ -33,6 +33,10 @@ SAMPLE_EXPORTER_CONFIG = {
             "name": "include_payment_amounts",
             "required": False
         },
+        {
+            "name": "group_multiple_choice",
+            "required": False
+        },
     ]
 }
 


### PR DESCRIPTION
Currently, the export of orderlines creates one column per possible answer of a mulitple choice question containing Yes/No.

This pull request introduces a new optional checkbox field to choose grouping these answers in a single column of the order line instead. It will use the question title as column header (instead of question title followed by the answer like it is done in the existing export) and all selected answers for each row as comma-separated list (each comma is followed by a blank as this export format is mainly intended for manual parsing/reading).

The feature is introduced as code change instead of a separate plugin to prevent large amounts of code duplications.

Additionally, one API test was slightly adjusted to support the new option.