### PR TITLE
Performance: Replace inlinestyler with css_inline; Add drf-ujson

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,4 +9,4 @@ dist/
 *.bak
 pretix/static/jsi18n/
 node_modules/
-
+.eggs/

--- a/src/pretix/api/serializers/settings.py
+++ b/src/pretix/api/serializers/settings.py
@@ -54,8 +54,8 @@ class SettingsSerializer(serializers.Serializer):
             f = DEFAULTS[fname]['serializer_class'](
                 **kwargs
             )
-            f._label = form_kwargs.get('label', fname)
-            f._help_text = form_kwargs.get('help_text')
+            f._label = str(form_kwargs.get('label', fname))
+            f._help_text = str(form_kwargs.get('help_text'))
             f.parent = self
             self.fields[fname] = f
 

--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 from itertools import groupby
 from smtplib import SMTPResponseException
 
+import css_inline
 from django.conf import settings
 from django.core.mail.backends.smtp import EmailBackend
 from django.db.models import Count
@@ -35,7 +36,6 @@ from django.utils.timezone import now
 from django.utils.translation import (
     get_language, gettext_lazy as _, pgettext_lazy,
 )
-from inlinestyler.utils import inline_css
 
 from pretix.base.i18n import (
     LazyCurrencyNumber, LazyDate, LazyExpiresDate, LazyNumber,
@@ -174,7 +174,11 @@ class TemplateBasedMailRenderer(BaseHTMLMailRenderer):
             htmlctx['ev'] = position.subevent or self.event
 
         tpl = get_template(self.template_name)
-        body_html = inline_css(tpl.render(htmlctx))
+        body_html = tpl.render(htmlctx)
+
+        inliner = css_inline.CSSInliner(remove_style_tags=True)
+        body_html = inliner.inline(body_html)
+
         return body_html
 
 

--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -45,7 +45,6 @@ from email.utils import formataddr
 from typing import Any, Dict, List, Sequence, Union
 from urllib.parse import urljoin, urlparse
 
-import cssutils
 import pytz
 import requests
 from bs4 import BeautifulSoup
@@ -79,7 +78,6 @@ from pretix.presale.ical import get_ical
 
 logger = logging.getLogger('pretix.base.mail')
 INVALID_ADDRESS = 'invalid-pretix-mail-address'
-cssutils.log.setLevel(logging.CRITICAL)
 
 
 class TolerantDict(dict):

--- a/src/pretix/base/services/notifications.py
+++ b/src/pretix/base/services/notifications.py
@@ -19,11 +19,11 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <https://www.gnu.org/licenses/>.
 #
+import css_inline
 from django.conf import settings
 from django.template.loader import get_template
 from django.utils.timezone import override
 from django_scopes import scope, scopes_disabled
-from inlinestyler.utils import inline_css
 
 from pretix.base.i18n import language
 from pretix.base.models import LogEntry, NotificationSetting, User
@@ -131,7 +131,11 @@ def send_notification_mail(notification: Notification, user: User):
     }
 
     tpl_html = get_template('pretixbase/email/notification.html')
-    body_html = inline_css(tpl_html.render(ctx))
+
+    body_html = tpl_html.render(ctx)
+    inliner = css_inline.CSSInliner(remove_style_tags=True)
+    body_html = inliner.inline(body_html)
+
     tpl_plain = get_template('pretixbase/email/notification.txt')
     body_plain = tpl_plain.render(ctx)
 

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -379,7 +379,12 @@ REST_FRAMEWORK = {
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
     ),
     'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
+        'drf_ujson.renderers.UJSONRenderer',
+    ),
+    'DEFAULT_PARSER_CLASSES': (
+        'drf_ujson.parsers.UJSONParser',
+        'rest_framework.parsers.FormParser',
+        'rest_framework.parsers.MultiPartParser'
     ),
     'TEST_REQUEST_RENDERER_CLASSES': [
         'rest_framework.renderers.MultiPartRenderer',

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 ignore = N802,W503,E402,C901,E722,W504,E252,N812,N806,E741
 max-line-length = 160
-exclude = migrations,.ropeproject,static,mt940.py,_static,build,make_testdata.py,*/testutils/settings.py,tests/settings.py,pretix/base/models/__init__.py,pretix/base/secretgenerators/pretix_sig1_pb2.py
+exclude = migrations,.ropeproject,static,mt940.py,_static,build,make_testdata.py,*/testutils/settings.py,tests/settings.py,pretix/base/models/__init__.py,pretix/base/secretgenerators/pretix_sig1_pb2.py,.eggs/*
 max-complexity = 11
 
 [isort]
@@ -13,7 +13,7 @@ extra_standard_library = typing,enum,mimetypes
 multi_line_output = 5
 line_length = 79
 honor_noqa = true
-skip = make_testdata.py,wsgi.py,bootstrap,celery_app.py,pretix/settings.py,tests/settings.py,pretix/testutils/settings.py
+skip = make_testdata.py,wsgi.py,bootstrap,celery_app.py,pretix/settings.py,tests/settings.py,pretix/testutils/settings.py,.eggs/*
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = tests.settings
@@ -34,7 +34,7 @@ filterwarnings =
 
 [coverage:run]
 source = pretix
-omit = */migrations/*,*/urls.py,*/tests/*,*/testdummy/*,*/admin.py,pretix/wsgi.py,pretix/settings.py
+omit = */migrations/*,*/urls.py,*/tests/*,*/testdummy/*,*/admin.py,pretix/wsgi.py,pretix/settings.py,.eggs/*
 
 [coverage:report]
 exclude_lines =

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -13,7 +13,7 @@ extra_standard_library = typing,enum,mimetypes
 multi_line_output = 5
 line_length = 79
 honor_noqa = true
-skip = make_testdata.py,wsgi.py,bootstrap,celery_app.py,pretix/settings.py,tests/settings.py,pretix/testutils/settings.py,.eggs/*
+skip_glob = make_testdata.py,wsgi.py,bootstrap,celery_app.py,pretix/settings.py,tests/settings.py,pretix/testutils/settings.py,.eggs/**
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = tests.settings

--- a/src/setup.py
+++ b/src/setup.py
@@ -191,7 +191,6 @@ setup(
         'django-statici18n==1.9.*',
         'djangorestframework==3.12.*',
         'drf_ujson2==1.6.*',
-        'inlinestyler==0.2.*',
         'isoweek',
         'jsonschema',
         'kombu==4.6.*',

--- a/src/setup.py
+++ b/src/setup.py
@@ -166,6 +166,7 @@ setup(
         'chardet<3.1.0,>=3.0.2',
         'cryptography>=3.4.2',
         'csscompressor',
+        'css-inline==0.7.*',
         'defusedcsv>=1.1.0',
         'dj-static',
         'Django==3.2.*',
@@ -189,6 +190,7 @@ setup(
         'django-scopes==1.2.*',
         'django-statici18n==1.9.*',
         'djangorestframework==3.12.*',
+        'drf_ujson2==1.6.*',
         'inlinestyler==0.2.*',
         'isoweek',
         'jsonschema',
@@ -253,6 +255,7 @@ setup(
         'memcached': ['pylibmc'],
         'mysql': ['mysqlclient'],
     },
+    setup_requires=['setuptools-rust'],
 
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
* This adds drf-ujson for faster JSON serializing/deserializing in the API. The effect on a single request is so little I couldn't measured it. The effect on production in total could still be significant and there's barely any cost in complexity.

* This replaces ``inlinestyler`` with ``css_inline``. In my very non-scientific tests I can confirm that this *significantly* improves email rendering. The benchmarks in the css_inline README claim a speedup of ~x100, which seems plausible. This could significantly reduce load on our email sending threads. The cost is that it makes us depend on a rust toolchain. There's no change for most users, since there are pre-built wheels on PyPI, but everyone running pretix on e.g. arm architectures will need a rust compiler and build it themselves.