### PR TITLE
Payment availability-check: ignore country if no invoice address given

### DIFF
--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -703,7 +703,7 @@ class BasePaymentProvider:
             try:
                 ia = order.invoice_address
             except InvoiceAddress.DoesNotExist:
-                return True
+                pass
             else:
                 if str(ia.country) not in restricted_countries:
                     return False


### PR DESCRIPTION
When limiting payment methods by country and no invoice adress is given, the check should be ignored/passed instead of returning True as checks later in the code path such as `order.sales_channel` as well as `self._is_still_available` might limit the current payment method.