### PR TITLE
Bulk action improvements: buttons (wording, color, icons, disabled-state), hide select-on-all-pages if only one results-page

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/subevents/index.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/index.html
@@ -90,7 +90,7 @@
                         </th>
                         <th></th>
                     </tr>
-                    {% if "can_change_event_settings" in request.eventpermset %}
+                    {% if "can_change_event_settings" in request.eventpermset and page_obj.paginator.num_pages > 1 %}
                         <tr class="table-select-all warning hidden">
                             <td>
                                 <input type="checkbox" name="__ALL" id="__all" data-results-total="{{ page_obj.paginator.count }}">

--- a/src/pretix/control/templates/pretixcontrol/subevents/index.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/index.html
@@ -167,18 +167,18 @@
                 </table>
             </div>
             {% if "can_change_event_settings" in request.eventpermset %}
-                <button type="submit" class="btn btn-default btn-save" name="action" value="delete">
-                    {% trans "Delete selected" %}
+                <button type="submit" class="btn btn-danger btn-save" name="action" value="delete">
+                    <i class="fa fa-trash"></i>{% trans "Delete selected" %}
                 </button>
-                <button type="submit" class="btn btn-default btn-save" name="action" value="disable"
+                <button type="submit" class="btn btn-primary btn-save" name="action" value="disable"
                         formaction="{% url "control:event.subevents.bulkedit"  organizer=request.event.organizer.slug event=request.event.slug %}">
-                    {% trans "Change selected" %}
+                    <i class="fa fa-edit"></i>{% trans "Edit selected" %}
                 </button>
                 <button type="submit" class="btn btn-default btn-save" name="action" value="enable">
-                    {% trans "Enable selected" %}
+                    <i class="fa fa-check"></i>{% trans "Activate selected" %}
                 </button>
                 <button type="submit" class="btn btn-default btn-save" name="action" value="disable">
-                    {% trans "Disable selected" %}
+                    <i class="fa fa-ban"></i>{% trans "Deactivate selected" %}
                 </button>
             {% endif %}
         </form>

--- a/src/pretix/control/templates/pretixcontrol/subevents/index.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/index.html
@@ -108,7 +108,7 @@
                         <tr>
                             <td>
                                 {% if "can_change_event_settings" in request.eventpermset %}
-                                    <label aria-label="{% trans "select row for batch-operation" %}" class="batch-select-label"><input type="checkbox" name="subevent" class="" value="{{ s.pk }}"/></label>
+                                    <label aria-label="{% trans "select row for batch-operation" %}" class="batch-select-label"><input type="checkbox" name="subevent" class="batch-select-checkbox" value="{{ s.pk }}"/></label>
                                 {% endif %}
                             </td>
                             <td>
@@ -167,6 +167,7 @@
                 </table>
             </div>
             {% if "can_change_event_settings" in request.eventpermset %}
+            <div class="batch-select-actions">
                 <button type="submit" class="btn btn-danger btn-save" name="action" value="delete">
                     <i class="fa fa-trash"></i>{% trans "Delete selected" %}
                 </button>
@@ -180,6 +181,7 @@
                 <button type="submit" class="btn btn-default btn-save" name="action" value="disable">
                     <i class="fa fa-ban"></i>{% trans "Deactivate selected" %}
                 </button>
+            </div>
             {% endif %}
         </form>
         {% include "pretixcontrol/pagination.html" %}

--- a/src/pretix/control/templates/pretixcontrol/subevents/index.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/index.html
@@ -93,7 +93,7 @@
                     {% if "can_change_event_settings" in request.eventpermset %}
                         <tr class="table-select-all warning hidden">
                             <td>
-                                <input type="checkbox" name="__ALL" id="__all">
+                                <input type="checkbox" name="__ALL" id="__all" data-results-total="{{ page_obj.paginator.count }}">
                             </td>
                             <td colspan="5">
                                 <label for="__all">

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -690,6 +690,7 @@ $(function () {
     // Tables with bulk selection, e.g. subevent list
     $("input[data-toggle-table]").each(function (ev) {
         var $toggle = $(this);
+        var $actionButtons = $(".batch-select-actions button", this.form);
         var $table = $toggle.closest("table");
         var $selectAll = $table.find(".table-select-all");
         var $rows = $table.find("tbody tr");
@@ -758,37 +759,38 @@ $(function () {
             });
         });
 
+        var update = function() {
+            var nrOfChecked = $checkboxes.filter(":checked").length;
 
-        var update = function () {
-            var all_same;
-            var checkboxes = $checkboxes.toArray();
-            var i = checkboxes.length;
-            while (i--) {
-                if (all_same === undefined) {
-                    all_same = checkboxes[i].checked;
-                    continue;
+            if (!nrOfChecked) {
+                $actionButtons.attr("disabled", true);
+
+                $selectAll.toggleClass("hidden", true).prop("hidden", true);
+                $selectAll.find("input").prop("checked", false);
+
+                $toggle.prop("checked", false).prop("indeterminate", false);
+            }
+            else {
+                $actionButtons.attr("disabled", false);
+
+                if (nrOfChecked == $checkboxes.length) {
+                    $selectAll.toggleClass("hidden", false).prop("hidden", false);
+                    $toggle.prop("checked", true).prop("indeterminate", false);
                 }
-                if (all_same != checkboxes[i].checked) {
-                    $toggle.prop("checked", false).prop("indeterminate", true).trigger("change");
-                    return;
+                else {
+                    $toggle.prop("checked",false).prop("indeterminate", true);
                 }
             }
-            $toggle.prop("checked", all_same).prop("indeterminate", false).trigger("change");
-        };
+        }
 
-        var debounceUpdate;
-        $checkboxes.change(function() {
-            //$(this).closest("tr").toggleClass("warning", this.checked);
-            // when changing the $toggle’s checked-property, lots of change events 
-            // get triggered => debounce
-            if (debounceUpdate) window.clearTimeout(debounceUpdate);
-            debounceUpdate = window.setTimeout(update, 10);
-        });
+        $checkboxes.change(update);
         $toggle.change(function (ev) {
-            if (!this.indeterminate) $checkboxes.prop("checked", this.checked);//.trigger("change");
-            $selectAll.toggleClass("hidden", !this.checked).prop("hidden", !this.checked);
-            if (!this.checked) $selectAll.find("input").prop("checked", false);
+            this.indeterminate = false;
+            $checkboxes.prop("checked", this.checked);
+            update();
         });
+
+        update();
     });
 
     // Items and categories

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -691,6 +691,7 @@ $(function () {
     $("input[data-toggle-table]").each(function (ev) {
         var $toggle = $(this);
         var $actionButtons = $(".batch-select-actions button", this.form);
+        var countLabels = $("<span></span>").appendTo($actionButtons);
         var $table = $toggle.closest("table");
         var $selectAll = $table.find(".table-select-all");
         var $rows = $table.find("tbody tr");
@@ -761,26 +762,17 @@ $(function () {
 
         var update = function() {
             var nrOfChecked = $checkboxes.filter(":checked").length;
+            var allChecked = nrOfChecked == $checkboxes.length;
 
-            if (!nrOfChecked) {
-                $actionButtons.attr("disabled", true);
+            if (!nrOfChecked) countLabels.empty();
+            else countLabels.text(" ("+nrOfChecked+")");
 
-                $selectAll.toggleClass("hidden", true).prop("hidden", true);
-                $selectAll.find("input").prop("checked", false);
+            if (!allChecked) $selectAll.find("input").prop("checked", false); 
 
-                $toggle.prop("checked", false).prop("indeterminate", false);
-            }
-            else {
-                $actionButtons.attr("disabled", false);
+            $actionButtons.attr("disabled", !nrOfChecked);
+            $toggle.prop("checked", allChecked).prop("indeterminate", nrOfChecked > 0 && !allChecked);
+            $selectAll.toggleClass("hidden", nrOfChecked !== $checkboxes.length).prop("hidden", nrOfChecked !== $checkboxes.length);
 
-                if (nrOfChecked == $checkboxes.length) {
-                    $selectAll.toggleClass("hidden", false).prop("hidden", false);
-                    $toggle.prop("checked", true).prop("indeterminate", false);
-                }
-                else {
-                    $toggle.prop("checked",false).prop("indeterminate", true);
-                }
-            }
         }
 
         $checkboxes.change(update);
@@ -789,6 +781,10 @@ $(function () {
             $checkboxes.prop("checked", this.checked);
             update();
         });
+        $selectAll.find("input").change(function(ev) {
+            if (this.checked) countLabels.text(" ("+this.getAttribute("data-results-total")+")");
+            else countLabels.text(" ("+$checkboxes.filter(":checked").length+")");
+        })
 
         update();
     });


### PR DESCRIPTION
This adds several improvements to bulk-select:
- buttons are now colored, especially the delete button has a .danger-class
- added icons to buttons
- buttons are disabled, if no row is selected
- checkbox to select all results on all pages is only available if results span more than one page