### PR TITLE
Fix waitinglist batch selection, add event.slug to download-filename

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/waitinglist/index.html
+++ b/src/pretix/control/templates/pretixcontrol/waitinglist/index.html
@@ -174,7 +174,7 @@
                     <tr>
                         <td>
                             {% if "can_change_orders" in request.eventpermset %}
-                                <label aria-label="{% trans "select row for batch-operation" %}" class="batch-select-label"><input type="checkbox" name="entry" class="batch-select-checkbox" value="{{ s.pk }}"/></label>
+                                <label aria-label="{% trans "select row for batch-operation" %}" class="batch-select-label"><input type="checkbox" name="entry" class="batch-select-checkbox" value="{{ e.pk }}"/></label>
                             {% endif %}
                         </td>
                         {% if request.event.settings.waiting_list_names_asked %}

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -318,6 +318,7 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
     def get_filename(self):
         return '{}_waitinglist'.format(self.request.event.slug)
 
+
 class EntryDelete(EventPermissionRequiredMixin, DeleteView):
     model = WaitingListEntry
     template_name = 'pretixcontrol/waitinglist/delete.html'

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -312,9 +312,11 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
             writer.writerow(row)
 
         r = HttpResponse(output.getvalue().encode("utf-8"), content_type='text/csv')
-        r['Content-Disposition'] = 'attachment; filename="waitinglist.csv"'
+        r['Content-Disposition'] = 'attachment; filename="{}.csv"'.format(self.get_filename())
         return r
 
+    def get_filename(self):
+        return '{}_waitinglist'.format(self.request.event.slug)
 
 class EntryDelete(EventPermissionRequiredMixin, DeleteView):
     model = WaitingListEntry


### PR DESCRIPTION
Batch selection of waitinglist entries was not working due to missing entry-ids. Download of a waitinglist used a generic name waitinglist.csv – changed to reflect the behaviour when using the export functionality.