### PR TITLE
Improvements around the waiting list

### DIFF
--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -463,6 +463,16 @@ def base_placeholders(sender, **kwargs):
             lambda event: (event if not event.has_subevents or not event.subevents.exists() else event.subevents.first()).get_date_from_display()
         ),
         SimpleFunctionalMailTextPlaceholder(
+            'url_remove', ['waiting_list_entry', 'event'],
+            lambda waiting_list_entry, event: build_absolute_uri(
+                event, 'presale:event.waitinglist.remove'
+            ) + '?voucher=' + waiting_list_entry.voucher.code,
+            lambda event: build_absolute_uri(
+                event,
+                'presale:event.waitinglist.remove',
+            ) + '?voucher=68CYU2H6ZTP3WLK5',
+        ),
+        SimpleFunctionalMailTextPlaceholder(
             'url', ['waiting_list_entry', 'event'],
             lambda waiting_list_entry, event: build_absolute_uri(
                 event, 'presale:event.redeem'

--- a/src/pretix/base/management/commands/makemigrations.py
+++ b/src/pretix/base/management/commands/makemigrations.py
@@ -33,6 +33,7 @@
 # License for the specific language governing permissions and limitations under the License.
 
 from django.core.management.commands.makemigrations import Command as Parent
+
 from ._migrations import monkeypatch_migrations
 
 monkeypatch_migrations()

--- a/src/pretix/base/models/waitinglist.py
+++ b/src/pretix/base/models/waitinglist.py
@@ -167,7 +167,7 @@ class WaitingListEntry(LoggedModel):
             # than the number of valid vouchers *issued through the waiting list*. Things can still go wrong due to
             # manually created vouchers, manually blocked seats or the minimum distance feature,  but this reduces
             # the possible damage a bit.
-            free_seats = ev.free_seats().filter(product=self.item).count() - (Voucher.objects.filter(
+            free_seats = ev.free_seats().filter(product=self.item).count() - (self.event.vouchers.filter(
                 Q(valid_until__isnull=True) | Q(valid_until__gte=now()),
                 block_quota=True,
                 item_id=self.item_id,

--- a/src/pretix/base/models/waitinglist.py
+++ b/src/pretix/base/models/waitinglist.py
@@ -171,7 +171,7 @@ class WaitingListEntry(LoggedModel):
                 Q(valid_until__isnull=True) | Q(valid_until__gte=now()),
                 block_quota=True,
                 item_id=self.item_id,
-                subevent=self.subevent_id,
+                subevent_id=self.subevent_id,
                 waitinglistentries__isnull=False
             ).aggregate(free=Sum(F('max_usages') - F('redeemed')))['free'] or 0)
             if not free_seats:

--- a/src/pretix/base/models/waitinglist.py
+++ b/src/pretix/base/models/waitinglist.py
@@ -21,8 +21,9 @@
 #
 from datetime import timedelta
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models, transaction
+from django.db.models import F, Q, Sum
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django_scopes import ScopedManager
@@ -114,9 +115,12 @@ class WaitingListEntry(LoggedModel):
         return '%s waits for %s' % (str(self.email), str(self.item))
 
     def clean(self):
-        WaitingListEntry.clean_duplicate(self.email, self.item, self.variation, self.subevent, self.pk)
-        WaitingListEntry.clean_itemvar(self.event, self.item, self.variation)
-        WaitingListEntry.clean_subevent(self.event, self.subevent)
+        try:
+            WaitingListEntry.clean_duplicate(self.email, self.item, self.variation, self.subevent, self.pk)
+            WaitingListEntry.clean_itemvar(self.event, self.item, self.variation)
+            WaitingListEntry.clean_subevent(self.event, self.subevent)
+        except ObjectDoesNotExist:
+            raise ValidationError('Invalid input')
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get('update_fields', [])
@@ -147,6 +151,32 @@ class WaitingListEntry(LoggedModel):
         )
         if availability[1] is None or availability[1] < 1:
             raise WaitingListException(_('This product is currently not available.'))
+
+        ev = self.subevent or self.event
+        if ev.seat_category_mappings.filter(product=self.item).exists():
+            # Generally, we advertise the waiting list to be based on quotas only. This makes it dangerous
+            # to use in combination with seating plans. If your event has 50 seats and a quota of 50 and
+            # default settings, everything is fine and the waiting list will work as usual. However, as soon
+            # as those two numbers diverge, either due to misconfiguration or due to intentional features such
+            # as our COVID-19 minimum distance feature, things get ugly. Theoretically, there could be
+            # significant quota available but not a single seat! The waiting list would happily send out vouchers
+            # which do not work at all. Generally, we consider this a "known bug" and not fixable with the current
+            # design of the waiting list and seating features.
+            # However, we've put in a simple safeguard that makes sure the waiting list on its own does not screw
+            # everything up. Specifically, we will not send out vouchers if the number of available seats is less
+            # than the number of valid vouchers *issued through the waiting list*. Things can still go wrong due to
+            # manually created vouchers, manually blocked seats or the minimum distance feature,  but this reduces
+            # the possible damage a bit.
+            free_seats = ev.free_seats().filter(product=self.item).count() - (Voucher.objects.filter(
+                Q(valid_until__isnull=True) | Q(valid_until__gte=now()),
+                block_quota=True,
+                item_id=self.item_id,
+                subevent=self.subevent_id,
+                waitinglistentries__isnull=False
+            ).aggregate(free=Sum(F('max_usages') - F('redeemed')))['free'] or 0)
+            if not free_seats:
+                raise WaitingListException(_('No seat with this product is currently available.'))
+
         if self.voucher:
             raise WaitingListException(_('A voucher has already been sent to this person.'))
         if '@' not in self.email:

--- a/src/pretix/base/services/waitinglist.py
+++ b/src/pretix/base/services/waitinglist.py
@@ -28,7 +28,7 @@ from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
 from pretix.base.models import (
-    Event, SeatCategoryMapping, User, Voucher, WaitingListEntry,
+    Event, SeatCategoryMapping, User, WaitingListEntry,
 )
 from pretix.base.models.waitinglist import WaitingListException
 from pretix.base.services.tasks import EventTask
@@ -49,7 +49,7 @@ def assign_automatically(event: Event, user_id: int=None, subevent_id: int=None)
 
     for m in SeatCategoryMapping.objects.filter(event=event).select_related('subevent'):
         # See comment in WaitingListEntry.send_voucher() for rationale
-        free_seats = (m.subevent or event).free_seats().filter(product_id=m.product_id).count() - (Voucher.objects.filter(
+        free_seats = (m.subevent or event).free_seats().filter(product_id=m.product_id).count() - (event.vouchers.filter(
             Q(valid_until__isnull=True) | Q(valid_until__gte=now()),
             block_quota=True,
             item_id=m.product_id,

--- a/src/pretix/base/services/waitinglist.py
+++ b/src/pretix/base/services/waitinglist.py
@@ -53,7 +53,7 @@ def assign_automatically(event: Event, user_id: int=None, subevent_id: int=None)
             Q(valid_until__isnull=True) | Q(valid_until__gte=now()),
             block_quota=True,
             item_id=m.product_id,
-            subevent=m.subevent_id,
+            subevent_id=m.subevent_id,
             waitinglistentries__isnull=False
         ).aggregate(free=Sum(F('max_usages') - F('redeemed')))['free'] or 0)
         seats_available[(m.product_id, m.subevent_id)] = free_seats

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1746,6 +1746,12 @@ Please note that this link is only valid within the next {hours} hours!
 We will reassign the ticket to the next person on the list if you do not
 redeem the voucher within that timeframe.
 
+If you do NOT need a ticket any more, we kindly ask you to click the
+following link instead to let us know. This way, we can send the ticket
+to the next person waiting as quickly as possible:
+
+{url_remove}
+
 Best regards,
 Your {event} team"""))
     },

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1747,8 +1747,8 @@ We will reassign the ticket to the next person on the list if you do not
 redeem the voucher within that timeframe.
 
 If you do NOT need a ticket any more, we kindly ask you to click the
-following link instead to let us know. This way, we can send the ticket
-to the next person waiting as quickly as possible:
+following link to let us know. This way, we can send the ticket as quickly
+as possible to the next person on the waiting list:
 
 {url_remove}
 

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -256,8 +256,21 @@
                 <div class="alert alert-info">
                     {% blocktrans trimmed %}
                         The waiting list currently is not compatible with some advanced features of pretix such as
-                        seating plans, add-on products or product bundles.
+                        add-on products or product bundles.
                     {% endblocktrans %}
+                </div>
+                <div class="alert alert-info">
+                    {% blocktrans trimmed %}
+                        The waiting list determines availability mainly based on quotas. If you use a seating plan and your
+                        number of available seats is less than the available quota, you might run into situations where
+                        people are sent an email from the waiting list but still are unable to book a seat.
+                    {% endblocktrans %}
+                    <strong>
+                        {% blocktrans trimmed %}
+                            Specifically, this means the waiting list is not safe to use together with the minimum distance
+                            feature of our seating plan module.
+                        {% endblocktrans %}
+                    </strong>
                 </div>
                 {% bootstrap_field sform.waiting_list_enabled layout="control" %}
                 {% bootstrap_field sform.waiting_list_auto layout="control" %}

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -249,7 +249,7 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
                         waitinglistentries__isnull=False
                     ).aggregate(free=Sum(F('max_usages') - F('redeemed')))['free'] or 0)
                     wle.availability = (
-                        0 if free_seats == 0 else wle.availability[0],
+                        Quota.AVAILABILITY_GONE if free_seats == 0 else wle.availability[0],
                         min(free_seats, wle.availability[1])
                     )
 

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -239,7 +239,7 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
                         if wle.variation
                         else wle.item.check_quotas(count_waitinglist=False, subevent=wle.subevent, _cache=quota_cache)
                     )
-                if wle.availability[0] == 100 and ev.seat_category_mappings.filter(product=wle.item).exists():
+                if wle.availability[0] == Quota.AVAILABILITY_OK and ev.seat_category_mappings.filter(product=wle.item).exists():
                     # See comment in WaitingListEntry.send_voucher() for rationale
                     free_seats = ev.free_seats().filter(product=wle.item).count() - (self.request.event.vouchers.filter(
                         Q(valid_until__isnull=True) | Q(valid_until__gte=now()),

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -50,7 +50,7 @@ from django.views import View
 from django.views.generic import ListView
 from django.views.generic.edit import DeleteView
 
-from pretix.base.models import Item, Voucher, WaitingListEntry
+from pretix.base.models import Item, WaitingListEntry
 from pretix.base.models.waitinglist import WaitingListException
 from pretix.base.services.waitinglist import assign_automatically
 from pretix.base.views.tasks import AsyncAction
@@ -241,7 +241,7 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
                     )
                 if wle.availability[0] == 100 and ev.seat_category_mappings.filter(product=wle.item).exists():
                     # See comment in WaitingListEntry.send_voucher() for rationale
-                    free_seats = ev.free_seats().filter(product=wle.item).count() - (Voucher.objects.filter(
+                    free_seats = ev.free_seats().filter(product=wle.item).count() - (self.request.event.vouchers.filter(
                         Q(valid_until__isnull=True) | Q(valid_until__gte=now()),
                         block_quota=True,
                         item_id=wle.item_id,

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -254,7 +254,7 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
                     )
 
                 itemvar_cache[(wle.item, wle.variation, wle.subevent)] = wle.availability
-            if wle.availability[0] == 100:
+            if wle.availability[0] == Quota.AVAILABILITY_OK:
                 any_avail = True
 
         ctx['any_avail'] = any_avail

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -50,7 +50,7 @@ from django.views import View
 from django.views.generic import ListView
 from django.views.generic.edit import DeleteView
 
-from pretix.base.models import Item, WaitingListEntry, Quota
+from pretix.base.models import Item, Quota, WaitingListEntry
 from pretix.base.models.waitinglist import WaitingListException
 from pretix.base.services.waitinglist import assign_automatically
 from pretix.base.views.tasks import AsyncAction

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -211,6 +211,30 @@
                         {% eventsignal event "pretix.presale.signals.render_seating_plan" request=request %}
                     {% endif %}
                 {% endif %}
+
+                {% if waitinglist_seated %}
+                    <aside class="front-page" aria-labelledby="waiting-list">
+                        <h3 id="waiting-list">{% trans "Waiting list" %}</h3>
+                        <div class="row">
+                            <div class="col-md-8 col-sm-6 col-xs-12">
+                                <p>
+                                    {% blocktrans trimmed %}
+                                        Some of the categories in the seating plan above are currently sold out. If you want, you can add yourself to the
+                                        waiting list. We will then notify if seats are available again.
+                                    {% endblocktrans %}
+                                </p>
+                            </div>
+                            <div class="col-md-4 col-sm-6 col-xs-12">
+                                <a href="{% eventurl event "presale:event.waitinglist" cart_namespace=cart_namespace|default_if_none:"" %}{% if subevent %}?subevent={{ subevent.pk }}{% endif %}" class="btn btn-default btn-block">
+                                    <span class="fa fa-plus-circle" aria-hidden="true"></span>
+                                    {% trans "Waiting list" %}
+                                </a>
+                            </div>
+                            <div class="clearfix"></div>
+                        </div>
+                    </aside>
+                {% endif %}
+
                 {% include "pretixpresale/event/fragment_product_list.html" %}
                 {% if ev.presale_is_running and display_add_to_cart %}
                     <section class="front-page">

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -227,7 +227,7 @@
                             <div class="col-md-4 col-sm-6 col-xs-12">
                                 <a href="{% eventurl event "presale:event.waitinglist" cart_namespace=cart_namespace|default_if_none:"" %}{% if subevent %}?subevent={{ subevent.pk }}{% endif %}" class="btn btn-default btn-block">
                                     <span class="fa fa-plus-circle" aria-hidden="true"></span>
-                                    {% trans "Waiting list" %}
+                                    {% trans "Join waiting list" %}
                                 </a>
                             </div>
                             <div class="clearfix"></div>

--- a/src/pretix/presale/templates/pretixpresale/event/waitinglist.html
+++ b/src/pretix/presale/templates/pretixpresale/event/waitinglist.html
@@ -6,13 +6,6 @@
     <form action="" method="post">
         {% csrf_token %}
         <div class="form-horizontal">
-            <div class="form-group">
-                <label class="col-md-3 control-label" for="id_email">{% trans "Product" %}</label>
-                <div class="col-md-9">
-                    <input class="form-control" readonly="readonly"
-                           value="{{ item.name }}{% if variation %} – {{ variation.value }}{% endif %}">
-                </div>
-            </div>
             {% if subevent %}
                 <div class="form-group">
                     <label class="col-md-3 control-label" for="id_email">{% trans "Event" %}</label>

--- a/src/pretix/presale/templates/pretixpresale/event/waitinglist_remove.html
+++ b/src/pretix/presale/templates/pretixpresale/event/waitinglist_remove.html
@@ -1,0 +1,20 @@
+{% extends "pretixpresale/event/base.html" %}
+{% load i18n eventurl bootstrap3 %}
+{% block title %}{% trans "Waiting list" %}{% endblock %}
+{% block content %}
+    <h2>{% trans "Remove me from the waiting list" %}</h2>
+    <form action="" method="post">
+        {% csrf_token %}
+        <p>
+            {% blocktrans trimmed %}
+                You have been selected from our waiting list to buy a ticket. If you do not need the ticket any more, please be so kind and remove your ticket from the list
+                so we can pass it on to the next person waiting as quickly as possible!
+            {% endblocktrans %}
+        </p>
+        <p class="text-center">
+            <button type="submit" class="btn btn-danger btn-lg">
+                {% trans "Yes, remove my ticket" context "waitinglist" %}
+            </button>
+        </p>
+    </form>
+{% endblock %}

--- a/src/pretix/presale/urls.py
+++ b/src/pretix/presale/urls.py
@@ -68,6 +68,7 @@ frame_wrapped_urls = [
     re_path(r'^(?P<subevent>[0-9]+)/seatingframe/$', pretix.presale.views.event.SeatingPlanView.as_view(),
             name='event.seatingplan'),
     re_path(r'^(?P<subevent>[0-9]+)/$', pretix.presale.views.event.EventIndex.as_view(), name='event.index'),
+    re_path(r'^waitinglist/remove$', pretix.presale.views.waiting.WaitingRemoveView.as_view(), name='event.waitinglist.remove'),
     re_path(r'^waitinglist', pretix.presale.views.waiting.WaitingView.as_view(), name='event.waitinglist'),
     re_path(r'^$', pretix.presale.views.event.EventIndex.as_view(), name='event.index'),
 ]

--- a/src/pretix/presale/views/waiting.py
+++ b/src/pretix/presale/views/waiting.py
@@ -30,7 +30,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django.views.generic import FormView, TemplateView
 
-from pretix.base.models.event import SubEvent
+from pretix.base.models.event import Quota, SubEvent
 from pretix.base.templatetags.urlreplace import url_replace
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.presale.views import EventViewMixin

--- a/src/pretix/presale/views/waiting.py
+++ b/src/pretix/presale/views/waiting.py
@@ -30,7 +30,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django.views.generic import FormView, TemplateView
 
-from pretix.base.models.event import Quota, SubEvent
+from pretix.base.models import Quota, SubEvent
 from pretix.base.templatetags.urlreplace import url_replace
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.presale.views import EventViewMixin

--- a/src/pretix/presale/views/waiting.py
+++ b/src/pretix/presale/views/waiting.py
@@ -118,7 +118,7 @@ class WaitingView(EventViewMixin, FormView):
             if form.instance.variation
             else form.instance.item.check_quotas(count_waitinglist=True, subevent=self.subevent)
         )
-        if availability[0] == 100:
+        if availability[0] == Quota.AVAILABILITY_OK:
             messages.error(self.request, _("You cannot add yourself to the waiting list as this product is currently "
                                            "available."))
             return redirect(self.get_index_url())

--- a/src/tests/base/test_waitinglist.py
+++ b/src/tests/base/test_waitinglist.py
@@ -69,6 +69,25 @@ class WaitingListTestCase(TestCase):
             wle.send_voucher()
 
     @classscope(attr='o')
+    def test_send_no_seat(self):
+        self.quota.items.add(self.item1)
+        self.quota.size = 10
+        self.quota.save()
+        self.event.seat_category_mappings.create(
+            layout_category='Stalls', product=self.item1
+        )
+        self.event.seats.create(seat_number="Foo", product=self.item1, seat_guid="Foo", blocked=True)
+        self.event.seats.create(seat_number="Bar", product=self.item1, seat_guid="Bar", blocked=True)
+        self.event.seats.create(seat_number="Baz", product=self.item1, seat_guid="Baz", blocked=True)
+        wle = WaitingListEntry.objects.create(
+            event=self.event, item=self.item1, email='foo@bar.com'
+        )
+        with self.assertRaises(WaitingListException):
+            wle.send_voucher()
+        self.event.seats.create(seat_number="Baz", product=self.item1, seat_guid="Baz", blocked=False)
+        wle.send_voucher()
+
+    @classscope(attr='o')
     def test_send_double(self):
         self.quota.variations.add(self.var1)
         self.quota.size = 1

--- a/src/tests/presale/test_event.py
+++ b/src/tests/presale/test_event.py
@@ -960,7 +960,8 @@ class WaitingListTest(EventTestMixin, SoupTest):
         self.assertIn('waiting list', response.rendered_content)
         response = self.client.post(
             '/%s/%s/waitinglist/?item=%d' % (self.orga.slug, self.event.slug, self.item.pk), {
-                'email': 'foo@bar.com'
+                'email': 'foo@bar.com',
+                'itemvar': str(self.item.pk)
             }
         )
         self.assertEqual(response.status_code, 302)
@@ -989,7 +990,8 @@ class WaitingListTest(EventTestMixin, SoupTest):
         self.assertIn('waiting list', response.rendered_content)
         response = self.client.post(
             '/%s/%s/waitinglist/?item=%d&subevent=%d' % (self.orga.slug, self.event.slug, self.item.pk, se1.pk), {
-                'email': 'foo@bar.com'
+                'email': 'foo@bar.com',
+                'itemvar': str(self.item.pk)
             }
         )
         self.assertEqual(response.status_code, 302)
@@ -1000,10 +1002,14 @@ class WaitingListTest(EventTestMixin, SoupTest):
             assert wle.subevent == se1
 
     def test_invalid_item(self):
-        response = self.client.get(
-            '/%s/%s/waitinglist/?item=%d' % (self.orga.slug, self.event.slug, self.item.pk + 1)
+        response = self.client.post(
+            '/%s/%s/waitinglist/' % (self.orga.slug, self.event.slug),
+            {
+                'email': 'foo@bar.com',
+                'itemvar': str(self.item.pk + 1),
+            }
         )
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
 
     def test_invalid_subevent(self):
         self.event.has_subevents = True
@@ -1028,10 +1034,11 @@ class WaitingListTest(EventTestMixin, SoupTest):
         self.q.save()
         response = self.client.post(
             '/%s/%s/waitinglist/?item=%d' % (self.orga.slug, self.event.slug, self.item.pk), {
-                'email': 'foo@bar.com'
+                'email': 'foo@bar.com',
+                'itemvar': str(self.item.pk)
             }
         )
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
         with scopes_disabled():
             self.assertFalse(WaitingListEntry.objects.filter(email='foo@bar.com').exists())
 
@@ -1048,10 +1055,11 @@ class WaitingListTest(EventTestMixin, SoupTest):
             q2.items.add(self.item)
         response = self.client.post(
             '/%s/%s/waitinglist/?item=%d&subevent=%d' % (self.orga.slug, self.event.slug, self.item.pk, se1.pk), {
-                'email': 'foo@bar.com'
+                'email': 'foo@bar.com',
+                'itemvar': str(self.item.pk),
             }
         )
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
         with scopes_disabled():
             self.assertFalse(WaitingListEntry.objects.filter(email='foo@bar.com').exists())
 


### PR DESCRIPTION
This PR bundles three new features for the waiting list.

## 1. MVP for seating support

"Good" seating support for the waiting list is hard or impossible for a variety of reasons. For example, in a seated event people usually just want any seat, not just from a specific category, which is entirely incompatible with the way our waiting list mechanism works. Additionally, the waiting list is based on quotas, while seated events not necessarily are. The hardest problem though is probably the "minimum distance" feature because it makes it unpredictable "how much space" a single voucher will use.

However, there is a series of simple use cases where the minimum distance is not in use and it's feasible to focus on specific use cases, such as usage of pretix in public libraries. In these cases it's also possible to equate quota numbers with seat numbers.

Technically, the only thing missing for this feature was putting in a button that allows to register for the waiting list for a seated product. Everything else already worked. However, I've decided to also implement a safeguard that stops the waiting list at least in the most obvious cases of "you have quota left but no seats".

## 2. Rejection link

If someone is selected from the waiting list and does not want the ticket any more, they can now click a "reject" link, freeing up the ticket immediately and removing the need to wait for 48h.

## 3. Customer account detection

If you're logged in to a customer account, the email address field is now pre-filled with the known address.