### PR TITLE
Event setup: do not create new team when staff session active

### DIFF
--- a/src/pretix/control/views/main.py
+++ b/src/pretix/control/views/main.py
@@ -161,6 +161,7 @@ class EventWizard(SafeSessionWizardView):
                 initial['locales'] = self.clone_from.settings.locales
                 initial['has_subevents'] = self.clone_from.has_subevents
             elif step == 'basics':
+                initial['request'] = self.request
                 initial['name'] = self.clone_from.name
 
                 if re.match('^.*-[0-9]+$', self.clone_from.slug):
@@ -270,7 +271,7 @@ class EventWizard(SafeSessionWizardView):
                 user=self.request.user,
             )
 
-            if not EventWizardBasicsForm.has_control_rights(self.request.user, event.organizer):
+            if not EventWizardBasicsForm.has_control_rights(self.request.user, event.organizer, self.request.session):
                 if basics_data["team"] is not None:
                     t = basics_data["team"]
                     t.limit_events.add(event)


### PR DESCRIPTION
With b260cca412df43d6e47d4d574cb2e5132399c2c0, team provisioning has been disabled for users that are staff. However, this leads to strange UX, as a new event created by a staff member, not currently in a staff session, resulted in a 404 directly after creation.

This PR updates this requirement to not need to select a team, only when a staff session is active.