### PR TITLE
Remove redundant mime-type from nginx config

### DIFF
--- a/deployment/docker/nginx.conf
+++ b/deployment/docker/nginx.conf
@@ -33,7 +33,7 @@ http {
 
 	gzip on;
 	gzip_disable "msie6";
-	gzip_types text/plain text/html text/css application/json application/javascript application/x-javascript text/javascript text/xml application/xml application/rss+xml application/atom+xml application/rdf+xml image/svg+xml;
+	gzip_types text/plain text/css application/json application/javascript application/x-javascript text/javascript text/xml application/xml application/rss+xml application/atom+xml application/rdf+xml image/svg+xml;
 	gzip_vary on;
 	gzip_proxied any;
 	gzip_comp_level 6;


### PR DESCRIPTION
Small change to remove warning noise from logs:

```sh
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/nginx.conf:43
```

http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types 

```sh
Enables gzipping of responses for the specified MIME types in addition to “text/html”. The special value “*” matches any MIME type (0.8.29). Responses with the “text/html” type are always compressed.
```