### PR TITLE
Fix Outlook >= 2010 trimming header image

### DIFF
--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -113,10 +113,6 @@
             font-size: 12px;
         }
 
-        .content {
-            padding: 0 18px;
-        }
-
         ::selection {
             background: {{ color }};
             color: #FFF;
@@ -150,7 +146,7 @@
         table.layout > tr > td.containertd,
         table.layout > tbody > tr > td.containertd,
         table.layout > thead > tr > td.containertd {
-            padding: 15px 0;
+            padding: 20px;
         }
 
         a.button {

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -36,7 +36,6 @@
         table.layout > tr > td.logo,
         table.layout > tbody > tr > td.logo,
         table.layout > thead > tr > td.logo {
-            border-top: 20px solid #eeeeee;/* change body.padding to border-top  */
             padding: {% if event.settings.logo_image_large %}0 0 0 0{% else %}20px 0 0 0{% endif %};
             line-height: 0;
         }
@@ -44,9 +43,6 @@
         table.layout > tr > td.header,
         table.layout > tbody > tr > td.header,
         table.layout > thead > tr > td.header {
-            {% if not event.settings.logo_image %}
-            border-top: 20px solid #eeeeee;/* change body.padding to border-top  */
-            {% endif %}
             padding: 0 20px;
             text-align: center;
         }
@@ -219,8 +215,8 @@
     <![endif]-->
 </head>
 <body align="center">
+    <table width="100%"><tr><td align="center" style="padding: 20px">
     <!--[if gte mso 9]>
-    <table width="100%"><tr><td align="center">
     <table width="600"><tr><td align="center"
     <![endif]-->
     <table class="layout" style="max-width:600px" border="0" cellspacing="0">
@@ -308,7 +304,7 @@
     <br/>
     <!--[if gte mso 9]>
     </td></tr></table>
-    </td></tr></table>
     <![endif]-->
+    </td></tr></table>
 </body>
 </html>

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -37,7 +37,7 @@
         table.layout > tbody > tr > td.logo,
         table.layout > thead > tr > td.logo {
             padding: {% if event.settings.logo_image_large %}0 0 0 0{% else %}20px 0 0 0{% endif %};
-            line-height: 0;
+            mso-line-height-rule: at-least;
         }
 
         table.layout > tr > td.header,

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -164,7 +164,8 @@
         }
 
         .order-button {
-            padding-top: 5px
+            padding-top: 5px;
+            text-align: center;
         }
         .order-button a.button {
             font-size: 12px;

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -233,9 +233,6 @@
         {% endif %}
         <tr>
             <td class="header" align="center">
-                <!--[if gte mso 9]>
-                    <table cellpadding="20"><tr><td align="center">
-                <![endif]-->
                 {% if event %}
                     <h2><a href="{% abseventurl event "presale:event.index" %}" target="_blank">{{ event.name }}</a>
                     </h2>
@@ -248,51 +245,30 @@
                 {% block header %}
                     <h1>{{ subject }}</h1>
                 {% endblock %}
-                <!--[if gte mso 9]>
-                    </td></tr></table>
-                <![endif]-->
             </td>
         </tr>
         <tr>
             <td class="containertd">
-                <!--[if gte mso 9]>
-                        <table cellpadding="20"><tr><td>
-                    <![endif]-->
                 <div class="content">
                     {{ body|safe }}
                 </div>
-                <!--[if gte mso 9]>
-                        </td></tr></table>
-                    <![endif]-->
             </td>
         </tr>
         {% if order %}
             <tr>
                 <td class="order containertd">
-                    <!--[if gte mso 9]>
-                        <table cellpadding="20"><tr><td>
-                    <![endif]-->
                     <div class="content">
                         {% include "pretixbase/email/order_details.html" %}
                     </div>
-                    <!--[if gte mso 9]>
-                        </td></tr></table>
-                    <![endif]-->
                 </td>
             </tr>
         {% endif %}
         {% if signature %}
             <tr>
                 <td class="order containertd">
-                    <!--[if gte mso 9]>
-                        <table cellpadding="20"><tr><td>
-                    <![endif]-->
                     <div class="content">
                         {{ signature | safe }}
                     </div>
-                    <!--[if gte mso 9]>
-                        </td></tr></table>
-                    <![endif]-->
                 </td>
             </tr>
         {% endif %}

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -14,16 +14,17 @@
 </o:OfficeDocumentSettings>
 </xml><![endif]-->
     <style type="text/css">
-        body {
+        body, .container {
             background-color: #eee;
-            background-position: top;
-            background-repeat: repeat-x;
             font-family: "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-size: 16px;
             line-height: 1.4;
             color: #333;
             margin: 0;
             padding: 0;
+        }
+        .container {
+            padding: 20px;
         }
 
         table.layout > tr > td,
@@ -212,9 +213,9 @@
     <![endif]-->
 </head>
 <body align="center">
-    <table width="100%"><tr><td align="center" style="padding: 20px">
+    <table width="100%"><tr><td align="center" class="container">
     <!--[if gte mso 9]>
-    <table width="600"><tr><td align="center"
+    <table width="600"><tr><td align="center">
     <![endif]-->
     <table class="layout" style="max-width:600px" border="0" cellspacing="0">
         {% if event.settings.logo_image %}

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -23,7 +23,7 @@
             line-height: 1.4;
             color: #333;
             margin: 0;
-            padding-top: 20px;
+            padding: 0;
         }
 
         table.layout > tr > td,
@@ -36,12 +36,17 @@
         table.layout > tr > td.logo,
         table.layout > tbody > tr > td.logo,
         table.layout > thead > tr > td.logo {
-            padding: 20px 0 0 0;
+            border-top: 20px solid #eeeeee;/* change body.padding to border-top  */
+            padding: {% if event.settings.logo_image_large %}0 0 0 0{% else %}20px 0 0 0{% endif %};
+            line-height: 0;
         }
 
         table.layout > tr > td.header,
         table.layout > tbody > tr > td.header,
         table.layout > thead > tr > td.header {
+            {% if not event.settings.logo_image %}
+            border-top: 20px solid #eeeeee;/* change body.padding to border-top  */
+            {% endif %}
             padding: 0 20px;
             text-align: center;
         }
@@ -221,7 +226,7 @@
     <table class="layout" style="max-width:600px" border="0" cellspacing="0">
         {% if event.settings.logo_image %}
             <tr>
-                <td style="line-height: 0; {% if event.settings.logo_image_large %}padding: 0;{% endif %}" align="center" class="logo">
+                <td align="center" class="logo">
                     {% if event.settings.logo_image_large %}
                         <img src="{% if event.settings.logo_image|thumb:'600_x5000'|first == '/' %}{{ site_url }}{% endif %}{{ event.settings.logo_image|thumb:'600_x5000' }}" alt="{{ event.name }}" style="width:100%" />
                     {% else %}


### PR DESCRIPTION
Outlook 2010/2013 cut off header images. I guess it is due to some issue with dynamic sizing the image and line-height and maybe even mso-line-height-rule.

This PR got a bit bigger as it improved and simplified the HTML-newsletter-template.

Among the improvements are:

- align text to the left; fully centered text is hard to read
- remove mso cellpadding-tables as they double up the spacing
- additionally add background-color to a table with width=100% for broader support (e.g. Yahoo and AOL)