### PR TITLE
Call plugin's installed() method upon event creation

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -634,7 +634,7 @@ class Event(EventMixin, LoggedModel):
             Quota,
         )
 
-        self.plugins = other.plugins
+        self.set_active_plugins(other.plugins.split(","), allow_restricted=True)
         self.is_public = other.is_public
         if other.date_admission:
             self.date_admission = self.date_from + (other.date_admission - other.date_from)

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -634,11 +634,11 @@ class Event(EventMixin, LoggedModel):
             Quota,
         )
 
-        # Note: avoid self.set_active_plugins() causes trouble for BadgeApp plugin
+        #  Note: avoid self.set_active_plugins(), it causes trouble e.g. for the badges plugin.
         #  Plugins can create data in installed() hook based on existing data of the event.
         #  Calling set_active_plugins() results in defaults being created while actually data
-        #  should come from the copied event. Instead events should use they might be copied
-        #  using the event_copy_data-signal for new events.
+        #  should come from the copied event. Instead plugins should use event_copy_data to move
+        #  over their data.
         self.plugins = other.plugins
         self.is_public = other.is_public
         if other.date_admission:

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -634,7 +634,12 @@ class Event(EventMixin, LoggedModel):
             Quota,
         )
 
-        self.set_active_plugins(other.plugins.split(","), allow_restricted=True)
+        # Note: avoid self.set_active_plugins() causes trouble for BadgeApp plugin
+        #  Plugins can create data in installed() hook based on existing data of the event.
+        #  Calling set_active_plugins() results in defaults being created while actually data
+        #  should come from the copied event. Instead events should use they might be copied
+        #  using the event_copy_data-signal for new events.
+        self.plugins = other.plugins
         self.is_public = other.is_public
         if other.date_admission:
             self.date_admission = self.date_from + (other.date_admission - other.date_from)

--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -1440,7 +1440,7 @@ class QuickSetupView(FormView):
             })
             quota.items.add(*items)
 
-        self.request.event.plugins = ",".join(plugins_active)
+        self.request.event.set_active_plugins(plugins_active, allow_restricted=True)
         self.request.event.save()
         messages.success(self.request, _('Your changes have been saved. You can now go on with looking at the details '
                                          'or take your event live to start selling!'))

--- a/src/pretix/control/views/main.py
+++ b/src/pretix/control/views/main.py
@@ -251,7 +251,7 @@ class EventWizard(SafeSessionWizardView):
         with transaction.atomic(), language(basics_data['locale']):
             event = form_dict['basics'].instance
             event.organizer = foundation_data['organizer']
-            event.plugins = settings.PRETIX_PLUGINS_DEFAULT
+            event.set_active_plugins(settings.PRETIX_PLUGINS_DEFAULT.split(","), allow_restricted=True)
             event.has_subevents = foundation_data['has_subevents']
             event.testmode = True
             form_dict['basics'].save()


### PR DESCRIPTION
Use the `event.set_active_plugins` to set the plugins to make sure that the installed function gets called for all plugin enable routes.

Note that in this commit all calls are made with `allow_restricted`, as there may be existing restricted plugins enabled for the copied event.  This is fine these locations do not accept user input to select plugins, they come from existing events or from the system configured django settings.

Fixes #2087
