### PR TITLE
A11y: add role=group and labels to multi-widgets

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -122,6 +122,8 @@ class NamePartsWidget(forms.MultiWidget):
                     these_attrs.pop('data-no-required-attr', None)
                 these_attrs['autocomplete'] = (self.attrs.get('autocomplete', '') + ' ' + self.autofill_map.get(self.scheme['fields'][i][0], 'off')).strip()
                 these_attrs['data-size'] = self.scheme['fields'][i][2]
+                if len(self.widgets) > 1:
+                    these_attrs['aria-label'] = self.scheme['fields'][i][1]
             else:
                 these_attrs = final_attrs
             output.append(widget.render(name + '_%s' % i, widget_value, these_attrs, renderer=renderer))

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -220,7 +220,7 @@ class WrappedPhonePrefixSelect(Select):
                 country_name = locale.territories.get(country_code)
                 if country_name:
                     choices.append((prefix, "{} {}".format(country_name, prefix)))
-        super().__init__(choices=sorted(choices, key=lambda item: item[1]))
+        super().__init__(choices=sorted(choices, key=lambda item: item[1]), attrs={'aria-label': pgettext_lazy('phonenumber', 'International area code')})
 
     def render(self, name, value, *args, **kwargs):
         return super().render(name, value or self.initial, *args, **kwargs)
@@ -243,7 +243,7 @@ class WrappedPhonePrefixSelect(Select):
 class WrappedPhoneNumberPrefixWidget(PhoneNumberPrefixWidget):
 
     def __init__(self, attrs=None, initial=None):
-        widgets = (WrappedPhonePrefixSelect(initial), forms.TextInput())
+        widgets = (WrappedPhonePrefixSelect(initial), forms.TextInput(attrs={'aria-label': pgettext_lazy('phonenumber', 'Phone number (without international area code)')}))
         super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -245,7 +245,10 @@ class WrappedPhonePrefixSelect(Select):
 class WrappedPhoneNumberPrefixWidget(PhoneNumberPrefixWidget):
 
     def __init__(self, attrs=None, initial=None):
-        widgets = (WrappedPhonePrefixSelect(initial), forms.TextInput(attrs={'aria-label': pgettext_lazy('phonenumber', 'Phone number (without international area code)')}))
+        attrs = {
+            'aria-label': pgettext_lazy('phonenumber', 'Phone number (without international area code)')
+        }
+        widgets = (WrappedPhonePrefixSelect(initial), forms.TextInput(attrs=attrs))
         super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/src/pretix/presale/forms/renderers.py
+++ b/src/pretix/presale/forms/renderers.py
@@ -110,13 +110,15 @@ class CheckoutFieldRenderer(FieldRenderer):
             is_valid = None
 
         if self.is_group_widget:
+            label_for= ""
             label_id = "legend-{}".format(self.field.html_name)
         else:
+            label_for=self.field.id_for_label
             label_id = ""
 
         html = render_label(
             label,
-            label_for=self.field.id_for_label,
+            label_for=label_for,
             label_class=self.get_label_class(),
             label_id=label_id,
             optional=not required and not isinstance(self.widget, CheckboxInput),


### PR DESCRIPTION
This fixes some accessibility problems regarding form widgets with multiple inputs (input groups).

- group inputs from `CheckboxSelectMultiple`, `RadioSelect` and `MultiWidget` with more than 1 widget together with `role=group` and `aria-labelledby` as described here: https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria
- add aria-label to every sub-input in `NamePartsWidget` and `WrappedPhoneNumberPrefixWidget`