### PR TITLE
Sendmail: Force preview and show number of orders

### DIFF
--- a/src/pretix/control/forms/__init__.py
+++ b/src/pretix/control/forms/__init__.py
@@ -153,7 +153,7 @@ class CachedFileInput(forms.ClearableFileInput):
 
         @property
         def is_img(self):
-            return any(self.file.filename.lower().endswith(e) for e in ('.jpg', '.jpeg', '.png', '.gif'))
+            return False  # thumbnailing doesn't work since the file isn't available publicly
 
         def __str__(self):
             return self.file.filename

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -177,7 +177,7 @@ class MailForm(FormPlaceholderMixin, forms.Form):
         self.fields['sendto'] = forms.MultipleChoiceField(
             label=_("Send to customers with order status"),
             widget=forms.CheckboxSelectMultiple(
-                attrs={'class': 'scrolling-multiple-choice'}
+                attrs={'class': 'scrolling-multiple-choice no-search'}
             ),
             choices=choices
         )

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -1,6 +1,7 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load humanize %}
 {% block title %}{% trans "Send out emails" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Send out emails" %}</h1>
@@ -38,7 +39,7 @@
             {% bootstrap_field form.subject layout='horizontal' %}
             {% bootstrap_field form.message layout='horizontal' %}
             {% bootstrap_field form.attachment layout='horizontal' %}
-            {% if request.method == "POST" %}
+            {% if output %}
             <fieldset>
             <legend>{% trans "E-mail preview" %}</legend>
                 <div class="tab-pane mail-preview-group">
@@ -52,11 +53,16 @@
             </fieldset>
             {% endif %}
             <div class="form-group submit-group">
-                <button type="submit" class="btn btn-default btn-save pull-left" name="action" value="preview">
+                <button type="submit" class="btn btn-default btn-save" name="action" value="preview">
                     {% trans "Preview email" %}
                 </button>
-                <button type="submit" class="btn btn-primary btn-save">
+                <button type="submit" class="btn btn-danger btn-save" name="action" value="send" {% if not output %}disabled{% endif %}>
                     {% trans "Send" %}
+                    {% if not output %}
+                        ({% trans "use preview first" %})
+                    {% else %}
+                        ({% blocktrans with number=order_count|intcomma %}{{ number }} orders{% endblocktrans %})
+                    {% endif %}
                 </button>
             </div>
         </form>

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -8,62 +8,92 @@
     {% block inner %}
         <form class="form-horizontal" method="post" action="" enctype="multipart/form-data">
             {% csrf_token %}
-            {% bootstrap_form_errors form %}
-            {% bootstrap_field form.recipients layout='horizontal' %}
-            {% bootstrap_field form.sendto layout='horizontal' %}
-            {% if form.subevent %}
-                {% bootstrap_field form.subevent layout='horizontal' %}
-                {% bootstrap_field form.subevents_from layout='horizontal' %}
-                {% bootstrap_field form.subevents_to layout='horizontal' %}
+            {% if is_preview %}
+                {% for k, l in request.POST.lists %}
+                    {% if k != "action" %}
+                        {% for v in l %}
+                            <input type="hidden" name="{{ k }}" value="{{ v }}">
+                        {% endfor %}
+                    {% endif %}
+                {% endfor %}
             {% endif %}
-            {% bootstrap_field form.created_from layout='horizontal' %}
-            {% bootstrap_field form.created_to layout='horizontal' %}
-            {% bootstrap_field form.items layout='horizontal' %}
-            <div class="row">
-                <div class="col-md-9 col-md-offset-3">
-                    <div class="panel-group">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <label data-toggle="collapse" data-target="#checkin_filter">
-                                    {{ form.filter_checkins }} {{ form.filter_checkins.label }}
-                                </label>
-                            </div>
-                            <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
-                                {% bootstrap_field form.not_checked_in layout='horizontal' %}
-                                {% bootstrap_field form.checkin_lists layout='horizontal' %}
+            {% bootstrap_form_errors form %}
+            <fieldset>
+                <legend>{% trans "Recipients" %}</legend>
+                {% bootstrap_field form.recipients layout='horizontal' %}
+                {% bootstrap_field form.sendto layout='horizontal' %}
+                {% if form.subevent %}
+                    {% bootstrap_field form.subevent layout='horizontal' %}
+                    {% bootstrap_field form.subevents_from layout='horizontal' %}
+                    {% bootstrap_field form.subevents_to layout='horizontal' %}
+                {% endif %}
+                {% bootstrap_field form.created_from layout='horizontal' %}
+                {% bootstrap_field form.created_to layout='horizontal' %}
+                {% bootstrap_field form.items layout='horizontal' %}
+                <div class="row">
+                    <div class="col-md-9 col-md-offset-3">
+                        <div class="panel-group">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <label data-toggle="collapse" data-target="#checkin_filter">
+                                        {{ form.filter_checkins }} {{ form.filter_checkins.label }}
+                                    </label>
+                                </div>
+                                <div id="checkin_filter" class="panel-body panel-collapse collapse {% if form.filter_checkins.value %} in {% else %} out {% endif %}">
+                                    {% bootstrap_field form.not_checked_in layout='horizontal' %}
+                                    {% bootstrap_field form.checkin_lists layout='horizontal' %}
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            {% bootstrap_field form.subject layout='horizontal' %}
-            {% bootstrap_field form.message layout='horizontal' %}
-            {% bootstrap_field form.attachment layout='horizontal' %}
-            {% if output %}
+            </fieldset>
+            <fieldset {% if is_preview %}class="hidden"{% endif %}>
+                <legend>{% trans "Content" %}</legend>
+                {% bootstrap_field form.subject layout='horizontal' %}
+                {% bootstrap_field form.message layout='horizontal' %}
+                {% bootstrap_field form.attachment layout='horizontal' %}
+            </fieldset>
+            {% if is_preview %}
             <fieldset>
-            <legend>{% trans "E-mail preview" %}</legend>
+                <legend>{% trans "E-mail preview" %}</legend>
                 <div class="tab-pane mail-preview-group">
                     {% for locale, out in output.items %}
                         <div lang="{{ locale }}" class="mail-preview">
                             <strong>{{ out.subject|safe }}</strong><br><br>
                             {{ out.html|safe }}
+                            {% if out.attachment %}
+                                <p>
+                                    <a href="{% url 'cachedfile.download' id=out.attachment.id %}" class="btn btn-default"
+                                        target="_blank">
+                                        <span class="fa fa-file" aria-hidden="true"></span>
+                                        {{ out.attachment.filename }}
+                                    </a>
+                                </p>
+                            {% endif %}
                         </div>
                     {% endfor %}
                 </div>
             </fieldset>
             {% endif %}
             <div class="form-group submit-group">
-                <button type="submit" class="btn btn-default btn-save" name="action" value="preview">
-                    {% trans "Preview email" %}
-                </button>
-                <button type="submit" class="btn btn-danger btn-save" name="action" value="send" {% if not output %}disabled{% endif %}>
-                    {% trans "Send" %}
-                    {% if not output %}
-                        ({% trans "use preview first" %})
-                    {% else %}
-                        ({% blocktrans with number=order_count|intcomma %}{{ number }} orders{% endblocktrans %})
-                    {% endif %}
-                </button>
+                {% if not is_preview %}
+                    {% trans "You need to preview your email before you can send it." %}
+                    &nbsp;&nbsp;
+                    <button type="submit" class="btn btn-default btn-save" name="action" value="preview">
+                        {% trans "Preview email" %}
+                    </button>
+                {% else %}
+                    <button type="submit" class="btn btn-default btn-save pull-left" name="action" value="edit">
+                        <span class="fa fa-edit" aria-hidden="true"></span>
+                        {% trans "Edit" %}
+                    </button>
+                    <button type="submit" class="btn btn-danger btn-save" name="action" value="send">
+                        <span class="fa fa-send" aria-hidden="true"></span>
+                        {% trans "Send" %}
+                        ({% blocktrans with number=order_count|default_if_none:0|intcomma %}{{ number }} orders{% endblocktrans %})
+                    </button>
+                {% endif %}
             </div>
         </form>
     {% endblock %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/send_form.html
@@ -91,7 +91,11 @@
                     <button type="submit" class="btn btn-danger btn-save" name="action" value="send">
                         <span class="fa fa-send" aria-hidden="true"></span>
                         {% trans "Send" %}
-                        ({% blocktrans with number=order_count|default_if_none:0|intcomma %}{{ number }} orders{% endblocktrans %})
+                        ({% blocktrans trimmed with number=order_count|default_if_none:0|intcomma count c=order_count|default_if_none:0 %}
+                            {{ number }} matching order
+                        {% plural %}
+                            {{ number }} matching orders
+                        {% endblocktrans %})
                     </button>
                 {% endif %}
             </div>

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -209,6 +209,7 @@ class SenderView(EventPermissionRequiredMixin, FormView):
                     self.output[l] = {
                         'subject': _('Subject: {subject}').format(subject=preview_subject),
                         'html': preview_text,
+                        'attachment': form.cleaned_data.get('attachment')
                     }
 
             self.order_count = ocnt
@@ -248,7 +249,15 @@ class SenderView(EventPermissionRequiredMixin, FormView):
         ctx = super().get_context_data(*args, **kwargs)
         ctx['output'] = getattr(self, 'output', None)
         ctx['order_count'] = getattr(self, 'order_count', None)
+        ctx['is_preview'] = self.request.method == 'POST' and self.request.POST.get('action') == 'preview'
         return ctx
+
+    def get_form(self, form_class=None):
+        f = super().get_form(form_class)
+        if self.request.method == 'POST' and self.request.POST.get('action') == 'preview':
+            for fname, field in f.fields.items():
+                field.widget.attrs['disabled'] = 'disabled'
+        return f
 
 
 class EmailHistoryView(EventPermissionRequiredMixin, ListView):

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -183,12 +183,14 @@ class SenderView(EventPermissionRequiredMixin, FormView):
 
         orders = orders.annotate(match_pos=Exists(opq)).filter(match_pos=True).distinct()
 
+        ocnt = orders.count()
+
         self.output = {}
-        if not orders:
+        if not ocnt:
             messages.error(self.request, _('There are no orders matching this selection.'))
             return self.get(self.request, *self.args, **self.kwargs)
 
-        if self.request.POST.get("action") == "preview":
+        if self.request.POST.get("action") != "send":
             for l in self.request.event.settings.locales:
                 with language(l, self.request.event.settings.region):
                     context_dict = TolerantDict()
@@ -209,6 +211,7 @@ class SenderView(EventPermissionRequiredMixin, FormView):
                         'html': preview_text,
                     }
 
+            self.order_count = ocnt
             return self.get(self.request, *self.args, **self.kwargs)
 
         kwargs = {
@@ -244,6 +247,7 @@ class SenderView(EventPermissionRequiredMixin, FormView):
     def get_context_data(self, *args, **kwargs):
         ctx = super().get_context_data(*args, **kwargs)
         ctx['output'] = getattr(self, 'output', None)
+        ctx['order_count'] = getattr(self, 'order_count', None)
         return ctx
 
 

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -188,6 +188,8 @@ class SenderView(EventPermissionRequiredMixin, FormView):
         self.output = {}
         if not ocnt:
             messages.error(self.request, _('There are no orders matching this selection.'))
+            self.request.POST = self.request.POST.copy()
+            self.request.POST.pop("action", "")
             return self.get(self.request, *self.args, **self.kwargs)
 
         if self.request.POST.get("action") != "send":
@@ -249,14 +251,15 @@ class SenderView(EventPermissionRequiredMixin, FormView):
         ctx = super().get_context_data(*args, **kwargs)
         ctx['output'] = getattr(self, 'output', None)
         ctx['order_count'] = getattr(self, 'order_count', None)
-        ctx['is_preview'] = self.request.method == 'POST' and self.request.POST.get('action') == 'preview'
+        ctx['is_preview'] = self.request.method == 'POST' and self.request.POST.get('action') == 'preview' and ctx['form'].is_valid()
         return ctx
 
     def get_form(self, form_class=None):
         f = super().get_form(form_class)
         if self.request.method == 'POST' and self.request.POST.get('action') == 'preview':
-            for fname, field in f.fields.items():
-                field.widget.attrs['disabled'] = 'disabled'
+            if f.is_valid():
+                for fname, field in f.fields.items():
+                    field.widget.attrs['disabled'] = 'disabled'
         return f
 
 

--- a/src/tests/plugins/sendmail/test_sendmail.py
+++ b/src/tests/plugins/sendmail/test_sendmail.py
@@ -84,6 +84,7 @@ def test_sendmail_simple_case(logged_in_client, sendmail_url, event, order, pos)
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -110,6 +111,7 @@ def test_sendmail_email_not_sent_if_order_not_match(logged_in_client, sendmail_u
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'p',
+                                      'action': 'send',
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -144,6 +146,7 @@ def test_sendmail_invalid_data(logged_in_client, sendmail_url, event, order, pos
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -171,6 +174,7 @@ def test_sendmail_multi_locales(logged_in_client, sendmail_url, event, item):
 
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'p',
+                                      'action': 'send',
                                       'recipients': 'orders',
                                       'items': item.pk,
                                       'subject_0': 'Test subject',
@@ -209,6 +213,7 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -223,6 +228,7 @@ def test_sendmail_subevents(logged_in_client, sendmail_url, event, order, pos):
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'orders',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -268,6 +274,7 @@ def test_sendmail_attendee_mails(logged_in_client, sendmail_url, event, order, p
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -292,6 +299,7 @@ def test_sendmail_both_mails(logged_in_client, sendmail_url, event, order, pos):
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'both',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -319,6 +327,7 @@ def test_sendmail_both_but_same_address(logged_in_client, sendmail_url, event, o
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'both',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -343,6 +352,7 @@ def test_sendmail_attendee_fallback(logged_in_client, sendmail_url, event, order
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos.item_id,
                                       'subject_0': 'Test subject',
@@ -372,6 +382,7 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
         djmail.outbox = []
         response = logged_in_client.post(sendmail_url,
                                          {'sendto': 'na',
+                                          'action': 'send',
                                           'recipients': 'attendees',
                                           'items': i2.pk,
                                           'subject_0': 'Test subject',
@@ -400,6 +411,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
                                       'filter_checkins': 'on',
@@ -418,6 +430,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
                                       'subject_0': 'Test subject',
@@ -437,6 +450,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
                                       'subject_0': 'Test subject',
@@ -456,6 +470,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
                                       'subject_0': 'Test subject',
@@ -477,6 +492,7 @@ def test_sendmail_attendee_checkin_filter(logged_in_client, sendmail_url, event,
     djmail.outbox = []
     response = logged_in_client.post(sendmail_url,
                                      {'sendto': 'na',
+                                      'action': 'send',
                                       'recipients': 'attendees',
                                       'items': pos2.item_id,
                                       'subject_0': 'Test subject',


### PR DESCRIPTION
Yesterday, a customer accidentally sent thousands of emails instead of a few.

This PR proposes to force mass emails to go through the "preview" step and showing the number of matching orders on the "send" button. It also makes the button red :rotating_light: 