### PR TITLE
Fix TypeError in Order.ticket_download_available on "empty" orders

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -783,6 +783,7 @@ class Order(LockModel, LoggedModel):
     def ticket_download_available(self):
         return self.event.settings.ticket_download and (
             self.event.settings.ticket_download_date is None
+            or self.ticket_download_date is None
             or now() > self.ticket_download_date
         ) and (
             self.status == Order.STATUS_PAID


### PR DESCRIPTION
Fixes the property `ticket_download_date` which could return `None` what is not handled correctly later on and results in type errors:

```
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: ERROR 2021-08-11 05:00:51,536 django.request log Internal Server Error: /Kuko/<redacted>/order/<redacted>/<redacted>/
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: Traceback (most recent call last):
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 47, in inner
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: response = get_response(request)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 181, in _get_response
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: response = wrapped_callback(request, *callback_args, **callback_kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/views/generic/base.py", line 70, in view
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: return self.dispatch(request, *args, **kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/utils/decorators.py", line 43, in _wrapper
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: return bound_method(*args, **kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/views/decorators/clickjacking.py", line 50, in wrapped_view
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: resp = view_func(*args, **kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/pretix/presale/views/robots.py", line 41, in dispatch
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: resp = super().dispatch(request, *args, **kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/views/generic/base.py", line 98, in dispatch
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: return handler(request, *args, **kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/pretix/presale/views/order.py", line 204, in get
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: return super().get(request, *args, **kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/django/views/generic/base.py", line 159, in get
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: context = self.get_context_data(**kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/pretix/presale/views/order.py", line 227, in get_context_data
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: ctx = super().get_context_data(**kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/pretix/presale/views/__init__.py", line 355, in get_context_data
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: context = super().get_context_data(**kwargs)
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/pretix/presale/views/order.py", line 177, in get_context_data
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: can_download and self.order.ticket_download_available and
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: File "/var/pretix/venv/lib/python3.7/site-packages/pretix/base/models/orders.py", line 775, in ticket_download_available
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: or now() > self.ticket_download_date
Aug 11 05:00:51 kulturkosmos-prod gunicorn[4458]: TypeError: '>' not supported between instances of 'datetime.datetime' and 'NoneType'
```

See the `ticket_download_available` -property:

```python
    @property
    def ticket_download_available(self):
        return self.event.settings.ticket_download and (
            self.event.settings.ticket_download_date is None
            or now() > self.ticket_download_date
        ) and (
            self.status == Order.STATUS_PAID
            or (
                (self.event.settings.ticket_download_pending or self.total == Decimal("0.00")) and
                self.status == Order.STATUS_PENDING and
                not self.require_approval
            )
        )
```

the line `or now() > self.ticket_download_date` breaks if `self.ticket_download_date` is `None`.
Instead of fixing the miss handling of `None` here, we fix the the original property and never return None to avoide this special case.

The alternative would be this:

```python
    @property
    def ticket_download_available(self):
        return self.event.settings.ticket_download and (
            self.event.settings.ticket_download_date is None
            or self.ticket_download_date is None
            or now() > self.ticket_download_date
        ) and (
            self.status == Order.STATUS_PAID
            or (
                (self.event.settings.ticket_download_pending or self.total == Decimal("0.00")) and
                self.status == Order.STATUS_PENDING and
                not self.require_approval
            )
        )
```

But it looks more elegant to get ride of the corner case.