### PR TITLE
Waitlist: Subevent-Picker, Subevent starttime

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/checkin/lists.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/lists.html
@@ -29,7 +29,7 @@
     {% if request.event.has_subevents %}
         <form class="form-inline helper-display-inline" action="" method="get">
             <form class="form-inline helper-display-inline" action="" method="get">
-                {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
+                {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" with auto_submit=True %}
             </form>
         </form>
     {% endif %}

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_subevent_choice_simple.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_subevent_choice_simple.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <p>
-    <select name="subevent" class="form-control simple-subevent-choice" data-model-select2="event"
+    <select name="subevent" class="form-control{% if auto_submit %} simple-subevent-choice{% endif %}" data-model-select2="event"
             data-select2-url="{% url "control:event.subevents.select2" organizer=request.event.organizer.slug event=request.event.slug %}"
             data-placeholder="{% trans "All dates" context "subevent" %}">
         {% for se in selected_subevents %}

--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -98,7 +98,7 @@
 
     {% if request.event.has_subevents %}
         <form class="form-inline helper-display-inline" action="" method="get">
-            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
+            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" with auto_submit=True %}
         </form>
     {% endif %}
     {% if not request.event.has_subevents or subevent %}

--- a/src/pretix/control/templates/pretixcontrol/items/quotas.html
+++ b/src/pretix/control/templates/pretixcontrol/items/quotas.html
@@ -15,7 +15,7 @@
     </p>
     {% if request.event.has_subevents %}
         <form class="form-inline helper-display-inline" action="" method="get">
-            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
+            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" with auto_submit=True %}
         </form>
     {% endif %}
     {% if quotas|length == 0 %}

--- a/src/pretix/control/templates/pretixcontrol/waitinglist/index.html
+++ b/src/pretix/control/templates/pretixcontrol/waitinglist/index.html
@@ -48,15 +48,9 @@
                             </p>
                         {% endif %}
                         {% if request.event.has_subevents %}
-                            <select name="subevent" class="form-control">
-                                <option value="">{% trans "All dates" context "subevent" %}</option>
-                                {% for se in request.event.subevents.all %}
-                                    <option value="{{ se.id }}"
-                                            {% if request.GET.subevent|add:0 == se.id %}selected="selected"{% endif %}>
-                                        {{ se.name }} – {{ se.get_date_range_display }}
-                                    </option>
-                                {% endfor %}
-                            </select>
+                            <div class="col-md-6">
+                                {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
+                            </div>
                         {% endif %}
                         <button class="btn btn-large btn-primary" type="submit">
                             {% trans "Send as many vouchers as possible" %}
@@ -110,15 +104,7 @@
             {% endfor %}
         </select>
         {% if request.event.has_subevents %}
-            <select name="subevent" class="form-control">
-                <option value="">{% trans "All dates" context "subevent" %}</option>
-                {% for se in request.event.subevents.all %}
-                    <option value="{{ se.id }}"
-                            {% if request.GET.subevent|add:0 == se.id %}selected="selected"{% endif %}>
-                        {{ se.name }} – {{ se.get_date_range_display }}
-                    </option>
-                {% endfor %}
-            </select>
+            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
         {% endif %}
         <button class="btn btn-primary" type="submit">{% trans "Filter" %}</button>
         <a href="?{% url_replace request "download" "yes" %}"
@@ -166,7 +152,7 @@
                             {% endif %}
                         </td>
                         {% if request.event.has_subevents %}
-                            <td>{{ e.subevent.name }} – {{ e.subevent.get_date_range_display }}</td>
+                            <td>{{ e.subevent.name }} – {{ e.subevent.get_date_range_display }} {{ e.subevent.date_from|date:"TIME_FORMAT" }}</td>
                         {% endif %}
                         <td>
                             {{ e.created|date:"SHORT_DATETIME_FORMAT" }}

--- a/src/pretix/control/templates/pretixcontrol/waitinglist/index.html
+++ b/src/pretix/control/templates/pretixcontrol/waitinglist/index.html
@@ -74,44 +74,50 @@
         </div>
     </div>
 
-    <p>
-    <form class="form-inline helper-display-inline" action="" method="get">
-        <select name="status" class="form-control">
-            <option value="a"
-                    {% if request.GET.status == "p" %}selected="selected"{% endif %}>{% trans "All entries" %}</option>
-            <option value="w"
-                    {% if request.GET.status == "w" or not request.GET.status %}selected="selected"{% endif %}>
-                {% trans "Waiting for a voucher" %}</option>
-            <option value="s"
-                    {% if request.GET.status == "s" %}selected="selected"{% endif %}>{% trans "Voucher assigned" %}</option>
-            <option value="v"
-                    {% if request.GET.status == "v" %}selected="selected"{% endif %}>
-                {% trans "Waiting for redemption" %}</option>
-            <option value="r"
-                    {% if request.GET.status == "r" %}selected="selected"{% endif %}>
-                {% trans "Successfully redeemed" %}</option>
-            <option value="e"
-                    {% if request.GET.status == "e" %}selected="selected"{% endif %}>
-                {% trans "Voucher expired" %}</option>
-        </select>
-        <select name="item" class="form-control">
-            <option value="">{% trans "All products" %}</option>
-            {% for item in items %}
-                <option value="{{ item.id }}"
-                        {% if request.GET.item|add:0 == item.id %}selected="selected"{% endif %}>
-                    {{ item }}
-                </option>
-            {% endfor %}
-        </select>
+    <form class="row filter-form" action="" method="get">
+        <div class="col-lg-2 col-md-3 col-xs-6">
+            <select name="status" class="form-control">
+                <option value="a"
+                        {% if request.GET.status == "p" %}selected="selected"{% endif %}>{% trans "All entries" %}</option>
+                <option value="w"
+                        {% if request.GET.status == "w" or not request.GET.status %}selected="selected"{% endif %}>
+                    {% trans "Waiting for a voucher" %}</option>
+                <option value="s"
+                        {% if request.GET.status == "s" %}selected="selected"{% endif %}>{% trans "Voucher assigned" %}</option>
+                <option value="v"
+                        {% if request.GET.status == "v" %}selected="selected"{% endif %}>
+                    {% trans "Waiting for redemption" %}</option>
+                <option value="r"
+                        {% if request.GET.status == "r" %}selected="selected"{% endif %}>
+                    {% trans "Successfully redeemed" %}</option>
+                <option value="e"
+                        {% if request.GET.status == "e" %}selected="selected"{% endif %}>
+                    {% trans "Voucher expired" %}</option>
+            </select>
+        </div>
+        <div class="col-lg-2 col-md-3 col-xs-6">
+            <select name="item" class="form-control">
+                <option value="">{% trans "All products" %}</option>
+                {% for item in items %}
+                    <option value="{{ item.id }}"
+                            {% if request.GET.item|add:0 == item.id %}selected="selected"{% endif %}>
+                        {{ item }}
+                    </option>
+                {% endfor %}
+            </select>
+        </div>
         {% if request.event.has_subevents %}
+        <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
             {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
+        </div>
         {% endif %}
-        <button class="btn btn-primary" type="submit">{% trans "Filter" %}</button>
-        <a href="?{% url_replace request "download" "yes" %}"
+        <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
+            <button class="btn btn-primary" type="submit"><span class="fa fa-filter"></span> {% trans "Filter" %}</button>
+            <a href="?{% url_replace request "download" "yes" %}"
                 class="btn btn-default"><i class="fa fa-download"></i>
-            {% trans "Download list" %}</a>
+                {% trans "Download list" %}</a>
+        </div>
     </form>
-    </p>
     <form method="post" action="?next={{ request.get_full_path|urlencode }}">
         {% csrf_token %}
         <div class="table-responsive">

--- a/src/pretix/plugins/statistics/templates/pretixplugins/statistics/index.html
+++ b/src/pretix/plugins/statistics/templates/pretixplugins/statistics/index.html
@@ -10,7 +10,7 @@
     <h1>{% trans "Statistics" %}</h1>
     {% if request.event.has_subevents %}
         <form class="form-inline helper-display-inline" action="" method="get">
-            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" %}
+            {% include "pretixcontrol/event/fragment_subevent_choice_simple.html" with auto_submit=True %}
         </form>
     {% endif %}
     {% if has_orders %}


### PR DESCRIPTION
This adds the starting time to the list of a subevent to the list of waitlist entries as well as the rich/select2 subevent-picker.

The top one in the "send as many vouchers out as possible" seems to be integrating quite nicely, the one just above the waitlistentries however refuses to play nicely, especially when the product/itempicker has very, very long entries. I tried to replicate the filterbar-behaviour of the order overview, but with no success...

Perhaps someone else wants to take a swing at the layout options here?

Ref: Z#2372969