### PR TITLE
Email: make responsive and show header image in MS Outlook

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -640,14 +640,14 @@ def convert_image_to_cid(image_src, cid_id, verify_ssl=True):
             image_src = normalize_image_url(image_src)
 
             path = urlparse(image_src).path
-            guess_subtype = os.path.splitext(path)[1][1:]
+            image_type = os.path.splitext(path)[1][1:]
 
             response = requests.get(image_src, verify=verify_ssl)
             mime_image = MIMEImage(
-                response.content, _subtype=guess_subtype)
+                response.content, _subtype=image_type)
 
         mime_image.add_header('Content-ID', '<%s>' % cid_id)
-        mime_image.add_header('Content-Disposition', 'inline; filename="%s"' % cid_id)
+        mime_image.add_header('Content-Disposition', 'inline;\n filename="{}.{}"'.format(cid_id, image_type))
 
         return mime_image
     except:

--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -647,6 +647,7 @@ def convert_image_to_cid(image_src, cid_id, verify_ssl=True):
                 response.content, _subtype=guess_subtype)
 
         mime_image.add_header('Content-ID', '<%s>' % cid_id)
+        mime_image.add_header('Content-Disposition', 'inline; filename=%s' % cid_id)
 
         return mime_image
     except:

--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -647,7 +647,7 @@ def convert_image_to_cid(image_src, cid_id, verify_ssl=True):
                 response.content, _subtype=guess_subtype)
 
         mime_image.add_header('Content-ID', '<%s>' % cid_id)
-        mime_image.add_header('Content-Disposition', 'inline; filename=%s' % cid_id)
+        mime_image.add_header('Content-Disposition', 'inline; filename="%s"' % cid_id)
 
         return mime_image
     except:

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -1,12 +1,18 @@
 {% load eventurl %}
 {% load i18n %}
 {% load thumb %}
-
-<!DOCTYPE html>
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, user-scalable=false">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{subject}}</title>
+<!--[if gte mso 9]><xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml><![endif]-->
     <style type="text/css">
         body {
             background-color: #eee;

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -216,7 +216,6 @@
     <![endif]-->
     <table class="layout" width="600" border="0" cellspacing="0">
         {% if event.settings.logo_image %}
-            <!--[if !mso]><!-- -->
             <tr>
                 <td style="line-height: 0; {% if event.settings.logo_image_large %}padding: 0;{% endif %}" align="center" class="logo">
                     {% if event.settings.logo_image_large %}
@@ -228,7 +227,6 @@
                     {% endif %}
                 </td>
             </tr>
-            <!--<![endif]-->
         {% endif %}
         <tr>
             <td class="header" align="center">

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -214,16 +214,14 @@
     <table width="100%"><tr><td align="center">
     <table width="600"><tr><td align="center"
     <![endif]-->
-    <table class="layout" width="600" border="0" cellspacing="0">
+    <table class="layout" style="max-width:600px" border="0" cellspacing="0">
         {% if event.settings.logo_image %}
             <tr>
                 <td style="line-height: 0; {% if event.settings.logo_image_large %}padding: 0;{% endif %}" align="center" class="logo">
                     {% if event.settings.logo_image_large %}
-                        <img src="{% if event.settings.logo_image|thumb:'1170x5000'|first == '/' %}{{ site_url }}{% endif %}{{ event.settings.logo_image|thumb:'1170x5000' }}" alt="{{ event.name }}"
-                             style="height: auto; max-width: 100%;" />
+                        <img src="{% if event.settings.logo_image|thumb:'600_x5000'|first == '/' %}{{ site_url }}{% endif %}{{ event.settings.logo_image|thumb:'600_x5000' }}" alt="{{ event.name }}" style="width:100%" />
                     {% else %}
-                        <img src="{% if event.settings.logo_image|thumb:'5000x120'|first == '/' %}{{ site_url }}{% endif %}{{ event.settings.logo_image|thumb:'5000x120' }}" alt="{{ event.name }}"
-                                style="height: auto; max-width: 100%;" />
+                        <img src="{% if event.settings.logo_image|thumb:'600_x120'|first == '/' %}{{ site_url }}{% endif %}{{ event.settings.logo_image|thumb:'600_x120' }}" alt="{{ event.name }}" style="width:100%" />
                     {% endif %}
                 </td>
             </tr>

--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -35,6 +35,48 @@ class ThumbnailError(Exception):
     pass
 
 
+"""
+
+# How "size" works:
+
+
+## normal resize
+
+image|thumb:"100x100" resizes the image proportionally to a maximum width and maximum height of 100px.
+I.e. an image of 200x100 will be resized to 100x50.
+An image of 40x80 will stay 40x80.
+
+
+## cropped resize with ^
+
+image|thumb:"100x100^" resizes the image proportionally to a minimum width and minimum height of 100px and then will be cropped to 100x100.
+I.e. an image of 300x200 will be resized to 150x100 and then cropped from center to 100x100.
+An image of 40x80 will stay 40x80.
+
+
+## min-size resize with _
+
+min-size-operator "_" works for width and height independently, so the following is possible:
+
+image|thumb:"100_x100" resizes the image to a maximum height of 100px (if it is lower, it does not upscale) and makes it at least 100px wide
+(if the resized image would be less than 100px wide it adds a white background to both sides to make it at least 100px wide).
+I.e. an image of 300x200 will be resized to 150x100.
+An image of 40x80 will stay 40x80 but padded with a white background to be 100x80.
+
+image|thumb:"100x100_" resizes the image to a maximum width of 100px (if it is lower, it does not upscale) and makes it at least 100px high
+(if the resized image would be less than 100px high it adds a white background to top and bottom to make it at least 100px high).
+I.e. an image of 400x200 will be resized to 100x50 and then padded from cener to be 100x100.
+An image of 40x80 will stay 40x80 but padded with a white background to be 40x100.
+
+image|thumb:"100_x100_" resizes the image proportionally to either a width or height of 100px – it takes the smaller side and resizes that to 100px,
+so the longer side will at least be 100px. So the resulting image will at least be 100px wide and at least 100px high. If the original image is bigger
+than 100x100 then no padding will occur. If the original image is smaller than 100x100, no resize will happen but padding to 100x100 will occur.
+I.e. an image of 400x200 will be resized to 200x100.
+An image of 40x80 will stay 40x80 but padded with a white background to be 100x100.
+
+"""
+
+
 def get_minsize(size):
     if "_" not in size:
         return (0, 0)

--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -34,14 +34,30 @@ from pretix.helpers.models import Thumbnail
 class ThumbnailError(Exception):
     pass
 
+def get_minsize(size):
+    if not "_" in size:
+        return (0, 0)
+    min_width = 0
+    min_height = 0
+    if "x" in size:
+        sizes = size.split('x')
+        if sizes[0].endswith("_"):
+            min_width = int(sizes[0][:-1])
+        if sizes[1].endswith("_"):
+            min_height = int(sizes[1][:-1])
+    elif size.endswith("_"):
+        min_width = int(size[:-1])
+        min_height = min_width
+    return (min_width, min_height)
 
 def get_sizes(size, imgsize):
     crop = False
     if size.endswith('^'):
         crop = True
         size = size[:-1]
-    if "_" in size:
-        # ignore _ for min-size here
+
+    min_width, min_height = get_minsize(size)
+    if min_width or min_height:
         size = size.replace("_", "")
 
     if 'x' in size:
@@ -50,6 +66,7 @@ def get_sizes(size, imgsize):
         size = [int(size), int(size)]
 
     if crop:
+        # currently crop and min-size cannot be combined
         wfactor = min(1, size[0] / imgsize[0])
         hfactor = min(1, size[1] / imgsize[1])
         if wfactor == hfactor:
@@ -65,12 +82,45 @@ def get_sizes(size, imgsize):
     else:
         wfactor = min(1, size[0] / imgsize[0])
         hfactor = min(1, size[1] / imgsize[1])
+        if min_width and min_height:
+            wfactor = max(wfactor, hfactor)
+        elif min_width:
+            wfactor = hfactor
+        elif min_height:
+            hfactor = wfactor
+
         if wfactor == hfactor:
             return (int(imgsize[0] * hfactor), int(imgsize[1] * wfactor)), None
         elif wfactor < hfactor:
             return (size[0], int(imgsize[1] * wfactor)), None
         else:
             return (int(imgsize[0] * hfactor), size[1]), None
+
+
+def resize_image(image, size):
+    # before we calc thumbnail, we need to check and apply EXIF-orientation
+    image = ImageOps.exif_transpose(image)
+
+    new_size, crop = get_sizes(size, image.size)
+    image = image.resize(new_size, resample=LANCZOS)
+    if crop:
+        image = image.crop(crop)
+
+    min_width, min_height = get_minsize(size)
+
+    if min_width > new_size[0] or min_height > new_size[1]:
+        padding = math.ceil(max(min_width - new_size[0], min_height - new_size[1]) / 2)
+        image = image.convert('RGB')
+        image = ImageOps.expand(image, border=padding, fill="white")
+
+        new_width = max(min_width, new_size[0])
+        new_height = max(min_height, new_size[1])
+        new_x = (image.width - new_width) // 2
+        new_y = (image.height - new_height) // 2
+
+        image = image.crop((new_x, new_y, new_x + new_width, new_y + new_height))
+
+    return image
 
 
 def create_thumbnail(sourcename, size):
@@ -81,38 +131,7 @@ def create_thumbnail(sourcename, size):
     except:
         raise ThumbnailError('Could not load image')
 
-    # before we calc thumbnail, we need to check and apply EXIF-orientation
-    image = ImageOps.exif_transpose(image)
-
-    new_size, crop = get_sizes(size, image.size)
-    image = image.resize(new_size, resample=LANCZOS)
-    if crop:
-        image = image.crop(crop)
-
-    if "_" in size:
-        min_width = 0
-        min_height = 0
-        if "x" in size:
-            sizes = size.split('x')
-            if sizes[0].endswith("_"):
-                min_width = int(sizes[0][:-1])
-            if sizes[1].endswith("_"):
-                min_height = int(sizes[1][:-1])
-        elif size.endswith("_"):
-            min_width = int(size[:-1])
-            min_height = min_width
-
-        if min_width > new_size[0] or min_height > new_size[1]:
-            padding = math.ceil(max(min_width - new_size[0], min_height - new_size[1]) / 2)
-            image = image.convert('RGB')
-            image = ImageOps.expand(image, border=padding, fill="white")
-
-            new_width = max(min_width, new_size[0])
-            new_height = max(min_height, new_size[1])
-            new_x = (image.width - new_width) // 2
-            new_y = (image.height - new_height) // 2
-
-            image = image.crop((new_x, new_y, new_x + new_width, new_y + new_height))
+    image = resize_image(image, size)
 
     if source.name.endswith('.jpg') or source.name.endswith('.jpeg'):
         # Yields better file sizes for photos

--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -89,6 +89,7 @@ def get_sizes(size, imgsize):
         hfactor = min(1, size[1] / imgsize[1])
         if min_width and min_height:
             wfactor = max(wfactor, hfactor)
+            hfactor = wfactor
         elif min_width:
             wfactor = hfactor
         elif min_height:

--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -34,8 +34,9 @@ from pretix.helpers.models import Thumbnail
 class ThumbnailError(Exception):
     pass
 
+
 def get_minsize(size):
-    if not "_" in size:
+    if "_" not in size:
         return (0, 0)
     min_width = 0
     min_height = 0
@@ -49,6 +50,7 @@ def get_minsize(size):
         min_width = int(size[:-1])
         min_height = min_width
     return (min_width, min_height)
+
 
 def get_sizes(size, imgsize):
     crop = False

--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -56,6 +56,9 @@ def get_sizes(size, imgsize):
         crop = True
         size = size[:-1]
 
+    if crop and "_" in size:
+        raise ThumbnailError('Size %s has errors: crop and minsize cannot be combined.' % size)
+
     min_width, min_height = get_minsize(size)
     if min_width or min_height:
         size = size.replace("_", "")

--- a/src/tests/helpers/test_thumb.py
+++ b/src/tests/helpers/test_thumb.py
@@ -1,0 +1,105 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+from django import urls
+from django.conf import settings
+
+from pretix.helpers.thumb import resize_image
+from PIL import Image
+
+def test_no_resize():
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "100x100")
+    width, height = img.size
+    assert width == 40
+    assert height == 20
+
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "100x100^")
+    width, height = img.size
+    assert width == 40
+    assert height == 20
+
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "10_x20")
+    width, height = img.size
+    assert width == 40
+    assert height == 20
+
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "40x10_")
+    width, height = img.size
+    assert width == 40
+    assert height == 20
+
+
+def test_resize():
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "10x10")
+    width, height = img.size
+    assert width == 10
+    assert height == 5
+
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "100x10")
+    width, height = img.size
+    assert width == 20
+    assert height == 10
+
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "10x100")
+    width, height = img.size
+    assert width == 10
+    assert height == 5
+
+
+def test_crop():
+    img = Image.new('RGB', (40, 20))
+    img = resize_image(img, "10x10^")
+    width, height = img.size
+    assert width == 10
+    assert height == 10
+
+
+def test_minsize():
+    img = Image.new('RGB', (60, 20))
+    img = resize_image(img, "10_x10")
+    width, height = img.size
+    assert width == 30
+    assert height == 10
+
+    img = Image.new('RGB', (10, 20))
+    img = resize_image(img, "10_x10")
+    width, height = img.size
+    assert width == 10
+    assert height == 10
+
+    img = Image.new('RGB', (60, 20))
+    img = resize_image(img, "10x10_")
+    width, height = img.size
+    assert width == 10
+    assert height == 10
+
+    img = Image.new('RGB', (20, 60))
+    img = resize_image(img, "10x10_")
+    width, height = img.size
+    assert width == 10
+    assert height == 30

--- a/src/tests/helpers/test_thumb.py
+++ b/src/tests/helpers/test_thumb.py
@@ -108,3 +108,9 @@ def test_minsize():
     width, height = img.size
     assert width == 10
     assert height == 30
+
+    img = Image.new('RGB', (20, 60))
+    img = resize_image(img, "100_x100_")
+    width, height = img.size
+    assert width == 100
+    assert height == 100

--- a/src/tests/helpers/test_thumb.py
+++ b/src/tests/helpers/test_thumb.py
@@ -102,3 +102,9 @@ def test_minsize():
     width, height = img.size
     assert width == 10
     assert height == 30
+
+    img = Image.new('RGB', (20, 60))
+    img = resize_image(img, "10_x10_")
+    width, height = img.size
+    assert width == 10
+    assert height == 30

--- a/src/tests/helpers/test_thumb.py
+++ b/src/tests/helpers/test_thumb.py
@@ -19,11 +19,10 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <https://www.gnu.org/licenses/>.
 #
-from django import urls
-from django.conf import settings
+from PIL import Image
 
 from pretix.helpers.thumb import resize_image
-from PIL import Image
+
 
 def test_no_resize():
     img = Image.new('RGB', (40, 20))


### PR DESCRIPTION
Email-Template simple_logo.html had a mso-specific comment, which basically removed the header image in MS Outlook clients. I also optimized the html header to the settings recommended on [campaignmonitor](https://www.campaignmonitor.com/blog/email-marketing/correct-doctype-to-use-in-html-email/) and [emailonacid](https://www.emailonacid.com/blog/article/email-development/which-code-should-i-include-in-every-email/).

To make the HTML-email more robust and responsive (ie not that small on smartphones when using a full-width header image), I changed the header-image to always have 600px width – for this to work with smaller images, they need to be padded to 600px width. Therefore I added a new scaling operator: `_` for the size-argument of the thumb-filter in django-templates.

min-size-operator for size-argument of thumb-filter works for width and height independently, so the following is possible:

`image|thumb:"100_x100"` resizes the image to a maximum height of 100px (if it is lower, it does not upscale) and makes it at least 100px wide (if the resized image would be less than 100px wide it adds a white background to both sides to make it at least 100px wide).

`image|thumb:"100x100_"` resizes the image to a maximum width of 100px (if it is lower, it does not upscale) and makes it at least 100px high (if the resized image would be less than 100px high it adds a white background to top and bottom to make it at least 100px high).

`image|thumb:"100_x100_"` resizes the image proportionally to either a width or height of 100px – it takes the smaller side and resizes that to 100px, so the longer side will at least be 100px. So the resulting image will at least be 100px wide and at least 100px high. If the original image is bigger than 100x100 then no padding will occur. If the original image is smaller than 100x100, no resize will happen but padding to 100x100 will occur.


