### PR TITLE
Increase padding if background color is set

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -40,7 +40,6 @@
 }
 
 .page-header.logo-large {
-  margin: 0 -15px;
 
   img {
     width: 100%;
@@ -62,6 +61,11 @@ h2.content-header {
 }
 
 @media (max-width: $screen-xs-max) {
+  .page-header.logo-large {
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-top: 0;
+  }
   h2.content-header small {
     display: block;
   }
@@ -76,8 +80,10 @@ h2.content-header {
     }
   }
   .page-header-links-outside {
-    padding-left: 0;
-    padding-right: 0;
+    @if ($body-bg != #FFFFFF) {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
   .page-header-links > div.header-part {
     @if ($body-bg != #FFFFFF) {
@@ -87,10 +93,11 @@ h2.content-header {
   }
 
   .page-header.logo-large {
+    margin-top: 0;
+
     @if ($body-bg != #FFFFFF) {
       margin-left: -25px;
       margin-right: -25px;
-      padding-bottom: 25px;
     }
 
     img {

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -70,6 +70,8 @@ h2.content-header {
   .main-box {
     @if ($body-bg != #FFFFFF) {
       margin: 20px auto;
+      padding-left: 25px;
+      padding-right: 25px;
       border-radius: $border-radius-large;
     }
   }
@@ -85,6 +87,12 @@ h2.content-header {
   }
 
   .page-header.logo-large {
+    @if ($body-bg != #FFFFFF) {
+      margin-left: -25px;
+      margin-right: -25px;
+      padding-bottom: 25px;
+    }
+
     img {
       @if ($body-bg != #FFFFFF) {
         border-top-right-radius: $border-radius-large;
@@ -92,7 +100,14 @@ h2.content-header {
       }
     }
   }
+
   .page-header .loginbox {
     padding-top: 0;
+  }
+}
+
+footer {
+  @if ($body-bg != #FFFFFF) {
+    padding-bottom: 0;
   }
 }


### PR DESCRIPTION
Open questions:

- Is 25 a good value? Our paddings are usually 15px or 30px, but 30px looked to much.

- Previously, the container width for content was constant for every desktop screen size. Now it will be inconsistent between ticket shops which *could* make it harder to work on future layout stuff. Possible courses of action:
	1. Accept that fact
	2. Increase the padding regardless of background color, making shops on white background narrower as well
	3. Increase container width

I think (iii) is too hard since that would require messing up bootstrap's breakpoints which could have all sorts of unintended consequences. (ii) is interesting since white background is no longer the default or preferred option anyways, however it's a waste of space in some cases and it might look weird depending on header styling. so just (i)?

cc @wiffbi 