### PR TITLE
i18n: add config for enabling a set of languages

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -311,7 +311,13 @@ is configured, memcached will be used for caching instead of redis.
 Translations
 ------------
 
-pretix comes with a number of translations. Some of them are marked as "incubating", which means
+pretix comes with a number of translations. All languages are enabled by default. If you want to limit
+the languages available in your installation, you can enable a set of languages like this::
+
+    [languages]
+    enabled=en,de
+
+Some of the languages them are marked as "incubating", which means
 they can usually only be selected in development mode. If you want to use them nevertheless, you
 can activate them like this::
 

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -495,11 +495,14 @@ LANGUAGES_INCUBATING = {
 LANGUAGES_RTL = {
     'ar', 'hw'
 }
-
-if DEBUG:
-    LANGUAGES = ALL_LANGUAGES
-else:
-    LANGUAGES = [(k, v) for k, v in ALL_LANGUAGES if k not in LANGUAGES_INCUBATING]
+LANGUAGES = []
+LANGUAGES_ENABLED = [lang for lang in config.get("languages", "enabled", fallback='').split(',') if lang]
+for k, v in ALL_LANGUAGES:
+    if not DEBUG and k in LANGUAGES_INCUBATING:
+        continue
+    if LANGUAGES_ENABLED and k not in LANGUAGES_ENABLED:
+        continue
+    LANGUAGES.append((k, v))
 
 
 EXTRA_LANG_INFO = {


### PR DESCRIPTION
Adds the `enabled` setting to the `[languages]` table in the pretix.cfg.
If left empty, or  omitted all languages are enabled.

Updates #2105 