### PR TITLE
Add new alert icons

### DIFF
--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -129,48 +129,40 @@ input[type=number]::-webkit-outer-spin-button {
   padding-left: 65px;
 
   &::before {
-    color: white;
+    content: "";
     position: absolute;
     display: block;
     left: 0;
     top: 0;
-    width: 50px;
-    padding-top: 13px;
-    text-align: center;
+    width: 51px;
     height: 100%;
-    font: normal normal normal 14px FontAwesome;
-    font-size: 24px;
-    text-rendering: auto; // optimizelegibility throws things off #1094
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    background-repeat: no-repeat;
+    background-position: 6px 6px;
+    background-size: 38px 38px;
   }
 }
 .sr-only.alert::before {
   background: none !important;
 }
 .alert-success::before {
-  background: $state-success-border;
-  content: "\f00c";
+  background-color: $state-success-border;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 36 36' xmlns='http://www.w3.org/2000/svg' xml:space='preserve'%3E%3Ccircle cx='18' cy='18' r='16' fill='%23fff'/%3E%3Cpath d='M25.57 14.65c0-.23-.1-.46-.26-.62l-1.24-1.24a.89.89 0 0 0-1.24 0l-5.98 6-2.68-2.7a.89.89 0 0 0-1.24 0l-1.24 1.24a.88.88 0 0 0 0 1.24l4.54 4.54a.88.88 0 0 0 1.24 0l7.84-7.84c.17-.16.26-.4.26-.62Z' fill='#{url-friendly-colour($state-success-text)}'/%3E%3C/svg%3E%0A");
 }
 .alert-info::before {
-  background: $state-info-border;
-  content: "\f129";
+  background-color: $state-info-border;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 36 36' xmlns='http://www.w3.org/2000/svg' xml:space='preserve'%3E%3Ccircle cx='18' cy='18' r='16' fill='%23fff'/%3E%3Cpath d='M21.74 22.66a.7.7 0 0 0-.7-.7h-.7v-6.28a.7.7 0 0 0-.7-.7h-4.19a.7.7 0 0 0-.7.7v1.4c0 .38.32.7.7.7h.7v4.19h-.7a.7.7 0 0 0-.7.7v1.4c0 .37.32.7.7.7h5.6a.7.7 0 0 0 .69-.7v-1.4Zm-1.4-12.57a.7.7 0 0 0-.7-.7h-2.8a.7.7 0 0 0-.69.7v2.1c0 .38.32.7.7.7h2.8a.7.7 0 0 0 .7-.7v-2.1Z' fill='#{url-friendly-colour($state-info-text)}'/%3E%3C/svg%3E%0A");
 }
 .alert-warning::before {
-  background: $state-warning-border;
-  content: "\f071";
-  font-size: 22px;
-  padding-top: 14px;
+  background-color: $state-warning-border;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 36 36' xmlns='http://www.w3.org/2000/svg' xml:space='preserve'%3E%3Cpath d='M20.04 2.89a2.2 2.2 0 0 0-3.87 0L2.88 27.24a2.22 2.22 0 0 0 1.94 3.27h26.57a2.22 2.22 0 0 0 1.94-3.27L20.04 2.89Z' fill='%23fff'/%3E%3Cpath d='M19.92 25.22c0 .26-.2.47-.45.47h-2.73a.46.46 0 0 1-.45-.47v-2.7c0-.25.2-.46.45-.46h2.73c.25 0 .45.21.45.47v2.7Zm-.02-5.31c-.02.19-.24.33-.5.33h-2.62c-.27 0-.48-.14-.48-.33l-.24-6.48c0-.09.04-.23.14-.3.09-.07.21-.16.34-.16h3.12c.13 0 .26.09.35.16.1.07.14.18.14.27l-.26 6.51Z' fill='#{url-friendly-colour($state-warning-text)}'/%3E%3C/svg%3E");
 }
 .alert-legal::before {
-  background: $state-info-border;
-  content: "\f0e3";
+  background-color: $state-info-border;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 36 36' xmlns='http://www.w3.org/2000/svg' xml:space='preserve'%3E%3Ccircle cx='18' cy='18' r='16' fill='%23fff'/%3E%3Cpath d='M19.41 11.55c0-.43.2-.79.58-1.08-.42-.27-.99-.4-1.7-.4-.62 0-1.1.13-1.46.4-.36.26-.54.62-.54 1.08 0 .42.13.76.38 1.01.18.15.5.33.95.57l1.77.85c1.04.48 1.79.9 2.25 1.25.51.36.88.8 1.1 1.3h-.02c.18.38.27.76.27 1.14 0 1.1-.62 2.18-1.85 3.22.48.46.81.9 1 1.3a3.84 3.84 0 0 1-.05 3.07c-.22.5-.54.91-.95 1.26-.42.34-.92.61-1.5.8a6.45 6.45 0 0 1-3.91 0 5.44 5.44 0 0 1-1.6-.79 3.67 3.67 0 0 1-1.1-1.22 3.11 3.11 0 0 1-.36-1.5c0-.66.17-1.2.52-1.59.36-.39.83-.59 1.42-.59.46 0 .87.16 1.22.48.36.32.53.7.53 1.16 0 .56-.33 1.03-1 1.41.03.05.07.1.13.13l.2.16a3.24 3.24 0 0 0 1.9.53c.67 0 1.2-.15 1.6-.46.38-.3.58-.7.58-1.22 0-.37-.13-.69-.38-.96a4.46 4.46 0 0 0-1.16-.82l-.9-.44A24.66 24.66 0 0 1 15 20.44a7.7 7.7 0 0 1-.9-.6c-.86-.73-1.29-1.54-1.29-2.45 0-1.16.62-2.23 1.87-3.22a4.7 4.7 0 0 1-.79-1.16 3.38 3.38 0 0 1 .95-3.98A5.02 5.02 0 0 1 18.14 8c1.3 0 2.37.3 3.21.91V8.9c.92.6 1.37 1.38 1.37 2.33 0 .51-.16.93-.49 1.27-.33.34-.75.5-1.26.5a1.6 1.6 0 0 1-1.12-.4c-.3-.28-.44-.62-.44-1.04Zm-1.27 4.66a26.2 26.2 0 0 1-1.73-.84c-.6.6-.89 1.13-.89 1.6 0 .34.13.63.39.87.17.15.42.31.74.5a30.57 30.57 0 0 0 1.93 1l.85.45c.58-.58.87-1.14.87-1.68 0-.36-.15-.67-.46-.94-.3-.27-.87-.6-1.7-.96Z' fill='#{url-friendly-colour($state-info-text)}'/%3E%3C/svg%3E");
 }
 .alert-danger::before {
-  background: $state-danger-border;
-  content: "\f071";
-  font-size: 22px;
-  padding-top: 14px;
+  background-color: $state-danger-border;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 36 36' xmlns='http://www.w3.org/2000/svg' xml:space='preserve'%3E%3Cpath d='M12.14 4.62h11.64l8.24 8.24V23.4l-8.24 8.24H12.14L3.9 23.39V12.86l8.24-8.24Z' fill='%23fff'/%3E%3Cpath d='M24.74 22.6c0-.28-.11-.56-.31-.76l-3.27-3.27 3.27-3.27a1.08 1.08 0 0 0 0-1.52l-1.51-1.5a1.08 1.08 0 0 0-1.52 0l-3.27 3.26-3.27-3.27a1.08 1.08 0 0 0-1.52 0l-1.5 1.51a1.08 1.08 0 0 0 0 1.52l3.26 3.27-3.27 3.27a1.08 1.08 0 0 0 0 1.52l1.51 1.51a1.08 1.08 0 0 0 1.52 0l3.27-3.27 3.27 3.27a1.08 1.08 0 0 0 1.52 0l1.51-1.51c.2-.2.31-.48.31-.76Z' fill='#{url-friendly-colour($state-danger-text)}'/%3E%3C/svg%3E%0A");
 }
 .alert-primary::before {
   background: $brand-primary !important;

--- a/src/pretix/static/pretixbase/scss/_variables.scss
+++ b/src/pretix/static/pretixbase/scss/_variables.scss
@@ -6,6 +6,10 @@
   @return mix(black, $color, $percentage);
 }
 
+@function url-friendly-colour($colour) {
+    @return '%23' + str-slice('#{$colour}', 2, -1)
+}
+
 $gray-darker: lighten(#000, 13.5%);
 $gray-dark: lighten(#000, 20%);
 $gray: lighten(#000, 33.5%);


### PR DESCRIPTION
As a pre-step for the A11y-branch to improve the contrast for the alert-warning icon, this PR adds a new set of icons that enables to isolate the actual icon from its base-form and color it with a higher contrast to meet minimum A11y requirements. By using SASS-variables, the coloring should automatically adapt to the improvements added in https://github.com/pretix/pretix/pull/2081