### PR TITLE
Day calendar: Fix missing current-time-bar back for all browsers

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -516,9 +516,8 @@ $(function () {
     $(".day-calendar").each(function() {
         var s = window.getComputedStyle($(".day-timeline > li").get(0));
 
-        if (s.getPropertyValue('grid-column-start') != "auto") return;
-        // Fix Chrome not being able to use calc-division in grid
-        $(".day-calendar").each(function() {
+        if (s.getPropertyValue('grid-column-start') == "auto") {
+            // Fix Chrome not being able to use calc-division in grid
             var rasterSize = this.getAttribute("data-raster-size");
             var duration = this.getAttribute("data-duration").split(":");
             var cols = duration[0]*60/rasterSize + duration[1]/rasterSize;
@@ -535,7 +534,7 @@ $(function () {
                 var columnSpan = duration[0]*60/rasterSize + duration[1]/rasterSize
                 this.style.gridColumn = columnStart + " / span " + columnSpan;
             });
-        });
+        }
 
         var timezone = this.getAttribute("data-timezone");
         var startTime = moment.tz(this.getAttribute("data-start"), timezone);

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -513,28 +513,31 @@ $(function () {
         var c = parseInt(this.getAttribute("data-concurrency"), 10);
         if (c > 9) this.style.setProperty('--concurrency', c);
     });
+
     $(".day-calendar").each(function() {
+        // Fix Chrome not being able to use calc-division in grid
         var s = window.getComputedStyle($(".day-timeline > li").get(0));
+        if (s.getPropertyValue('grid-column-start') != "auto") return;
 
-        if (s.getPropertyValue('grid-column-start') == "auto") {
-            // Fix Chrome not being able to use calc-division in grid
-            var rasterSize = this.getAttribute("data-raster-size");
+        var rasterSize = this.getAttribute("data-raster-size");
+        var duration = this.getAttribute("data-duration").split(":");
+        var cols = duration[0]*60/rasterSize + duration[1]/rasterSize;
+
+        $(".day-timeline", this).css("grid-template-columns", "repeat(" + cols + ", minmax(var(--col-min-size, 3em), 1fr))");
+
+        $(".day-timeline > li", this).each(function() {
+            var s = window.getComputedStyle(this);
+
+            var offset = this.getAttribute("data-offset").split(":");
             var duration = this.getAttribute("data-duration").split(":");
-            var cols = duration[0]*60/rasterSize + duration[1]/rasterSize;
 
-            $(".day-timeline", this).css("grid-template-columns", "repeat(" + cols + ", minmax(var(--col-min-size, 3em), 1fr))");
+            var columnStart = 1 + offset[0]*60/rasterSize + offset[1]/rasterSize;
+            var columnSpan = duration[0]*60/rasterSize + duration[1]/rasterSize
+            this.style.gridColumn = columnStart + " / span " + columnSpan;
+        });
+    });
 
-            $(".day-timeline > li", this).each(function() {
-                var s = window.getComputedStyle(this);
-
-                var offset = this.getAttribute("data-offset").split(":");
-                var duration = this.getAttribute("data-duration").split(":");
-
-                var columnStart = 1 + offset[0]*60/rasterSize + offset[1]/rasterSize;
-                var columnSpan = duration[0]*60/rasterSize + duration[1]/rasterSize
-                this.style.gridColumn = columnStart + " / span " + columnSpan;
-            });
-        }
+    $(".day-calendar").each(function() {
 
         var timezone = this.getAttribute("data-timezone");
         var startTime = moment.tz(this.getAttribute("data-start"), timezone);


### PR DESCRIPTION
The recent fix for Chrome broke the current-time-bar for all browsers that support CSS-calc-division in CSS-grid.