### PR TITLE
Exporters: Fix crash in error url determination

### DIFF
--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -2209,9 +2209,12 @@ class ExportDoView(EventPermissionRequiredMixin, ExportMixin, AsyncAction, Templ
 
     @cached_property
     def exporter(self):
-        d = getattr(self.request, self.request.method)
+        if self.request.method == "POST":
+            identifier = self.request.POST.get("exporter")
+        else:
+            identifier = self.request.GET.get("exporter")
         for ex in self.exporters:
-            if ex.identifier == d.get("exporter"):
+            if ex.identifier == identifier:
                 return ex
 
     def get(self, request, *args, **kwargs):

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -2204,10 +2204,14 @@ class ExportDoView(EventPermissionRequiredMixin, ExportMixin, AsyncAction, Templ
             'organizer': self.request.event.organizer.slug
         }) + '?identifier=' + self.exporter.identifier
 
+    def get_check_url(self, task_id, ajax):
+        return self.request.path + '?async_id=%s&exporter=%s' % (task_id, self.exporter.identifier) + ('&ajax=1' if ajax else '')
+
     @cached_property
     def exporter(self):
+        d = getattr(self.request, self.request.method)
         for ex in self.exporters:
-            if ex.identifier == self.request.POST.get("exporter"):
+            if ex.identifier == d.get("exporter"):
                 return ex
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
This should fix error 49419. When exporting orders aysnc, the key „exporter“ is not available in `POST` (as the check-url is called via `GET`). Add exporter-identifier to check-url and make `@cachedproperty exporter` look for it based on `request.method`.

Please note: I could not figure out how to test this fix. Any hint how to force async behaviour for export would be appreciated.