### PR TITLE
Add missing "deactivated"-property for items-typeahead

### DIFF
--- a/src/pretix/control/views/typeahead.py
+++ b/src/pretix/control/views/typeahead.py
@@ -581,7 +581,7 @@ def itemvarquota_select2(request, **kwargs):
     for i in itemqs:
         variations = list(i.variations.all())
         if variations:
-            choices.append((str(i.pk), _('{product} – Any variation').format(product=i), ''))
+            choices.append((str(i.pk), _('{product} – Any variation').format(product=i), '', not i.active))
             for v in variations:
                 choices.append(('%d-%d' % (i.pk, v.pk), '%s – %s' % (i, v.value), '', not i.active))
         else:

--- a/src/pretix/control/views/typeahead.py
+++ b/src/pretix/control/views/typeahead.py
@@ -583,7 +583,7 @@ def itemvarquota_select2(request, **kwargs):
         if variations:
             choices.append((str(i.pk), _('{product} – Any variation').format(product=i), '', not i.active))
             for v in variations:
-                choices.append(('%d-%d' % (i.pk, v.pk), '%s – %s' % (i, v.value), '', not i.active))
+                choices.append(('%d-%d' % (i.pk, v.pk), '%s – %s' % (i, v.value), '', not v.active))
         else:
             choices.append((str(i.pk), str(i), '', not i.active))
     for q in quotaqs:


### PR DESCRIPTION
The first commit should fix PRETIXEU-46C.

The second commit is up for debate - I just stumbled upon this and figured that if we are working with variations, this should probably reflect the variations state and not the items state.