### PR TITLE
Event API: Add search parameter

### DIFF
--- a/doc/api/resources/events.rst
+++ b/doc/api/resources/events.rst
@@ -88,6 +88,8 @@ Endpoints
 
     The ``with_availability_for`` parameter has been added.
 
+    The ``search`` query parameter has been added to filter events by their slug, name, or location in any language.
+
 .. http:get:: /api/v1/organizers/(organizer)/events/
 
    Returns a list of all events within a given organizer the authenticated user/token has access to.
@@ -170,6 +172,7 @@ Endpoints
                                  attribute with values of 100 for "tickets available", values less than 100 for "tickets sold out or reserved",
                                  and ``null`` for "status unknown". These values might be served from a cache. This parameter can make the response
                                  slow.
+   :query search: Only return events matching a given search query.
    :param organizer: The ``slug`` field of a valid organizer
    :statuscode 200: no error
    :statuscode 401: Authentication failure

--- a/src/tests/api/test_events.py
+++ b/src/tests/api/test_events.py
@@ -194,6 +194,17 @@ def test_event_list_filter(token_client, organizer, event):
 
 
 @pytest.mark.django_db
+def test_event_list_name_filter(token_client, organizer, event):
+    resp = token_client.get('/api/v1/organizers/{}/events/?search=Dummy'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+
+    resp = token_client.get('/api/v1/organizers/{}/events/?search=notdummy'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 0
+
+
+@pytest.mark.django_db
 def test_event_get(token_client, organizer, event):
     resp = token_client.get('/api/v1/organizers/{}/events/{}/'.format(organizer.slug, event.slug))
     res = copy.copy(TEST_EVENT_RES)


### PR DESCRIPTION
The events API is paginated with 50 events. When searching for a specific event within a large Pretix installations UX becomes very bad. Using this filter users are able to quickly find their event by name.