### PR TITLE
Fix #2150 -- Do not expose internal product names in modify view

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/order_modify.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order_modify.html
@@ -63,7 +63,7 @@
                             {% for form in forms %}
                                 {% if form.pos.item != pos.item %}
                                     {# Add-Ons #}
-                                    <legend>+ {{ form.pos.item }}</legend>
+                                    <legend>+ {{ form.pos.item.name }}</legend>
                                 {% endif %}
                                 {% bootstrap_form form layout="checkout" %}
                             {% endfor %}


### PR DESCRIPTION
When editing an order in the frontend, addon-products show the internal name, if provided. This should be the public name.