### PR TITLE
Setup: Allow django-hijack v2.2

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -177,7 +177,7 @@ setup(
         'django-formset-js-improved==0.5.0.2',
         'django-formtools==2.3',
         'django-hierarkey==1.0.*,>=1.0.4',
-        'django-hijack>=2.1.10,<2.3.0',
+        'django-hijack>=2.2.0,<2.3.0',
         'django-i18nfield==1.9.*,>=1.9.3',
         'django-libsass==0.9',
         'django-localflavor>=3.0,<3.2',

--- a/src/setup.py
+++ b/src/setup.py
@@ -177,7 +177,7 @@ setup(
         'django-formset-js-improved==0.5.0.2',
         'django-formtools==2.3',
         'django-hierarkey==1.0.*,>=1.0.4',
-        'django-hijack>=2.1.10,<2.2.0',
+        'django-hijack>=2.1.10,<2.3.0',
         'django-i18nfield==1.9.*,>=1.9.3',
         'django-libsass==0.9',
         'django-localflavor>=3.0,<3.2',


### PR DESCRIPTION
Latest macOS throws an error on setup with django-hijack==2.1.10, allow 2.2.x