### PR TITLE
Fix checkin-list pdf export subevent time formatting

### DIFF
--- a/src/pretix/plugins/checkinlists/exporters.py
+++ b/src/pretix/plugins/checkinlists/exporters.py
@@ -276,7 +276,7 @@ class PDFCheckinList(ReportlabExportMixin, CheckInListMixin, BaseExporter):
             story += [
                 Spacer(1, 3 * mm),
                 Paragraph(
-                    '{} ({} {})'.format(cl.subevent.name, cl.subevent.get_date_range_display(), date_format(cl.subevent.date_from, 'SHORT_TIME_FORMAT')),
+                    '{} ({} {})'.format(cl.subevent.name, cl.subevent.get_date_range_display(), date_format(cl.subevent.date_from, 'TIME_FORMAT')),
                     self.get_style()
                 ),
             ]


### PR DESCRIPTION
I was getting this formatting error when exporting a checkin list as pdf for a single subevent.

![image](https://user-images.githubusercontent.com/5970076/114285039-56419100-9a54-11eb-9275-d501262653ba.png)

[Blame](https://github.com/pretix/pretix/blame/master/src/pretix/plugins/checkinlists/exporters.py#L279)