### PR TITLE
[WIP] Stick add-to-cart button to the bottom of form

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -172,6 +172,12 @@ article.item-with-variations:last-child, .product-row:last-child {
 }
 section.front-page {
     margin-top: 30px;
+    position: sticky;
+    bottom: 0;
+    top: 100px;
+    padding: 10px 0;
+    background: rgba(255,255,255,.8);
+    z-index: 10;
 }
 .offline-banner {
     background: $brand-danger;


### PR DESCRIPTION
This PR is simply here to test what a sticky add-to-cart button would look like as suggested in #1128. Sticking the button to the bottom of the screen and contain it inside the product-listing form sounds like a possible solution for long forms with lots of products, but IMHO it does not work well – IMHO it actually confuses even more as the add-to-cart button is visible all the time, even if e.g. the first product is sold out. The button isn’t even clickable as it is currently disabled (see #2210). Furthermore it could overlay the next product, so users might think they are done and there are not more products to explore.

![Bildschirmfoto 2021-10-04 um 10 56 53](https://user-images.githubusercontent.com/276509/135823146-a18314c0-22a2-4a83-a0ce-930315624d3e.png)

![Bildschirmfoto 2021-10-04 um 10 57 10](https://user-images.githubusercontent.com/276509/135823171-45a95f9a-801e-4e49-8ddf-1b065f3aaa7d.png)

So generally the sticky-approach has the problem of communicating to the user, that there are/might be additional products/tickets to explore. I think if we really need to make the product-listing/cart-page easier to understand, I think we should explore something different.