### PR TITLE
Subevent bulk edit: check if list formset has changed only if not None

### DIFF
--- a/src/pretix/control/views/subevents.py
+++ b/src/pretix/control/views/subevents.py
@@ -1151,10 +1151,9 @@ class SubEventBulkEdit(SubEventQueryMixin, EventPermissionRequiredMixin, FormVie
         extra = 0
         kwargs = {}
 
-        if self.sampled_lists is not None:
-            kwargs['instance'] = self.get_queryset()[0]
-        else:
+        if self.sampled_lists is None:
             return None
+        kwargs['instance'] = self.get_queryset()[0]
 
         formsetclass = inlineformset_factory(
             SubEvent, CheckinList,
@@ -1167,7 +1166,7 @@ class SubEventBulkEdit(SubEventQueryMixin, EventPermissionRequiredMixin, FormVie
         )
 
     def save_list_formset(self, log_entries):
-        if not self.list_formset.has_changed() or self.sampled_lists is None:
+        if self.sampled_lists is None or not self.list_formset.has_changed():
             return
         qidx = 0
         subevents = list(self.get_queryset().prefetch_related('checkinlist_set'))


### PR DESCRIPTION
I sometimes get a failed test run for this code path:
https://github.com/pretix/pretix/runs/3278779442?check_suite_focus=true

`self.list_formset` is `None` if `self.sampled_lists` is `None` – see https://github.com/pretix/pretix/blob/master/src/pretix/control/views/subevents.py#L1154

I therefore changed to if statement in `save_list_formset` to first check `self.sampled_lists`. Furthermore I changed to double negation logic in https://github.com/pretix/pretix/blob/master/src/pretix/control/views/subevents.py#L1154 because I always stuble upon double negation.