### PR TITLE
Fix #2363 – Email: change text-alignment from center to left (right for rtl)

### DIFF
--- a/src/pretix/base/templates/pretixbase/email/base.html
+++ b/src/pretix/base/templates/pretixbase/email/base.html
@@ -116,6 +116,9 @@
             width: 100%;
             height: auto;
         }
+        .content {
+            text-align: left;
+        }
 
         .content table {
             width: 100%;
@@ -142,7 +145,8 @@
         }
 
         .order-button {
-            padding-top: 5px
+            padding-top: 5px;
+            text-align: center;
         }
         .order-button a.button {
             font-size: 12px;
@@ -173,7 +177,7 @@
             body {
                 direction: rtl;
             }
-            .content table td {
+            .content {
                 text-align: right;
             }
         {% endif %}

--- a/src/pretix/base/templates/pretixbase/email/base.html
+++ b/src/pretix/base/templates/pretixbase/email/base.html
@@ -85,9 +85,6 @@
             -webkit-hyphens: auto;
             hyphens: auto;
         }
-        p:last-child {
-            margin-bottom: 0;
-        }
 
         .footer {
             padding: 10px;

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -104,9 +104,6 @@
             -webkit-hyphens: auto;
             hyphens: auto;
         }
-        p:last-child {
-            margin-bottom: 0;
-        }
 
         .footer {
             padding: 10px;

--- a/src/pretix/base/templates/pretixbase/email/simple_logo.html
+++ b/src/pretix/base/templates/pretixbase/email/simple_logo.html
@@ -136,6 +136,10 @@
             display: block;
         }
 
+        .content {
+            text-align: left;
+        }
+
         .content table {
             width: 100%;
         }
@@ -197,7 +201,7 @@
             body {
                 direction: rtl;
             }
-            .content table td {
+            .content {
                 text-align: right;
             }
         {% endif %}


### PR DESCRIPTION
This PR also removes the `p:last-child` margin-bottom: 0; rule – which interestingly did not have any effect as the CSS-inliner somehow mixed up specifity and first inlined margin-bottom:0; from `p:last-child`, but then inlined `margin: 0 0 10px;` from `p`

Closes #2363 