### PR TITLE
CSP: Strip keys with empty values from header

### DIFF
--- a/src/pretix/base/middleware.py
+++ b/src/pretix/base/middleware.py
@@ -208,7 +208,7 @@ def _parse_csp(header):
 
 
 def _render_csp(h):
-    return "; ".join(k + ' ' + ' '.join(v) for k, v in h.items())
+    return "; ".join(k + ' ' + ' '.join(v) for k, v in h.items() if v)
 
 
 def _merge_csp(a, b):


### PR DESCRIPTION
When adding/merging domains for CSP-header it could happen that empty lists were added, which resulted in faulty CSP-Headers which resulted in an exception when parsing such a CSP-header.