### PR TITLE
Geo fields: Allow overriding existing values

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/fragment_geodata.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_geodata.html
@@ -4,6 +4,7 @@
 
 <div class="geodata-section">
     {% bootstrap_field form.location layout="control" %}
+    {% include "pretixcontrol/event/fragment_geodata_autoupdate.html" %}
     <div class="form-group geodata-group"
          data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}"
          data-attrib="{{ global_settings.leaflet_tiles_attribution }}"

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_geodata.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_geodata.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load bootstrap3 %}
+{% load static %}
+
+<div class="geodata-section">
+    {% bootstrap_field form.location layout="control" %}
+    <div class="form-group geodata-group"
+         data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}"
+         data-attrib="{{ global_settings.leaflet_tiles_attribution }}"
+         data-icon="{% static "leaflet/images/marker-icon.png" %}"
+         data-shadow="{% static "leaflet/images/marker-shadow.png" %}">
+        <label class="col-md-3 control-label">
+            {% trans "Geo coordinates" %}<br>
+            <span class="optional">{% trans "Optional" %}</span>
+        </label>
+        <div class="col-md-4">
+            {% bootstrap_field form.geo_lat layout="inline" %}
+            {% if global_settings.opencagedata_apikey %}
+                <p class="attrib">
+                    <a href="https://openstreetmap.org/" target="_blank">
+                        {% trans "Geocoding data © OpenStreetMap" %}
+                    </a>
+                </p>
+            {% endif %}
+        </div>
+        <div class="col-md-4">
+            {% bootstrap_field form.geo_lon layout="inline" %}
+        </div>
+        <div class="col-md-1">
+        </div>
+    </div>
+</div>

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_geodata_autoupdate.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_geodata_autoupdate.html
@@ -1,11 +1,8 @@
 {% load i18n %}
 
-<div class="form-group geodata-autoupdate">
-    <div class="col-md-3"></div>
-    <div class="col-md-9">
-        <p class="help-block error-notification"><i class="fa fa-warning"></i> {% trans "Failed to retrieve geo coordinates." %}</p>
-        <p class="help-block loading-notification"><i class="fa fa-cog fa-spin"></i> {% trans "Retrieving geo coordinates for location …" %}</p>
-        <p class="help-block updated-notification"><i class="fa fa-check"></i> {% trans "Your geo coordinates have been updated." %}</p>
-        <p class="help-block triggered-notification"><i class="fa fa-question-circle"></i> {% trans "You changed the location. Do you want to update your geo coordinates?" %} <button type="button" data-action="update" class="btn btn-secondary">{% trans "Update geo coordinates" %}</button></p>
-    </div>
-</div>
+<span class="geodata-autoupdate">
+    <span class="optional" data-notification="error" title="{% trans "Failed to retrieve geo coordinates" %}"><i class="fa fa-warning"></i></span>
+    <span class="optional" data-notification="loading" title="{% trans "Retrieving geo coordinates …" %}"><i class="fa fa-cog fa-spin"></i></span>
+    <span class="optional" data-notification="updated"><i class="fa fa-check"></i> {% trans "Geo coordinates updated" %}</span>
+    <span class="optional" data-notification="confirm">New geo coordinates. <button type="button" data-action="update" class="btn btn-link text-nowrap">{% trans "Update map?" %}</button></span>
+</span>

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_geodata_autoupdate.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_geodata_autoupdate.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<div class="form-group geodata-autoupdate">
+    <div class="col-md-3"></div>
+    <div class="col-md-9">
+        <p class="help-block error-notification"><i class="fa fa-warning"></i> {% trans "Failed to retrieve geo coordinates." %}</p>
+        <p class="help-block loading-notification"><i class="fa fa-cog fa-spin"></i> {% trans "Retrieving geo coordinates for location …" %}</p>
+        <p class="help-block updated-notification"><i class="fa fa-check"></i> {% trans "Your geo coordinates have been updated." %}</p>
+        <p class="help-block triggered-notification"><i class="fa fa-question-circle"></i> {% trans "You changed the location. Do you want to update your geo coordinates?" %} <button type="button" data-action="update" class="btn btn-secondary">{% trans "Update geo coordinates" %}</button></p>
+    </div>
+</div>

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -24,34 +24,7 @@
                 {% endif %}
                 {% bootstrap_field form.date_from layout="control" %}
                 {% bootstrap_field form.date_to layout="control" %}
-                <div class="geodata-section">
-                    {% bootstrap_field form.location layout="control" %}
-                    <div class="form-group geodata-group"
-                         data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}"
-                         data-attrib="{{ global_settings.leaflet_tiles_attribution }}"
-                         data-icon="{% static "leaflet/images/marker-icon.png" %}"
-                         data-shadow="{% static "leaflet/images/marker-shadow.png" %}">
-                        <label class="col-md-3 control-label">
-                            {% trans "Geo coordinates" %}<br>
-                            <span class="optional">{% trans "Optional" %}</span>
-                        </label>
-                        <div class="col-md-4">
-                            {% bootstrap_field form.geo_lat layout="inline" %}
-                            {% if global_settings.opencagedata_apikey %}
-                                <p class="attrib">
-                                    <a href="https://openstreetmap.org/" target="_blank">
-                                        {% trans "Geocoding data © OpenStreetMap" %}
-                                    </a>
-                                </p>
-                            {% endif %}
-                        </div>
-                        <div class="col-md-4">
-                            {% bootstrap_field form.geo_lon layout="inline" %}
-                        </div>
-                        <div class="col-md-1">
-                        </div>
-                    </div>
-                </div>
+                {% include "pretixcontrol/event/fragment_geodata.html" %}
                 {% bootstrap_field form.date_admission layout="control" %}
                 {% bootstrap_field form.currency layout="control" %}
                 {% bootstrap_field sform.contact_mail layout="control" %}

--- a/src/pretix/control/templates/pretixcontrol/events/create_basics.html
+++ b/src/pretix/control/templates/pretixcontrol/events/create_basics.html
@@ -39,30 +39,7 @@
         {% if form.date_to %}
             {% bootstrap_field form.date_to layout="control" %}
         {% endif %}
-        <div class="geodata-section">
-            {% bootstrap_field form.location layout="control" %}
-            <div class="form-group geodata-group" data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}" data-attrib="{{ global_settings.leaflet_tiles_attribution }}" data-icon="{% static "leaflet/images/marker-icon.png" %}" data-shadow="{% static "leaflet/images/marker-shadow.png" %}">
-                <label class="col-md-3 control-label">
-                    {% trans "Geo coordinates" %}<br>
-                    <span class="optional">{% trans "Optional" %}</span>
-                </label>
-                <div class="col-md-4">
-                    {% bootstrap_field form.geo_lat layout="inline" %}
-                    {% if global_settings.opencagedata_apikey %}
-                        <p class="attrib">
-                            <a href="https://openstreetmap.org/" target="_blank">
-                                {% trans "Geocoding data © OpenStreetMap" %}
-                            </a>
-                        </p>
-                    {% endif %}
-                </div>
-                <div class="col-md-4">
-                    {% bootstrap_field form.geo_lon layout="inline" %}
-                </div>
-                <div class="col-md-1">
-                </div>
-            </div>
-        </div>
+        {% include "pretixcontrol/event/fragment_geodata.html" %}
         {% bootstrap_field form.currency layout="control" %}
         {% bootstrap_field form.tax_rate addon_after="%" layout="control" %}
     </fieldset>

--- a/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
@@ -384,30 +384,7 @@
             <legend>{% trans "General information" %}</legend>
             {% bootstrap_field form.name layout="control" %}
             {% bootstrap_field form.active layout="control" %}
-            <div class="geodata-section">
-                {% bootstrap_field form.location layout="control" %}
-                <div class="form-group geodata-group" data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}" data-attrib="{{ global_settings.leaflet_tiles_attribution }}" data-icon="{% static "leaflet/images/marker-icon.png" %}" data-shadow="{% static "leaflet/images/marker-shadow.png" %}">
-                    <label class="col-md-3 control-label">
-                        {% trans "Geo coordinates" %}<br>
-                        <span class="optional">{% trans "Optional" %}</span>
-                    </label>
-                    <div class="col-md-4">
-                        {% bootstrap_field form.geo_lat layout="inline" %}
-                        {% if global_settings.opencagedata_apikey %}
-                            <p class="attrib">
-                                <a href="https://openstreetmap.org/" target="_blank">
-                                    {% trans "Geocoding data © OpenStreetMap" %}
-                                </a>
-                            </p>
-                        {% endif %}
-                    </div>
-                    <div class="col-md-4">
-                        {% bootstrap_field form.geo_lon layout="inline" %}
-                    </div>
-                    <div class="col-md-1">
-                    </div>
-                </div>
-            </div>
+            {% include "pretixcontrol/event/fragment_geodata.html" %}
             {% bootstrap_field form.frontpage_text layout="control" %}
             {% bootstrap_field form.is_public layout="control" %}
             {% if meta_forms %}

--- a/src/pretix/control/templates/pretixcontrol/subevents/bulk_edit.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/bulk_edit.html
@@ -32,6 +32,7 @@
             {% bootstrap_field form.active layout="bulkedit" %}
             <div class="geodata-section">
                 {% bootstrap_field form.location layout="bulkedit" %}
+                {% include "pretixcontrol/event/fragment_geodata_autoupdate.html" %}
                 <div class="form-group geodata-group"
                         data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}"
                         data-attrib="{{ global_settings.leaflet_tiles_attribution }}"

--- a/src/pretix/control/templates/pretixcontrol/subevents/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/detail.html
@@ -25,30 +25,7 @@
                     {% bootstrap_field form.active layout="control" %}
                     {% bootstrap_field form.date_from layout="control" %}
                     {% bootstrap_field form.date_to layout="control" %}
-                    <div class="geodata-section">
-                        {% bootstrap_field form.location layout="control" %}
-                        <div class="form-group geodata-group" data-tiles="{{ global_settings.leaflet_tiles|default_if_none:"" }}" data-attrib="{{ global_settings.leaflet_tiles_attribution }}" data-icon="{% static "leaflet/images/marker-icon.png" %}" data-shadow="{% static "leaflet/images/marker-shadow.png" %}">
-                            <label class="col-md-3 control-label">
-                                {% trans "Geo coordinates" %}<br>
-                                <span class="optional">{% trans "Optional" %}</span>
-                            </label>
-                            <div class="col-md-4">
-                                {% bootstrap_field form.geo_lat layout="inline" %}
-                                {% if global_settings.opencagedata_apikey %}
-                                    <p class="attrib">
-                                        <a href="https://openstreetmap.org/" target="_blank">
-                                            {% trans "Geocoding data © OpenStreetMap" %}
-                                        </a>
-                                    </p>
-                                {% endif %}
-                            </div>
-                            <div class="col-md-4">
-                                {% bootstrap_field form.geo_lon layout="inline" %}
-                            </div>
-                            <div class="col-md-1">
-                            </div>
-                        </div>
-                    </div>
+                    {% include "pretixcontrol/event/fragment_geodata.html" %}
                     {% bootstrap_field form.date_admission layout="control" %}
                     {% bootstrap_field form.frontpage_text layout="control" %}
                     {% bootstrap_field form.is_public layout="control" %}

--- a/src/pretix/static/pretixcontrol/js/ui/geo.js
+++ b/src/pretix/static/pretixcontrol/js/ui/geo.js
@@ -22,7 +22,7 @@ $(function () {
         var debounceLocationChange, debounceLatLonChange, delayLoadingIndicator, delayUpdateDismissal;
         var touched = $lat.val() !== "";
         var xhr;
-        var lastLocation;
+        var lastLocation = $.trim($location.val().replace(/\n/g, ", "));
 
         function load() {
             window.clearTimeout(debounceLocationChange);

--- a/src/pretix/static/pretixcontrol/js/ui/geo.js
+++ b/src/pretix/static/pretixcontrol/js/ui/geo.js
@@ -32,16 +32,21 @@ $(function () {
             lastLocation = q;
 
             window.clearTimeout(delayLoadingIndicator);
-            delayLoadingIndicator = window.setTimeout(function() {
-                $sec.removeClass("notify-updated").addClass("notify-loading");
-            }, 1000);
+            if ($sec.hasClass("notify-error") || $sec.hasClass("notify-updated") || $sec.hasClass("notify-triggered")) {
+                $sec.removeClass("notify-error notify-updated notify-triggered").addClass("notify-loading");
+            }
+            else {
+                delayLoadingIndicator = window.setTimeout(function() {
+                    $sec.removeClass("notify-error notify-updated notify-triggered").addClass("notify-loading");
+                }, 1000);
+            }
 
             if (xhr) xhr.abort();
 
             xhr = $.getJSON('/control/geocode/?q=' + encodeURIComponent(q), function (res) {
                 var q2 = $.trim($location.val().replace(/\n/g, ", "));
                 window.clearTimeout(delayLoadingIndicator);
-                $sec.removeClass("notify-updated").removeClass("notify-loading");
+                $sec.removeClass("notify-error notify-updated notify-triggered notify-loading");
                 if (q2 !== q) {
                     return;  // lost race
                 }

--- a/src/pretix/static/pretixcontrol/js/ui/geo.js
+++ b/src/pretix/static/pretixcontrol/js/ui/geo.js
@@ -1,128 +1,128 @@
 /*globals $*/
 
 $(function () {
-  var j = 0;
-  $(".geodata-section").each(function () {
-    // Geocoding
-    var $sec = $(this);
-    var $inp = $(this).find("textarea[lang=en], input[lang=en]").first();
-    if ($inp.length === 0) {
-      $inp = $(this).find("textarea, input").first();
-    }
-    var timer, timer2;
-    var touched = $sec.find("input[name$=geo_lat]").val() !== "";
-
-    function load() {
-      window.clearTimeout(timer);
-      var q = $.trim($inp.val().replace(/\n/g, ", "));
-      if ((touched && $sec.find("input[name$=geo_lat]").val() !== "") || $.trim(q) === "") {
-        return;
-      }
-      $sec.find(".col-md-1").html("<span class='fa fa-cog fa-spin'></span>");
-      $.getJSON('/control/geocode/?q=' + encodeURIComponent(q), function (res) {
-        var q2 = $.trim($inp.val().replace(/\n/g, ", "));
-        if (q2 !== q) {
-          return;  // lost race
+    var j = 0;
+    $(".geodata-section").each(function () {
+        // Geocoding
+        var $sec = $(this);
+        var $inp = $(this).find("textarea[lang=en], input[lang=en]").first();
+        if ($inp.length === 0) {
+            $inp = $(this).find("textarea, input").first();
         }
-        if (res.results) {
-          $sec.find("input[name$=geo_lat]").val(res.results[0].lat);
-          $sec.find("input[name$=geo_lon]").val(res.results[0].lon);
-          center(13);
+        var timer, timer2;
+        var touched = $sec.find("input[name$=geo_lat]").val() !== "";
+
+        function load() {
+            window.clearTimeout(timer);
+            var q = $.trim($inp.val().replace(/\n/g, ", "));
+            if ((touched && $sec.find("input[name$=geo_lat]").val() !== "") || $.trim(q) === "") {
+                return;
+            }
+            $sec.find(".col-md-1").html("<span class='fa fa-cog fa-spin'></span>");
+            $.getJSON('/control/geocode/?q=' + encodeURIComponent(q), function (res) {
+                var q2 = $.trim($inp.val().replace(/\n/g, ", "));
+                if (q2 !== q) {
+                    return;  // lost race
+                }
+                if (res.results) {
+                    $sec.find("input[name$=geo_lat]").val(res.results[0].lat);
+                    $sec.find("input[name$=geo_lon]").val(res.results[0].lon);
+                    center(13);
+                }
+                $sec.find(".col-md-1").html("");
+            })
         }
-        $sec.find(".col-md-1").html("");
-      })
-    }
 
-    $sec.find("input[name$=geo_lat], input[name$=geo_lon]").change(function () {
-      touched = $sec.find("input[name$=geo_lat]").val() !== "";
-      center(13);
-    }).keyup(function () {
-      if (timer2) {
-        window.clearTimeout(timer2);
-      }
-      timer2 = window.setTimeout(center, 300);
-    });
+        $sec.find("input[name$=geo_lat], input[name$=geo_lon]").change(function () {
+            touched = $sec.find("input[name$=geo_lat]").val() !== "";
+            center(13);
+        }).keyup(function () {
+            if (timer2) {
+                window.clearTimeout(timer2);
+            }
+            timer2 = window.setTimeout(center, 300);
+        });
 
-    $inp.change(load);
-    $inp.keyup(function () {
-      if (timer) {
-        window.clearTimeout(timer);
-      }
-      timer = window.setTimeout(load, 1000);
-    });
+        $inp.change(load);
+        $inp.keyup(function () {
+            if (timer) {
+                window.clearTimeout(timer);
+            }
+            timer = window.setTimeout(load, 1000);
+        });
 
-    // Map
-    var $grp = $sec.find(".geodata-group");
-    var tiles = $grp.attr("data-tiles");
-    var attrib = $grp.attr("data-attrib");
-    if (tiles) {
-      var $map = $("<div>");
-      $grp.append($("<div>").addClass("col-md-9 col-md-offset-3").append($map));
-      var map = L.map($map.get(0));
-      L.tileLayer(tiles, {
-        attribution: attrib,
-        maxZoom: 18,
-      }).addTo(map);
-      var $lat = $sec.find("input[name$=geo_lat]");
-      var $lon = $sec.find("input[name$=geo_lon]");
+        // Map
+        var $grp = $sec.find(".geodata-group");
+        var tiles = $grp.attr("data-tiles");
+        var attrib = $grp.attr("data-attrib");
+        if (tiles) {
+            var $map = $("<div>");
+            $grp.append($("<div>").addClass("col-md-9 col-md-offset-3").append($map));
+            var map = L.map($map.get(0));
+            L.tileLayer(tiles, {
+                attribution: attrib,
+                maxZoom: 18,
+            }).addTo(map);
+            var $lat = $sec.find("input[name$=geo_lat]");
+            var $lon = $sec.find("input[name$=geo_lon]");
 
-      function getpoint() {
-        if ($lat.val() !== "" && $lon.val() !== "") {
-          var p = [parseFloat($lat.val().replace(",", ".")), parseFloat($lon.val().replace(",", "."))];
-          // Clip to valid ranges. Very invalid lon/lat values can even lead to browser crashes in leaflet apparently
-          if (p[0] < -90) p[0] = -90
-          if (p[0] > 90) p[0] = 90
-          if (p[1] < -180) p[1] = -180
-          if (p[1] > 180) p[1] = 180
-          return p
+            function getpoint() {
+                if ($lat.val() !== "" && $lon.val() !== "") {
+                    var p = [parseFloat($lat.val().replace(",", ".")), parseFloat($lon.val().replace(",", "."))];
+                    // Clip to valid ranges. Very invalid lon/lat values can even lead to browser crashes in leaflet apparently
+                    if (p[0] < -90) p[0] = -90
+                    if (p[0] > 90) p[0] = 90
+                    if (p[1] < -180) p[1] = -180
+                    if (p[1] > 180) p[1] = 180
+                    return p
+                } else {
+                    return [0.0, 0.0];
+                }
+            }
+
+            var marker = L.marker(getpoint(), {
+                draggable: 'true',
+                icon: L.icon({
+                    iconUrl: $grp.attr("data-icon"),
+                    shadowUrl: $grp.attr("data-shadow"),
+                    iconSize: [25, 41],
+                    iconAnchor: [12, 41],
+                    popupAnchor: [1, -34],
+                    tooltipAnchor: [16, -28],
+                    shadowSize: [41, 41]
+                })
+            });
+            marker.addTo(map);
+            marker.on("dragend", function (event) {
+                var position = marker.getLatLng();
+                marker.setLatLng(position, {
+                    draggable: 'true'
+                }).bindPopup(position).update();
+                $lat.val(position.lat.toFixed(7));
+                $lon.val(position.lng.toFixed(7));
+                center(null);
+            });
+
+            function center(zoom) {
+                if ($lat.val() !== "" && $lon.val() !== "") {
+                    if (zoom) {
+                        map.setView(getpoint(), zoom);
+                    } else {
+                        map.panTo(getpoint());
+                    }
+                    marker.setLatLng(getpoint(), {
+                        draggable: 'true'
+                    }).bindPopup(getpoint()).update();
+                } else {
+                    map.fitWorld();
+                }
+            }
+
+            center(13);
         } else {
-          return [0.0, 0.0];
+            function center(zoom) {
+            }
         }
-      }
 
-      var marker = L.marker(getpoint(), {
-        draggable: 'true',
-        icon: L.icon({
-          iconUrl: $grp.attr("data-icon"),
-          shadowUrl: $grp.attr("data-shadow"),
-          iconSize: [25, 41],
-          iconAnchor: [12, 41],
-          popupAnchor: [1, -34],
-          tooltipAnchor: [16, -28],
-          shadowSize: [41, 41]
-        })
-      });
-      marker.addTo(map);
-      marker.on("dragend", function (event) {
-        var position = marker.getLatLng();
-        marker.setLatLng(position, {
-          draggable: 'true'
-        }).bindPopup(position).update();
-        $lat.val(position.lat.toFixed(7));
-        $lon.val(position.lng.toFixed(7));
-        center(null);
-      });
-
-      function center(zoom) {
-        if ($lat.val() !== "" && $lon.val() !== "") {
-          if (zoom) {
-            map.setView(getpoint(), zoom);
-          } else {
-            map.panTo(getpoint());
-          }
-          marker.setLatLng(getpoint(), {
-            draggable: 'true'
-          }).bindPopup(getpoint()).update();
-        } else {
-          map.fitWorld();
-        }
-      }
-
-      center(13);
-    } else {
-      function center(zoom) {
-      }
-    }
-
-  });
+    });
 });

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -242,15 +242,22 @@ input[type=number].short {
   width: 80px !important;
 }
 
-.geodata-autoupdate .help-block {
-  display: none;
-}
-.notify-loading .loading-notification,
-.notify-triggered .triggered-notification,
-.notify-updated .updated-notification,
-.notify-error .error-notification {
+.geodata-autoupdate {
   display: block;
 }
+.geodata-autoupdate .btn-link {
+  padding: 0;
+}
+.geodata-autoupdate [data-notification] {
+  display: none;
+}
+[data-notify=error] [data-notification=error],
+[data-notify=loading] [data-notification=loading],
+[data-notify=updated] [data-notification=updated],
+[data-notify=confirm] [data-notification=confirm] {
+  display: block;
+}
+
 .geodata-group {
   .form-group {
     margin: 0 0 10px 0;

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -248,7 +248,7 @@ input[type=number].short {
 .notify-loading .loading-notification,
 .notify-triggered .triggered-notification,
 .notify-updated .updated-notification,
-.notify-failed .failed-notification {
+.notify-error .error-notification {
   display: block;
 }
 .geodata-group {

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -241,6 +241,16 @@ div.mail-preview {
 input[type=number].short {
   width: 80px !important;
 }
+
+.geodata-autoupdate .help-block {
+  display: none;
+}
+.notify-loading .loading-notification,
+.notify-triggered .triggered-notification,
+.notify-updated .updated-notification,
+.notify-failed .failed-notification {
+  display: block;
+}
 .geodata-group {
   .form-group {
     margin: 0 0 10px 0;


### PR DESCRIPTION
This changes the current behavior, that overwrites geo coordinates automatically as long as the coordinates were empty at some point during the edit process and haven’t been changed manually since. If manual changes to the coordinates have been made and the location is changed later on, this now shows a message asking to overwrite the existing/manually adjusted geo coordinates.

It’s currently a bit _jumpy_ as, when the message is shown, it pushes down the rest of the form below. Not sure if we should add slideDown/slideUp-animation.