### PR TITLE
PayPal: Add postfix-field and pass information to custom-field

### DIFF
--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -145,7 +145,7 @@ class Paypal(BasePaymentProvider):
             ('postfix',
              forms.CharField(
                  label=_('Reference postfix'),
-                 help_text=_('Any value entered here will be added in front of the regular booking reference '
+                 help_text=_('Any value entered here will be added behind the regular booking reference '
                              'containing the order number.'),
                  required=False,
              )),
@@ -296,9 +296,9 @@ class Paypal(BasePaymentProvider):
                             "items": [
                                 {
                                     "name": '{prefix}{orderstring}{postfix}'.format(
-                                        prefix=self.settings.prefix if self.settings.prefix else '',
+                                        prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                                         orderstring=__('Order for %s') % str(request.event),
-                                        postfix=self.settings.postfix if self.settings.postfix else ''
+                                        postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                                     ),
                                 }
                             ]
@@ -310,9 +310,9 @@ class Paypal(BasePaymentProvider):
                         "description": __('Event tickets for {event}').format(event=request.event.name),
                         "payee": payee,
                         "custom": '{prefix}{slug}{postfix}'.format(
-                            prefix=self.settings.prefix if self.settings.prefix else '',
+                            prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                             slug=request.event.slug.upper(),
-                            postfix=self.settings.postfix if self.settings.postfix else ''
+                            postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                         )
                     }
                 ]
@@ -411,12 +411,12 @@ class Paypal(BasePaymentProvider):
                         "items": [
                             {
                                 "name": '{prefix}{orderstring}{postfix}'.format(
-                                    prefix=self.settings.prefix if self.settings.prefix else '',
+                                    prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                                     orderstring=__('Order {slug}-{code}').format(
                                         slug=self.event.slug.upper(),
                                         code=payment_obj.order.code
                                     ),
-                                    postfix=self.settings.postfix if self.settings.postfix else ''
+                                    postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                                 ),
                                 "quantity": 1,
                                 "price": self.format_price(payment_obj.amount),
@@ -429,12 +429,12 @@ class Paypal(BasePaymentProvider):
                     "op": "replace",
                     "path": "/transactions/0/description",
                     "value": '{prefix}{orderstring}{postfix}'.format(
-                        prefix=self.settings.prefix if self.settings.prefix else '',
+                        prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                         orderstring=__('Order {order} for {event}').format(
                             event=request.event.name,
                             order=payment_obj.order.code
                         ),
-                        postfix=self.settings.postfix if self.settings.postfix else ''
+                        postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                     ),
                 }
             ])
@@ -635,12 +635,12 @@ class Paypal(BasePaymentProvider):
                             "items": [
                                 {
                                     "name": '{prefix}{orderstring}{postfix}'.format(
-                                        prefix=self.settings.prefix if self.settings.prefix else '',
+                                        prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                                         orderstring=__('Order {slug}-{code}').format(
                                             slug=self.event.slug.upper(),
                                             code=payment_obj.order.code
                                         ),
-                                        postfix=self.settings.postfix if self.settings.postfix else ''
+                                        postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                                     ),
                                     "quantity": 1,
                                     "price": self.format_price(payment_obj.amount),
@@ -653,19 +653,19 @@ class Paypal(BasePaymentProvider):
                             "total": self.format_price(payment_obj.amount)
                         },
                         "description": '{prefix}{orderstring}{postfix}'.format(
-                            prefix=self.settings.prefix if self.settings.prefix else '',
+                            prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                             orderstring=__('Order {order} for {event}').format(
                                 event=request.event.name,
                                 order=payment_obj.order.code
                             ),
-                            postfix=self.settings.postfix if self.settings.postfix else ''
+                            postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                         ),
                         "payee": payee,
                         "custom": '{prefix}{slug}-{code}{postfix}'.format(
-                            prefix=self.settings.prefix if self.settings.prefix else '',
+                            prefix='{} '.format(self.settings.prefix) if self.settings.prefix else '',
                             slug=self.event.slug.upper(),
                             code=payment_obj.order.code,
-                            postfix=self.settings.postfix if self.settings.postfix else ''
+                            postfix=' {}'.format(self.settings.postfix) if self.settings.postfix else ''
                         ),
                     }
                 ]

--- a/src/pretix/plugins/paypal/payment.py
+++ b/src/pretix/plugins/paypal/payment.py
@@ -141,7 +141,14 @@ class Paypal(BasePaymentProvider):
                  help_text=_('Any value entered here will be added in front of the regular booking reference '
                              'containing the order number.'),
                  required=False,
-             ))
+             )),
+            ('postfix',
+             forms.CharField(
+                 label=_('Reference postfix'),
+                 help_text=_('Any value entered here will be added in front of the regular booking reference '
+                             'containing the order number.'),
+                 required=False,
+             )),
         ]
 
         d = OrderedDict(
@@ -288,11 +295,11 @@ class Paypal(BasePaymentProvider):
                         "item_list": {
                             "items": [
                                 {
-                                    "name": ('{} '.format(self.settings.prefix) if self.settings.prefix else '') +
-                                    __('Order for %s') % str(request.event),
-                                    "quantity": 1,
-                                    "price": self.format_price(cart['total']),
-                                    "currency": request.event.currency
+                                    "name": '{prefix}{orderstring}{postfix}'.format(
+                                        prefix=self.settings.prefix if self.settings.prefix else '',
+                                        orderstring=__('Order for %s') % str(request.event),
+                                        postfix=self.settings.postfix if self.settings.postfix else ''
+                                    ),
                                 }
                             ]
                         },
@@ -301,7 +308,12 @@ class Paypal(BasePaymentProvider):
                             "total": self.format_price(cart['total'])
                         },
                         "description": __('Event tickets for {event}').format(event=request.event.name),
-                        "payee": payee
+                        "payee": payee,
+                        "custom": '{prefix}{slug}{postfix}'.format(
+                            prefix=self.settings.prefix if self.settings.prefix else '',
+                            slug=request.event.slug.upper(),
+                            postfix=self.settings.postfix if self.settings.postfix else ''
+                        )
                     }
                 ]
             })
@@ -398,9 +410,13 @@ class Paypal(BasePaymentProvider):
                     "value": {
                         "items": [
                             {
-                                "name": ('{} '.format(self.settings.prefix) if self.settings.prefix else '') +
-                                __('Order {slug}-{code}').format(
-                                    slug=self.event.slug.upper(), code=payment_obj.order.code
+                                "name": '{prefix}{orderstring}{postfix}'.format(
+                                    prefix=self.settings.prefix if self.settings.prefix else '',
+                                    orderstring=__('Order {slug}-{code}').format(
+                                        slug=self.event.slug.upper(),
+                                        code=payment_obj.order.code
+                                    ),
+                                    postfix=self.settings.postfix if self.settings.postfix else ''
                                 ),
                                 "quantity": 1,
                                 "price": self.format_price(payment_obj.amount),
@@ -412,11 +428,14 @@ class Paypal(BasePaymentProvider):
                 {
                     "op": "replace",
                     "path": "/transactions/0/description",
-                    "value": ('{} '.format(self.settings.prefix) if self.settings.prefix else '') +
-                    __('Order {order} for {event}').format(
-                        event=request.event.name,
-                        order=payment_obj.order.code
-                    )
+                    "value": '{prefix}{orderstring}{postfix}'.format(
+                        prefix=self.settings.prefix if self.settings.prefix else '',
+                        orderstring=__('Order {order} for {event}').format(
+                            event=request.event.name,
+                            order=payment_obj.order.code
+                        ),
+                        postfix=self.settings.postfix if self.settings.postfix else ''
+                    ),
                 }
             ])
             try:
@@ -615,10 +634,13 @@ class Paypal(BasePaymentProvider):
                         "item_list": {
                             "items": [
                                 {
-                                    "name": ('{} '.format(self.settings.prefix) if self.settings.prefix else '') +
-                                    __('Order {slug}-{code}').format(
-                                        slug=self.event.slug.upper(),
-                                        code=payment_obj.order.code
+                                    "name": '{prefix}{orderstring}{postfix}'.format(
+                                        prefix=self.settings.prefix if self.settings.prefix else '',
+                                        orderstring=__('Order {slug}-{code}').format(
+                                            slug=self.event.slug.upper(),
+                                            code=payment_obj.order.code
+                                        ),
+                                        postfix=self.settings.postfix if self.settings.postfix else ''
                                     ),
                                     "quantity": 1,
                                     "price": self.format_price(payment_obj.amount),
@@ -630,12 +652,21 @@ class Paypal(BasePaymentProvider):
                             "currency": request.event.currency,
                             "total": self.format_price(payment_obj.amount)
                         },
-                        "description": ('{} '.format(self.settings.prefix) if self.settings.prefix else '') +
-                        __('Order {order} for {event}').format(
-                            event=request.event.name,
-                            order=payment_obj.order.code
+                        "description": '{prefix}{orderstring}{postfix}'.format(
+                            prefix=self.settings.prefix if self.settings.prefix else '',
+                            orderstring=__('Order {order} for {event}').format(
+                                event=request.event.name,
+                                order=payment_obj.order.code
+                            ),
+                            postfix=self.settings.postfix if self.settings.postfix else ''
                         ),
-                        "payee": payee
+                        "payee": payee,
+                        "custom": '{prefix}{slug}-{code}{postfix}'.format(
+                            prefix=self.settings.prefix if self.settings.prefix else '',
+                            slug=self.event.slug.upper(),
+                            code=payment_obj.order.code,
+                            postfix=self.settings.postfix if self.settings.postfix else ''
+                        ),
                     }
                 ]
             })


### PR DESCRIPTION
Z#2378438

This PR addresses the following issues:
- Adding a postfix-field in addition to the already existing prefix-field
- Passing the `{prefix}{event}-{code}{postfix}`-construct to PayPal's `transaction.custom`-field for use in settlement reports.
- Rework all transfer reason fields and similar to also include the postfix

Semi-Breaking changes:
- So far, when a prefix was defined, the resulting string would have been 'PREFIX Order for...'. With this change, we are eliminating the whitespaces/moving the responsibility for whitespaces to the the prefix-setup. I'd be willing to ship it like this, or - if requested - to add a migration to add a whitespace to existing set up prefixes.

I'd also be open to remove the prefixes (and by extension postfixes) from all user-facing fields and only have them in the `transaction.custom`-field, as this is the designated field by PayPal for settlement-stuff. If we do this, we should however at least inform the few customers using this on pretix hosted.