### PR TITLE
Event creation: call plugin installed() after persisting event

### DIFF
--- a/src/pretix/control/views/main.py
+++ b/src/pretix/control/views/main.py
@@ -261,10 +261,10 @@ class EventWizard(SafeSessionWizardView):
         with transaction.atomic(), language(basics_data['locale']):
             event = form_dict['basics'].instance
             event.organizer = foundation_data['organizer']
-            event.set_active_plugins(settings.PRETIX_PLUGINS_DEFAULT.split(","), allow_restricted=True)
             event.has_subevents = foundation_data['has_subevents']
             event.testmode = True
             form_dict['basics'].save()
+            event.set_active_plugins(settings.PRETIX_PLUGINS_DEFAULT.split(","), allow_restricted=True)
             event.log_action(
                 'pretix.event.added',
                 user=self.request.user,


### PR DESCRIPTION
With #2089, PluginConfig.installed() is also called for newly created events. However, the passed event argument is still not committed. The plugins cannot use the event to insert or select objects, as it does not have an ID yet.