### PR TITLE
Display subevent location and end time in cart

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -156,6 +156,29 @@ class EventMixin:
             return _date(self.date_from.astimezone(tz), "DATE_FORMAT")
         return daterange(self.date_from.astimezone(tz), self.date_to.astimezone(tz))
 
+    def get_time_range_display(self, tz=None, force_show_end=False) -> str:
+        """
+        Returns a formatted string containing the start time and sometimes the end time
+        of the event with respect to the current locale and to the ``show_date_to``
+        setting. Dates are not shown. This is usually used in combination with get_date_range_display
+        """
+        tz = tz or self.timezone
+
+        show_date_to = self.date_to and (self.settings.show_date_to or force_show_end) and (
+            # Show date to if start and end are on the same day ("08:00-10:00")
+            self.date_to.astimezone(tz).date() == self.date_from.astimezone(tz).date() or
+            # Show date to if start and end are on consecutive days and less than 24h ("23:00-03:00")
+            (self.date_to.astimezone(tz).date() == self.date_from.astimezone(tz).date() + timedelta(days=1) and
+             self.date_to.astimezone(tz).time() < self.date_from.astimezone(tz).time())
+            # Do not show end time if this is a 5-day event because there's no way to make it understandable
+        )
+        if show_date_to:
+            return '{} – {}'.format(
+                _date(self.date_from.astimezone(tz), "TIME_FORMAT"),
+                _date(self.date_to.astimezone(tz), "TIME_FORMAT"),
+            )
+        return _date(self.date_from.astimezone(tz), "TIME_FORMAT")
+
     @property
     def timezone(self):
         return pytz.timezone(self.settings.timezone)

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -44,7 +44,7 @@
                 {% if line.subevent.location %}
                 {% if not line.addon_to or line.addon_to.subevent_id != line.subevent_id %}
                     <div class="cart-icon-details collapse-lines" data-expand-text="{% trans "Show full location" %}">
-                        <span class="content text-muted">{{ line.subevent.location|linebreaksbr }}</span>
+                        <span class="content text-muted" id="full-location-{{ line.pk }}">{{ line.subevent.location|linebreaksbr }}</span>
                     </div>
                 {% endif %}
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -43,8 +43,7 @@
                 </div>
                 {% if line.subevent.location %}
                     <div class="cart-icon-details collapse-lines" data-expand-text="{% trans "Show full location" %}">
-                        <span class="fa fa-map-marker fa-fw" aria-hidden="true"></span>
-                        <span class="content">{{ line.subevent.location|linebreaksbr }}</span>
+                        <span class="content text-muted">{{ line.subevent.location|linebreaksbr }}</span>
                     </div>
                 {% endif %}
             {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -42,9 +42,11 @@
                     </span>
                 </div>
                 {% if line.subevent.location %}
+                {% if not line.addon_to or line.addon_to.subevent_id != line.subevent_id %}
                     <div class="cart-icon-details collapse-lines" data-expand-text="{% trans "Show full location" %}">
                         <span class="content text-muted">{{ line.subevent.location|linebreaksbr }}</span>
                     </div>
+                {% endif %}
                 {% endif %}
             {% endif %}
             {% if line.used_membership %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -15,27 +15,43 @@
                 – {{ line.variation }}
             {% endif %}
             {% if line.seat %}
-                <br />
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="14" viewBox="0 0 4.7624999 3.7041668" class="svg-icon">
-                    <path
-                            d="m 1.9592032,1.8522629e-4 c -0.21468,0 -0.38861,0.17394000371 -0.38861,0.38861000371 0,0.21466 0.17393,0.38861 0.38861,0.38861 0.21468,0 0.3886001,-0.17395 0.3886001,-0.38861 0,-0.21467 -0.1739201,-0.38861000371 -0.3886001,-0.38861000371 z m 0.1049,0.84543000371 c -0.20823,-0.0326 -0.44367,0.12499 -0.39998,0.40462997 l 0.20361,1.01854 c 0.0306,0.15316 0.15301,0.28732 0.3483,0.28732 h 0.8376701 v 0.92708 c 0,0.29313 0.41187,0.29447 0.41187,0.005 v -1.19115 c 0,-0.14168 -0.0995,-0.29507 -0.29094,-0.29507 l -0.65578,-10e-4 -0.1757,-0.87644 C 2.3042533,0.95300523 2.1890432,0.86500523 2.0641032,0.84547523 Z m -0.58549,0.44906997 c -0.0946,-0.0134 -0.20202,0.0625 -0.17829,0.19172 l 0.18759,0.91054 c 0.0763,0.33956 0.36802,0.55914 0.66042,0.55914 h 0.6015201 c 0.21356,0 0.21448,-0.32143 -0.003,-0.32143 H 2.1954632 c -0.19911,0 -0.36364,-0.11898 -0.41341,-0.34107 l -0.17777,-0.87126 c -0.0165,-0.0794 -0.0688,-0.11963 -0.12557,-0.12764 z"/>
-                </svg>
-                {{ line.seat }}
+                <div class="cart-icon-details">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="14" viewBox="0 0 4.7624999 3.7041668" class="svg-icon">
+                        <path
+                                d="m 1.9592032,1.8522629e-4 c -0.21468,0 -0.38861,0.17394000371 -0.38861,0.38861000371 0,0.21466 0.17393,0.38861 0.38861,0.38861 0.21468,0 0.3886001,-0.17395 0.3886001,-0.38861 0,-0.21467 -0.1739201,-0.38861000371 -0.3886001,-0.38861000371 z m 0.1049,0.84543000371 c -0.20823,-0.0326 -0.44367,0.12499 -0.39998,0.40462997 l 0.20361,1.01854 c 0.0306,0.15316 0.15301,0.28732 0.3483,0.28732 h 0.8376701 v 0.92708 c 0,0.29313 0.41187,0.29447 0.41187,0.005 v -1.19115 c 0,-0.14168 -0.0995,-0.29507 -0.29094,-0.29507 l -0.65578,-10e-4 -0.1757,-0.87644 C 2.3042533,0.95300523 2.1890432,0.86500523 2.0641032,0.84547523 Z m -0.58549,0.44906997 c -0.0946,-0.0134 -0.20202,0.0625 -0.17829,0.19172 l 0.18759,0.91054 c 0.0763,0.33956 0.36802,0.55914 0.66042,0.55914 h 0.6015201 c 0.21356,0 0.21448,-0.32143 -0.003,-0.32143 H 2.1954632 c -0.19911,0 -0.36364,-0.11898 -0.41341,-0.34107 l -0.17777,-0.87126 c -0.0165,-0.0794 -0.0688,-0.11963 -0.12557,-0.12764 z"/>
+                    </svg>
+                    {{ line.seat }}
+                </div>
             {% endif %}
             {% if line.voucher %}
-                <br /><span class="fa fa-tags fa-fw" aria-hidden="true"></span> {% trans "Voucher code used:" %} {{ line.voucher.code }}
+                <div class="cart-icon-details">
+                    <span class="fa fa-tags fa-fw" aria-hidden="true"></span> {% trans "Voucher code used:" %} {{ line.voucher.code }}
+                </div>
             {% endif %}
             {% if line.subevent %}
-                <br /><span class="fa fa-calendar fa-fw" aria-hidden="true"></span> {{ line.subevent.name }} &middot; {{ line.subevent.get_date_range_display }}
-                {% if event.settings.show_times %}
-                    <span data-time="{{ line.subevent.date_from.isoformat }}" data-timezone="{{ request.event.timezone }}" data-time-short>
-                        <span class="fa fa-clock-o" aria-hidden="true"></span>
-                        {{ line.subevent.date_from|date:"TIME_FORMAT" }}
+                <div class="cart-icon-details">
+                    <span class="fa fa-calendar fa-fw" aria-hidden="true"></span> {{ line.subevent.name }}
+                    <br>
+                    <span class="text-muted">
+                        {{ line.subevent.get_date_range_display }}
+                        {% if event.settings.show_times %}
+                            &middot; <span data-time="{{ line.subevent.date_from.isoformat }}" data-timezone="{{ request.event.timezone }}" data-time-short>
+                            {{ line.subevent.get_time_range_display }}
+                        </span>
+                        {% endif %}
                     </span>
+                </div>
+                {% if line.subevent.location %}
+                    <div class="cart-icon-details collapse-lines" data-expand-text="{% trans "Show full location" %}">
+                        <span class="fa fa-map-marker fa-fw" aria-hidden="true"></span>
+                        <span class="content">{{ line.subevent.location|linebreaksbr }}</span>
+                    </div>
                 {% endif %}
             {% endif %}
             {% if line.used_membership %}
-                <br /><span class="fa fa-id-card fa-fw" aria-hidden="true"></span> {{ line.used_membership }}
+                <div class="cart-icon-details">
+                    <span class="fa fa-id-card fa-fw" aria-hidden="true"></span> {{ line.used_membership }}
+                </div>
             {% endif %}
 
             {% if line.issued_gift_cards %}

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -86,10 +86,15 @@ $(function () {
         var br_exp = /<br\s*\/?>/i;
         $content.text(original_html.split(br_exp).join(', '));
         if ($content.get(0).scrollWidth > $content.get(0).offsetWidth) {
-            var $handler = $("<button>").text($(this).attr("data-expand-text")).addClass("btn btn-link collapse-handler");
+            var $handler = $("<button>")
+                .text($(this).attr("data-expand-text"))
+                .addClass("btn btn-link collapse-handler")
+                .attr("aria-controls", $content.attr('id'))
+                .attr("aria-expanded", "false");
             $handler.on("click", function (ev) {
                 $content.html(original_html);
-                $(ev.target).remove();
+                $handler.attr("aria-expanded", "true").attr("aria-hidden", "true");
+                $handler.hide();
             });
             $(this).append($handler);
         }

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -86,7 +86,7 @@ $(function () {
         var br_exp = /<br\s*\/?>/i;
         $content.text(original_html.split(br_exp).join(', '));
         if ($content.get(0).scrollWidth > $content.get(0).offsetWidth) {
-            var $handler = $("<a>").text($(this).attr("data-expand-text")).addClass("collapse-handler");
+            var $handler = $("<button>").text($(this).attr("data-expand-text")).addClass("btn btn-link collapse-handler");
             $handler.on("click", function (ev) {
                 $content.html(original_html);
                 $(ev.target).remove();

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -79,4 +79,19 @@ $(function () {
         e.preventDefault();
         return true;
     });
+
+    $(".cart-icon-details.collapse-lines").each(function () {
+        var $content = $(this).find(".content");
+        var original_html = $content.html();
+        var br_exp = /<br\s*\/?>/i;
+        $content.text(original_html.split(br_exp).join(', '));
+        if ($content.get(0).scrollWidth > $content.get(0).offsetWidth) {
+            var $handler = $("<a>").text($(this).attr("data-expand-text")).addClass("collapse-handler");
+            $handler.on("click", function (ev) {
+                $content.html(original_html);
+                $(ev.target).remove();
+            });
+            $(this).append($handler);
+        }
+    })
 });

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -84,8 +84,11 @@
                 white-space: nowrap;
                 text-overflow: ellipsis;
             }
-            a.collapse-handler {
+            .collapse-handler {
                 cursor: pointer;
+                display: inline;
+                padding: 0;
+                text-decoration: underline;
             }
         }
     }

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -66,6 +66,29 @@
             margin-top: 5px;
         }
     }
+
+    .cart-icon-details {
+        position: relative;
+        padding-left: 1.4em;
+        text-indent: 0;
+        .fa, svg {
+            position: absolute;
+            left: 0;
+            top: .22em;
+        }
+
+        &.collapse-lines {
+            .content {
+                display: block;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
+            a.collapse-handler {
+                cursor: pointer;
+            }
+        }
+    }
 }
 
 .apply-voucher {


### PR DESCRIPTION
This is an attempt to fix two customer complaints:
- End time not being shown in cart (but we'll still only show it for events <24h, otherwise things get confusing)
- Location not being shown in cart / order confirmation

**Before**:

![Screenshot 2021-09-05 at 22-08-10 Museum](https://user-images.githubusercontent.com/64280/132140908-c0c38907-754c-4925-9506-592fe282fa3b.png)

**End**:

![Screenshot 2021-09-05 at 22-42-49 Start only](https://user-images.githubusercontent.com/64280/132140906-4729ab71-d4c3-4ec8-b556-41b2bfd4025b.png)

I'm still a little unsatisfied with how full this gets when there's attendee names and addresses and questions and stuff, but there's probably little room to fix that.