### PR TITLE
Check-in rules: Make logic results understandable

### DIFF
--- a/doc/api/resources/checkinlists.rst
+++ b/doc/api/resources/checkinlists.rst
@@ -697,6 +697,9 @@ Order position endpoints
    * ``product`` - Tickets with this product may not be scanned at this device
    * ``rules`` - Check-in prevented by a user-defined rule
 
+   In case of reason ``rules``, there might be an additional response field ``reason_explanation`` with a human-readable
+   description of the violated rules. However, that field can also be missing or be ``null``.
+
    :param organizer: The ``slug`` field of the organizer to fetch
    :param event: The ``slug`` field of the event to fetch
    :param list: The ID of the check-in list to look for

--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -185,6 +185,7 @@ class CheckinList(LoggedModel):
         # Every change to our supported JSON logic must be done
         # * in pretix.base.services.checkin
         # * in pretix.base.models.checkin
+        # * in pretix.helpers.jsonlogic_boolalg
         # * in checkinrules.js
         # * in libpretixsync
         top_level_operators = {

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -480,9 +480,10 @@ class SQLLogic:
 
 
 class CheckInError(Exception):
-    def __init__(self, msg, code):
+    def __init__(self, msg, code, reason=None):
         self.msg = msg
         self.code = code
+        self.reason = reason
         super().__init__(msg)
 
 
@@ -617,11 +618,13 @@ def perform_checkin(op: OrderPosition, clist: CheckinList, given_answers: dict, 
             rule_data = LazyRuleVars(op, clist, dt)
             logic = _get_logic_environment(op.subevent or clist.event)
             if not logic.apply(clist.rules, rule_data):
+                reason = _logic_explain(clist.rules, op.subevent or clist.event, rule_data)
                 raise CheckInError(
                     _('Entry not permitted: {explanation}.').format(
-                        explanation=_logic_explain(clist.rules, op.subevent or clist.event, rule_data)
+                        explanation=reason
                     ),
-                    'rules'
+                    'rules',
+                    reason=reason
                 )
 
         device = None

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -77,7 +77,7 @@ def _build_time(t=None, value=None, ev=None):
 
 def _logic_explain(rules, ev, rule_data):
     """
-    Explains whe the logic denied the check-in. Only works for a denied check-in.
+    Explains when the logic denied the check-in. Only works for a denied check-in.
 
     While our custom check-in logic is very flexible, its main problem is that is is pretty
     intransparent during execution. If the logic causes an entry to be forbidden, the result

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -79,7 +79,7 @@ def _logic_explain(rules, ev, rule_data):
     """
     Explains when the logic denied the check-in. Only works for a denied check-in.
 
-    While our custom check-in logic is very flexible, its main problem is that is is pretty
+    While our custom check-in logic is very flexible, its main problem is that it is pretty
     intransparent during execution. If the logic causes an entry to be forbidden, the result
     of the logic evaluation is just a simple ``False``, which is very unhelpful to explain to
     attendees why they don't get into the event.

--- a/src/pretix/helpers/jsonlogic_boolalg.py
+++ b/src/pretix/helpers/jsonlogic_boolalg.py
@@ -1,0 +1,90 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def convert_to_dnf(rules):
+    """
+    Converts a set of rules to disjunctive normal form, i.e. returns something of the form
+    `(a AND b AND c) OR (a AND d AND f)`
+    without further nesting.
+    """
+    if not isinstance(rules, dict):
+        return rules
+
+    def _distribute_or_over_and(r):
+        operator = list(r.keys())[0]
+        values = rules[operator]
+        if operator == "and":
+            arg_to_distribute = [arg for arg in values if isinstance(arg, dict) and "or" in arg]
+            if not arg_to_distribute:
+                return rules
+            arg_to_distribute = arg_to_distribute[0]
+            other_args = [arg for arg in values if arg is not arg_to_distribute]
+            return {
+                "or": [
+                    {"and": [*other_args, dval]} for dval in arg_to_distribute["or"]
+                ]
+            }
+        elif operator in ("!", "!!", "?:", "if"):
+            raise ValueError(f"Operator {operator} currently unsupported by convert_to_dnf")
+        else:
+            return r
+
+    def _simplify_chained_operators(r):
+        # Simplify `(a OR b) OR (c or d)` to `a OR b OR c OR d` and the same with `AND`
+        if not isinstance(r, dict):
+            return r
+        operator = list(r.keys())[0]
+        values = rules[operator]
+        if operator not in ("or", "and"):
+            return r
+        new_values = []
+        for v in values:
+            if not isinstance(v, dict) or operator not in v:
+                new_values.append(v)
+            else:
+                new_values += v[operator]
+        return {operator: new_values}
+
+    # Run _distribute_or_over_and on until it no longer changes anything. Do so recursively
+    # for the full expression tree.
+    old_rules = rules
+    while True:
+        rules = _distribute_or_over_and(rules)
+        operator = list(rules.keys())[0]
+        values = rules[operator]
+        if not isinstance(values, list):
+            values = [values]
+        rules = {
+            operator: [
+                convert_to_dnf(v) for v in values
+            ] if len(values) > 1 else convert_to_dnf(values[0])
+        }
+        if old_rules == rules:
+            break
+        old_rules = rules
+    # Simplify leftovers of the recursion
+    rules = _simplify_chained_operators(rules)
+    return rules

--- a/src/tests/helpers/test_jsonlogic_boolalg.py
+++ b/src/tests/helpers/test_jsonlogic_boolalg.py
@@ -1,0 +1,80 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from pretix.helpers.jsonlogic_boolalg import convert_to_dnf
+
+params = [
+    (
+        {"and": [{"var": "a"}, {"eq": [{"var": "a"}, 3]}]},
+        {"and": [{"var": "a"}, {"eq": [{"var": "a"}, 3]}]},
+    ),
+    (
+        {"or": [{"var": "a"}, {"eq": [{"var": "a"}, 3]}]},
+        {"or": [{"var": "a"}, {"eq": [{"var": "a"}, 3]}]},
+    ),
+    (
+        {"and": [{"or": ["a", "b"]}, 3]},
+        {"or": [{"and": [3, "a"]}, {"and": [3, "b"]}]},
+    ),
+    (
+        {"and": [{"or": ["a", "b"]}, {"or": ["c", "d"]}]},
+        {"or": [{"and": ["a", "c"]}, {"and": ["a", "d"]}, {"and": ["b", "c"]}, {"and": ["b", "d"]}]},
+    ),
+    (
+        {"and": [{"or": ["a", {"and": ["e", "f"]}]}, {"or": ["c", "d"]}]},
+        {"or": [{"and": ["a", "c"]}, {"and": ["a", "d"]}, {"and": ["e", "f", "c"]}, {"and": ["e", "f", "d"]}]},
+    ),
+    (
+        {"and": [{"or": ["a", {"and": ["e", {"or": ["f", "g"]}]}]}, {"or": ["c", "d"]}]},
+        {"or": [{"and": ["a", "c"]}, {"and": ["a", "d"]}, {"and": ["c", "e", "f"]}, {"and": ["c", "e", "g"]},
+                {"and": ["d", "e", "f"]}, {"and": ["d", "e", "g"]}]},
+    ),
+    (
+        {"and": [{"or": ["a", {"and": ["e", {"or": ["f", {"and": ["g", "h"]}]}]}]}, {"or": ["c", "d"]}]},
+        {"or": [{"and": ["a", "c"]}, {"and": ["a", "d"]}, {"and": ["c", "e", "f"]}, {"and": ["c", "e", "g", "h"]},
+                {"and": ["d", "e", "f"]}, {"and": ["d", "e", "g", "h"]}]},
+    ),
+]
+
+
+def compare_ignoring_order(data1, data2):
+    if isinstance(data1, list) and isinstance(data2, list):
+        try:
+            assert set(data1) == set(data2)
+        except:
+            print(data1, data2)
+            assert len(data1) == len(data2) and all(data1.count(i) == data2.count(i) for i in data1)
+    elif isinstance(data1, dict) and isinstance(data2, dict):
+        assert set(data1.keys()) == set(data2.keys())
+        compare_ignoring_order(list(data1.values()), list(data2.values()))
+    else:
+        assert data1 == data2
+
+
+@pytest.mark.parametrize("logic,expected", params)
+def test_convert_to_dnf(logic, expected):
+    print("orig", logic)
+    print("resu", convert_to_dnf(logic))
+    print("expe", expected)
+    assert convert_to_dnf(logic) == expected


### PR DESCRIPTION
While our custom check-in logic is very flexible, its main problem is that is is pretty intransparent during execution. If the logic causes an entry to be forbidden, the result of the logic evaluation is just a simple ``False``, which is very unhelpful to explain to attendees why they don't get into the event.

The main problem with fixing this is that there is no correct answer for this, it is always up for interpretation. A good example is the following set of rules:

- Attendees with a regular ticket can enter the venue between 09:00 and 17:00 on three days 
- Attendees with a VIP ticket can enter the venue between 08:00 and 18:00 on three days

If an attendee with a regular ticket now shows up at 17:30 on the first day, there are three possible error messages:

a) You do not have a VIP ticket
b) You can only get in before 17:00
c) You can only get in after 09:00 tomorrow

All three of them are just as valid, and "fixing" either one of them would get the attendee in. Showing all three is too much, especially since the list can get very long with complex logic.

We therefore make an opinionated choice based on a number of assumptions. An example for these assumptions is "it is very unlikely that the attendee is unable to change their ticket type". Additionally, we favor a "close failure". Therefore, in the above example, we'd show "You can only get in before 17:00". In the middle of the night it would switch to "You can only get in after 09:00".

Todo:

- [x] expose to api
- [ ] show in apps