### PR TITLE
Use upgrade strategy "eager"

### DIFF
--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -289,7 +289,7 @@ To upgrade to a new pretix release, pull the latest code changes and run the fol
 ``postgres`` with ``mysql`` if necessary)::
 
     $ source /var/pretix/venv/bin/activate
-    (venv)$ pip3 install -U pretix gunicorn
+    (venv)$ pip3 install -U --upgrade-strategy eager pretix gunicorn
     (venv)$ python -m pretix migrate
     (venv)$ python -m pretix rebuild
     (venv)$ python -m pretix updatestyles


### PR DESCRIPTION
Pip's default strategy is to keep the version of all packages which do not explicitly require an upgrade. This caused issues for me for the second time now in the migration step, because some dependencies were not compatible with the new pretix version, but not explicitly listed as a such. Also I think the "eager" strategy better resembles what happens in the docker container build, as it always installs the newest versions.