### PR TITLE
Documentation typo fix

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -1759,7 +1759,7 @@ class OrderRefund(models.Model):
         Marks the refund as complete. This does not modify the state of the order.
 
         :param user: The user who performed the change
-        :param user: The API auth token that performed the change
+        :param auth: The API auth token that performed the change
         """
         self.state = self.REFUND_STATE_DONE
         self.execution_date = self.execution_date or now()

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -616,7 +616,7 @@ class EventCancelForm(forms.Form):
         required=False
     )
     manual_refund = forms.BooleanField(
-        label=_('Create manual refund if the payment method odes not support automatic refunds'),
+        label=_('Create manual refund if the payment method does not support automatic refunds'),
         widget=forms.CheckboxInput(attrs={'data-display-dependency': '#id_auto_refund'}),
         initial=True,
         required=False,


### PR DESCRIPTION
There is a typo in the documentation of OrderRefund.done(user, auth). It is written "param user" twice, where in the second it should be "param auth".

UPD: There is another typo in the label.