### PR TITLE
License check: improve license detection for DistInfoDistribution packages.

### DIFF
--- a/src/pretix/control/views/global_settings.py
+++ b/src/pretix/control/views/global_settings.py
@@ -169,7 +169,7 @@ class LicenseCheckView(StaffMemberRequiredMixin, FormView):
         license, url = None, None
         try:
             pkg = pkg_resources.get_distribution(pkg)
-        except pkg_resources.DistributionNotFound:
+        except:
             return None, None
         try:
             for line in pkg.get_metadata_lines(pkg.PKG_INFO):

--- a/src/pretix/control/views/global_settings.py
+++ b/src/pretix/control/views/global_settings.py
@@ -168,12 +168,11 @@ class LicenseCheckView(StaffMemberRequiredMixin, FormView):
     def _get_license_for_pkg(self, pkg):
         license, url = None, None
         try:
-            pkgs = pkg_resources.require(pkg)
-            pkg = pkgs[0]
-        except:
+            pkg = pkg_resources.get_distribution(pkg)
+        except pkg_resources.DistributionNotFound:
             return None, None
         try:
-            for line in pkg.get_metadata_lines('PKG-INFO'):
+            for line in pkg.get_metadata_lines(pkg.PKG_INFO):
                 if ': ' in line:
                     (k, v) = line.split(': ', 1)
                     if k == "License":


### PR DESCRIPTION
The license finder assumes that installed packages are in `.egg` or `.egg-info` format and does not consider `.dist-info` packages, which uses the `METADATA` field for package info. See [pkg_resources.DistInfoDistribution](https://github.com/pypa/pip/blob/main/src/pip/_vendor/pkg_resources/__init__.py#L3000) for reference.