### PR TITLE
[WIP] API: sort answers by questions’ position

### DIFF
--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -848,7 +848,8 @@ class OrderPositionViewSet(mixins.DestroyModelMixin, mixins.UpdateModelMixin, vi
         if self.request.query_params.get('pdf_data', 'false') == 'true':
             qs = qs.prefetch_related(
                 Prefetch('checkins', queryset=Checkin.objects.all()),
-                'answers', 'answers__options', 'answers__question',
+                Prefetch('answers', queryset=QuestionAnswer.objects.order_by('answers__question__position')),
+                'answers__options', 'answers__question',
                 Prefetch('addons', qs.select_related('item', 'variation')),
                 Prefetch('order', Order.objects.select_related('invoice_address').prefetch_related(
                     Prefetch(


### PR DESCRIPTION
Currently when accessing order positions through the API, answers are not sorted (usually means in random order or by creation date). Answers should instead be sorted by their questions’ position.