### PR TITLE
Organizer: improve calender navigation on organizer page (Z#177488)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
@@ -3,41 +3,38 @@
 {% load urlreplace %}
 <nav aria-label="{% trans "calendar navigation" %}">
     <ul class="row calendar-nav">
-        <li class="col-sm-4 hidden-xs text-left flip">
-            <a href="?{% url_replace request "year" subevent_list.before.year "month" subevent_list.before.month %}"
+        <li class="col-sm-4 col-xs-2 text-left flip">
+            <a href="?{% url_replace request "date" subevent_list.before|date:"Y-m" %}"
                     class="btn btn-default" aria-label="{% blocktrans with month=subevent_list.before|date:"F Y" %}Show previous month, {{ month }}{% endblocktrans %}">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                {{ subevent_list.before|date:"F Y" }}
+                <span class="hidden-xs">{{ subevent_list.before|date:"F Y" }}</span>
             </a>
         </li>
-        <li class="col-sm-4 col-xs-12 text-center">
+        <li class="col-sm-4 col-xs-8 text-center">
             <form class="form-inline" method="get" id="monthselform" action="{% eventurl event "presale:event.index" cart_namespace=cart_namespace %}">
                 {% for f, v in request.GET.items %}
-                    {% if f != "month" and f != "year" %}
+                    {% if f != "date" %}
                         <input type="hidden" name="{{ f }}" value="{{ v }}">
                     {% endif %}
                 {% endfor %}
-                <div role="group" aria-label="{% trans "Select month and year to show" %}">
-                    <select name="month" class="form-control" aria-label="{% trans "Month" %}">
-                        {% for m in subevent_list.months %}
-                            <option value="{{ m|date:"m" }}" {% if m.month == subevent_list.date.month %}selected{% endif %}>{{ m|date:"F" }}</option>
-                        {% endfor %}
-                    </select>
-                    <select name="year" class="form-control" aria-label="{% trans "Year" %}">
-                        {% for y in subevent_list.years %}
-                            <option value="{{ y }}" {% if y == subevent_list.date.year %}selected{% endif %}>{{ y }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
+                <select name="date" class="form-control" aria-label="{% trans "Select month to show" %}">
+                {% for y in subevent_list.years %}
+                    <optgroup label="{{ y }}">
+                    {% for m in subevent_list.months %}
+                        <option value="{{ y }}-{{ m|date:"m" }}" {% if m.month == subevent_list.date.month and y == subevent_list.date.year %}selected{% endif %}>{{ m|date:"F" }} {{ y }}</option>
+                    {% endfor %}
+                    </optgroup>
+                {% endfor %}
+                </select>
                 <button type="submit" class="js-hidden btn btn-default">
                     {% trans "Go" %}
                 </button>
             </form>
         </li>
-        <li class="col-sm-4 hidden-xs text-right flip">
-            <a href="?{% url_replace request "year" subevent_list.after.year "month" subevent_list.after.month %}"
+        <li class="col-sm-4 col-xs-2 text-right flip">
+            <a href="?{% url_replace request "date" subevent_list.after|date:"Y-m" %}"
                 class="btn btn-default" aria-label="{% blocktrans with month=subevent_list.after|date:"F Y" %}Show next month, {{ month }}{% endblocktrans %}">
-                {{ subevent_list.after|date:"F Y" }}
+                <span class="hidden-xs">{{ subevent_list.after|date:"F Y" }}</span>
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>
             </a>
         </li>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -3,54 +3,55 @@
 {% load urlreplace %}
 <nav aria-label="{% trans "calendar navigation" %}">
     <ul class="row calendar-nav">
-        <li class="col-sm-4 hidden-xs text-left flip">
-            <a href="?{% url_replace request "year" subevent_list.before.isocalendar.0 "week" subevent_list.before.isocalendar.1 %}"
+        <li class="col-sm-4 col-xs-2 text-left flip">
+            <a href="?{% url_replace request "date" subevent_list.before|date:"o-\WW" %}"
                 class="btn btn-default" aria-label="{% blocktrans with week=subevent_list.before|date:subevent_list.week_format %}Show previous week, {{ week }}{% endblocktrans %}">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                {{ subevent_list.before|date:subevent_list.week_format }}
+                <span class="hidden-xs">{{ subevent_list.before|date:subevent_list.week_format }}</span>
             </a>
         </li>
-        <li class="col-sm-4 col-xs-12 text-center">
+        <li class="col-sm-4 col-xs-8 text-center">
             <form class="form-inline" method="get" id="monthselform" action="{% eventurl event "presale:event.index" cart_namespace=cart_namespace %}">
             {% for f, v in request.GET.items %}
-                {% if f != "week" and f != "year" %}
+                {% if f != "date" %}
                     <input type="hidden" name="{{ f }}" value="{{ v }}">
                 {% endif %}
             {% endfor %}
-                <div role="group" aria-label="{% trans "Select week and year to show" %}">
-                    <select name="week" class="form-control select-calendar-week-short" aria-label="{% trans "Week" %}">
-                        {% for w in subevent_list.weeks %}
-                            <option value="{{ w.0.isocalendar.1 }}" {% if w.0.isocalendar.1 == subevent_list.date.isocalendar.1 %}selected{% endif %}>{% trans "W" %} {{ w.0.isocalendar.1 }} ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{ w.1|date:"SHORT_DATE_FORMAT" }})</option>
-                        {% endfor %}
-                    </select>
-                    <select name="year" class="form-control" aria-label="{% trans "Year" %}">
-                        {% for y in subevent_list.years %}
-                            <option value="{{ y }}" {% if y == subevent_list.date.isocalendar.0 %}selected{% endif %}>{{ y }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
+                <select name="date" class="form-control" aria-label="{% trans "Select week to show" %}">
+                {% for weeks_per_year in subevent_list.weeks %}
+                    <optgroup label="{{ weeks_per_year.0.0.year }}">
+                    {% for w in weeks_per_year %}
+                        <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
+                                {% if w.0.isocalendar.0 == subevent_list.date.isocalendar.0 and w.0.isocalendar.1 == subevent_list.date.isocalendar.1 %}selected{% endif %}>
+                                {{ w.0|date:"WEEK_FORMAT" }}
+                            ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{ w.1|date:"SHORT_DATE_FORMAT" }})
+                        </option>
+                    {% endfor %}
+                    </optgroup>
+                {% endfor %}
+                </select>
                 <button type="submit" class="js-hidden btn btn-default">
                     {% trans "Go" %}
                 </button>
             </form>
         </li>
-        <li class="col-sm-4 hidden-xs text-right flip">
-            <a href="?{% url_replace request "year" subevent_list.after.isocalendar.0 "week" subevent_list.after.isocalendar.1 %}"
+        <li class="col-sm-4 col-xs-2 text-right flip">
+            <a href="?{% url_replace request "date" subevent_list.after|date:"o-\WW" %}"
                 class="btn btn-default" aria-label="{% blocktrans with week=subevent_list.after|date:subevent_list.week_format %}Show next week, {{ week }}{% endblocktrans %}">
-                {{ subevent_list.after|date:subevent_list.week_format }}
+                <span class="hidden-xs">{{ subevent_list.after|date:subevent_list.week_format }}</span>
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>
             </a>
         </li>
     </ul>
 </nav>
 {% include "pretixpresale/fragment_week_calendar.html" with show_avail=event.settings.event_list_availability days=subevent_list.days show_names=subevent_list.show_names %}
-<div class="col-sm-4 visible-xs text-center" aria-hidden="true">
-    <a href="?{% url_replace request "year" subevent_list.before.isocalendar.0 "week" subevent_list.before.isocalendar.1 %}"
+<div class="visible-xs text-center" aria-hidden="true">
+    <a href="?{% url_replace request "date" subevent_list.before|date:"o-\WW" %}"
             class="btn btn-default">
         <span class="fa fa-arrow-left" aria-hidden="true"></span>
         {{ subevent_list.before|date:subevent_list.week_format }}
     </a>
-    <a href="?{% url_replace request "year" subevent_list.after.isocalendar.0 "week" subevent_list.after.isocalendar.1 %}"
+    <a href="?{% url_replace request "date" subevent_list.after|date:"o-\WW" %}"
             class="btn btn-default">
         {{ subevent_list.after|date:subevent_list.week_format }}
         <span class="fa fa-arrow-right" aria-hidden="true"></span>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -24,7 +24,7 @@
                         <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
                                 {% if w.0.isocalendar.0 == subevent_list.date.isocalendar.0 and w.0.isocalendar.1 == subevent_list.date.isocalendar.1 %}selected{% endif %}>
                                 {{ w.0|date:"WEEK_FORMAT" }}
-                            ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{ w.1|date:"SHORT_DATE_FORMAT" }})
+                            ({{ w.0|date:"MONTH_DAY_FORMAT" }} – {{ w.1|date:"MONTH_DAY_FORMAT" }})
                         </option>
                     {% endfor %}
                     </optgroup>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
@@ -5,7 +5,6 @@
 <div class="btn-group" role="group">
     <a href="?{% url_replace request "style" "list" "date" "" %}" type="button" 
             class="btn btn-default{% if style == "list" %} active{% endif %}">
-        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
         {% trans "List" %}
     </a>
     <a href="?{% url_replace request "style" "week" "old" "" "page" "" "date" date|date:"Y-\WW" %}" type="button"

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
@@ -7,16 +7,16 @@
             class="btn btn-default{% if style == "list" %} active{% endif %}">
         {% trans "List" %}
     </a>
-    <a href="?{% url_replace request "style" "week" "old" "" "page" "" "date" date|date:"o-\WW" %}" type="button"
+    <a href="?{% if "date" in request.GET %}{% url_replace request "style" "week" "old" "" "page" "" "date" date|date:"o-\WW" %}{% else %}{% url_replace request "style" "week" "old" "" "page" "" %}{% endif %}" type="button"
             class="btn btn-default{% if style == "week" %} active{% endif %}">
         {% trans "Week" %}
     </a>
-    <a href="?{% url_replace request "style" "calendar" "old" "" "page" "" "date"  date|date:"Y-m" %}"
+    <a href="?{% if "date" in request.GET %}{% url_replace request "style" "calendar" "old" "" "page" "" "date" date|date:"Y-m" %}{% else %}{% url_replace request "style" "calendar" "old" "" "page" "" %}{% endif %}"
             type="button"
             class="btn btn-default{% if style == "calendar" %} active{% endif %}">
         {% trans "Month" %}
     </a>
-    <a href="?{% url_replace request "style" "day" "old" "" "page" ""  "date"  date|date:"Y-m-d" %}" type="button"
+    <a href="?{% if "date" in request.GET %}{% url_replace request "style" "day" "old" "" "page" ""  "date" date|date:"Y-m-d" %}{% else %}{% url_replace request "style" "day" "old" "" "page" ""  "date" %}{% endif %}" type="button"
        class="btn btn-default{% if style == "day" %} active{% endif %}">
         {% trans "Day" %}
     </a>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
@@ -7,7 +7,7 @@
             class="btn btn-default{% if style == "list" %} active{% endif %}">
         {% trans "List" %}
     </a>
-    <a href="?{% url_replace request "style" "week" "old" "" "page" "" "date" date|date:"Y-\WW" %}" type="button"
+    <a href="?{% url_replace request "style" "week" "old" "" "page" "" "date" date|date:"o-\WW" %}" type="button"
             class="btn btn-default{% if style == "week" %} active{% endif %}">
         {% trans "Week" %}
     </a>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar_nav.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+{% load eventurl %}
+{% load urlreplace %}
+
+<div class="btn-group" role="group">
+    <a href="?{% url_replace request "style" "list" "date" "" %}" type="button" 
+            class="btn btn-default{% if style == "list" %} active{% endif %}">
+        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
+        {% trans "List" %}
+    </a>
+    <a href="?{% url_replace request "style" "week" "old" "" "page" "" "date" date|date:"Y-\WW" %}" type="button"
+            class="btn btn-default{% if style == "week" %} active{% endif %}">
+        {% trans "Week" %}
+    </a>
+    <a href="?{% url_replace request "style" "calendar" "old" "" "page" "" "date"  date|date:"Y-m" %}"
+            type="button"
+            class="btn btn-default{% if style == "calendar" %} active{% endif %}">
+        {% trans "Month" %}
+    </a>
+    <a href="?{% url_replace request "style" "day" "old" "" "page" ""  "date"  date|date:"Y-m-d" %}" type="button"
+       class="btn btn-default{% if style == "day" %} active{% endif %}">
+        {% trans "Day" %}
+    </a>
+</div>
+<a href="{% eventurl request.organizer "presale:organizer.ical" %}?{% url_replace request "locale" request.LANGUAGE_CODE "page" "" "old" "" "style" "" "date" "" %}"
+        class="btn btn-default">
+    <span class="fa fa-calendar-plus-o" aria-hidden="true"></span>
+    {% trans "iCal" %}
+</a>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -19,30 +19,7 @@
         {% endfor %}
         <div class="row">
             <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
-                <div class="btn-group" role="group">
-                    <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" "" "date" "" %}" type="button" class="btn btn-default">
-                        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
-                        {% trans "List" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "week" "old" "" "month" "" "year" "" "date" "" %}" type="button"
-                            class="btn btn-default">
-                        {% trans "Week" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "calendar" "old" "" "week" "" "date" "" %}"
-                            type="button"
-                            class="btn btn-default active">
-                        {% trans "Month" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
-                       class="btn btn-default">
-                        {% trans "Day" %}
-                    </a>
-                </div>
-                <a href="{% eventurl request.organizer "presale:organizer.ical" %}?{% url_replace request "locale" request.LANGUAGE_CODE "page" "" "old" "" "week" "" "style" "" "month" "" "year" "" %}"
-                        class="btn btn-default">
-                    <span class="fa fa-calendar-plus-o" aria-hidden="true"></span>
-                    {% trans "iCal" %}
-                </a>
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
             </div>
             <div class="col-md-4 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month to show" %}">
                 <select name="date" class="form-control" aria-label="{% trans "Month" %}">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -19,7 +19,7 @@
         {% endfor %}
         <div class="row">
             <div class="col-md-5 col-sm-6 col-xs-12 text-left flip">
-                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="calendar" %}
             </div>
             <div class="col-md-2 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month to show" %}">
                 <select name="date" class="form-control" aria-label="{% trans "Month" %}">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -13,7 +13,7 @@
     <h3>{{ date|date:"F Y" }}</h3>
     <form class="form-inline" method="get" id="monthselform" action="{% eventurl request.organizer "presale:organizer.index" %}">
         {% for f, v in request.GET.items %}
-            {% if f != "month" and f != "year" %}
+            {% if f != "month" and f != "year" and f != "date" %}
                 <input type="hidden" name="{{ f }}" value="{{ v }}">
             {% endif %}
         {% endfor %}
@@ -44,16 +44,15 @@
                     {% trans "iCal" %}
                 </a>
             </div>
-            <div class="col-md-4 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month and year to show" %}">
-                <select name="month" class="form-control" aria-label="{% trans "Month" %}">
+            <div class="col-md-4 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month to show" %}">
+                <select name="date" class="form-control" aria-label="{% trans "Month" %}">
+                {% for y in years %}
+                    <optgroup label="{{ y }}">
                     {% for m in months %}
-                        <option value="{{ m|date:"m" }}" {% if m == date %}selected{% endif %}>{{ m|date:"F" }}</option>
+                        <option value="{{ y }}-{{ m|date:"m" }}" {% if m.month == date.month and y == date.year %}selected{% endif %}>{{ m|date:"F" }} {{ y }}</option>
                     {% endfor %}
-                </select>
-                <select name="year" class="form-control" aria-label="{% trans "Year" %}">
-                    {% for y in years %}
-                        <option value="{{ y }}" {% if y == date.year %}selected{% endif %}>{{ y }}</option>
-                    {% endfor %}
+                    </optgroup>
+                {% endfor %}
                 </select>
                 <button type="submit" class="js-hidden btn btn-default">
                     {% trans "Go" %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -13,7 +13,7 @@
     <h3>{{ date|date:"F Y" }}</h3>
     <form class="form-inline" method="get" id="monthselform" action="{% eventurl request.organizer "presale:organizer.index" %}">
         {% for f, v in request.GET.items %}
-            {% if f != "month" and f != "year" and f != "date" %}
+            {% if f != "date" %}
                 <input type="hidden" name="{{ f }}" value="{{ v }}">
             {% endif %}
         {% endfor %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -18,10 +18,10 @@
             {% endif %}
         {% endfor %}
         <div class="row">
-            <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
+            <div class="col-md-5 col-sm-6 col-xs-12 text-left flip">
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
             </div>
-            <div class="col-md-4 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month to show" %}">
+            <div class="col-md-2 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month to show" %}">
                 <select name="date" class="form-control" aria-label="{% trans "Month" %}">
                 {% for y in years %}
                     <optgroup label="{{ y }}">
@@ -35,7 +35,7 @@
                     {% trans "Go" %}
                 </button>
             </div>
-            <div class="col-md-4 hidden-sm hidden-xs text-right flip">
+            <div class="col-md-5 hidden-sm hidden-xs text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before|date:"Y-m" %}" class="btn btn-default">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -21,7 +21,7 @@
             <div class="col-md-5 col-sm-6 col-xs-12 text-left flip">
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="calendar" %}
             </div>
-            <div class="col-md-2 col-sm-6 col-xs-12 text-center" role="group" aria-label="{% trans "Select month to show" %}">
+            <div class="col-md-2 col-sm-4 col-xs-8 text-center" role="group" aria-label="{% trans "Select month to show" %}">
                 <select name="date" class="form-control" aria-label="{% trans "Month" %}">
                 {% for y in years %}
                     <optgroup label="{{ y }}">
@@ -35,17 +35,19 @@
                     {% trans "Go" %}
                 </button>
             </div>
-            <div class="col-md-5 hidden-sm hidden-xs text-right flip">
+            <div class="col-md-5 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
-                    <a href="?{% url_replace request "date" before|date:"Y-m" %}" class="btn btn-default">
+                    <a href="?{% url_replace request "date" before|date:"Y-m" %}"
+                       class="btn btn-default" aria-label="{{ before|date:"F Y" }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                        {{ before|date:"F Y" }}
+                        <span class="hidden-sm hidden-xs">{{ before|date:"F Y" }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
-                    <a href="?{% url_replace request "date" after|date:"Y-m" %}" class="btn btn-default">
+                    <a href="?{% url_replace request "date" after|date:"Y-m" %}"
+                       class="btn btn-default" aria-label="{{ after|date:"F Y" }}">
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
-                        {{ after|date:"F Y" }}
+                        <span class="hidden-sm hidden-xs">{{ after|date:"F Y" }}</span>
                     </a>
                 {% endif %}
             </div>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -60,13 +60,13 @@
             </div>
             <div class="col-md-4 hidden-sm hidden-xs text-right flip">
                 {% if has_before %}
-                    <a href="?{% url_replace request "year" before.year "month" before.month %}" class="btn btn-default">
+                    <a href="?{% url_replace request "date" before|date:"Y-m" %}" class="btn btn-default">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
                         {{ before|date:"F Y" }}
                     </a>
                 {% endif %}
                 {% if has_after %}
-                    <a href="?{% url_replace request "year" after.year "month" after.month %}" class="btn btn-default">
+                    <a href="?{% url_replace request "date" after|date:"Y-m" %}" class="btn btn-default">
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                         {{ after|date:"F Y" }}
                     </a>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -21,23 +21,20 @@
             <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
                 <div class="btn-group" role="group">
                     <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" "" "date" "" %}" type="button" class="btn btn-default">
-                        <span class="fa fa-list" aria-hidden="true"></span>
+                        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
                         {% trans "List" %}
                     </a>
                     <a href="?{% url_replace request "style" "week" "old" "" "month" "" "year" "" "date" "" %}" type="button"
                             class="btn btn-default">
-                        <span class="fa fa-calendar" aria-hidden="true"></span>
                         {% trans "Week" %}
                     </a>
                     <a href="?{% url_replace request "style" "calendar" "old" "" "week" "" "date" "" %}"
                             type="button"
                             class="btn btn-default active">
-                        <span class="fa fa-calendar" aria-hidden="true"></span>
                         {% trans "Month" %}
                     </a>
                     <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
                        class="btn btn-default">
-                        <span class="fa fa-th" aria-hidden="true"></span>
                         {% trans "Day" %}
                     </a>
                 </div>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -22,24 +22,24 @@
             <div class="col-md-5 col-sm-6 col-xs-12 text-left flip">
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="day" %}
             </div>
-            <div class="col-md-2 col-sm-4 col-xs-12 text-center">
+            <div class="col-md-2 col-sm-4 col-xs-8 text-center">
                 <input class="datepickerfield form-control" value="{{ date|date:"SHORT_DATE_FORMAT" }}" name="date">
                 <button type="submit" class="js-hidden btn btn-default">
                     {% trans "Go" %}
                 </button>
             </div>
-            <div class="col-md-5 col-sm-2 hidden-xs text-right flip">
+            <div class="col-md-5 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before.date.isoformat %}"
                        class="btn btn-default" aria-label="{{ before|date:"SHORT_DATE_FORMAT" }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                        <span class="hidden-sm">{{ before|date:"SHORT_DATE_FORMAT" }}</span>
+                        <span class="hidden-sm hidden-xs">{{ before|date:"SHORT_DATE_FORMAT" }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
                     <a href="?{% url_replace request "date" after.date.isoformat %}"
                        class="btn btn-default" aria-label="{{ after|date:"SHORT_DATE_FORMAT" }}">
-                        <span class="hidden-sm">{{ after|date:"SHORT_DATE_FORMAT" }}</span>
+                        <span class="hidden-sm hidden-xs">{{ after|date:"SHORT_DATE_FORMAT" }}</span>
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                     </a>
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -20,31 +20,7 @@
         {% endfor %}
         <div class="row">
             <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
-                <div class="btn-group" role="group">
-                    <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" "" "date" "" %}" type="button"
-                       class="btn btn-default">
-                        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
-                        {% trans "List" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "week" "month" "" "old" "" "date" "" %}" type="button"
-                       class="btn btn-default">
-                        {% trans "Week" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "calendar" "week" "" "old" "" "year" "" "date" "" %}"
-                       type="button"
-                       class="btn btn-default">
-                        {% trans "Month" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
-                       class="btn btn-default active">
-                        {% trans "Day" %}
-                    </a>
-                </div>
-                <a href="{% eventurl request.organizer "presale:organizer.ical" %}?{% url_replace request "locale" request.LANGUAGE_CODE "page" "" "old" "" "week" "" "style" "" "month" "" "year" "" "date" "" %}"
-                   class="btn btn-default">
-                    <span class="fa fa-calendar-plus-o" aria-hidden="true"></span>
-                    {% trans "iCal" %}
-                </a>
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
             </div>
             <div class="col-sm-4 col-xs-12 text-center">
                 <input class="datepickerfield form-control" value="{{ date|date:"SHORT_DATE_FORMAT" }}" name="date">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -20,7 +20,7 @@
         {% endfor %}
         <div class="row">
             <div class="col-md-5 col-sm-6 col-xs-12 text-left flip">
-                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="day" %}
             </div>
             <div class="col-md-2 col-sm-4 col-xs-12 text-center">
                 <input class="datepickerfield form-control" value="{{ date|date:"SHORT_DATE_FORMAT" }}" name="date">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -19,27 +19,24 @@
             {% endif %}
         {% endfor %}
         <div class="row">
-            <div class="col-sm-4 hidden-xs text-left flip">
+            <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
                 <div class="btn-group" role="group">
                     <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" "" "date" "" %}" type="button"
                        class="btn btn-default">
-                        <span class="fa fa-list" aria-hidden="true"></span>
+                        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
                         {% trans "List" %}
                     </a>
                     <a href="?{% url_replace request "style" "week" "month" "" "old" "" "date" "" %}" type="button"
                        class="btn btn-default">
-                        <span class="fa fa-calendar" aria-hidden="true"></span>
                         {% trans "Week" %}
                     </a>
                     <a href="?{% url_replace request "style" "calendar" "week" "" "old" "" "year" "" "date" "" %}"
                        type="button"
                        class="btn btn-default">
-                        <span class="fa fa-calendar" aria-hidden="true"></span>
                         {% trans "Month" %}
                     </a>
                     <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
                        class="btn btn-default active">
-                        <span class="fa fa-th" aria-hidden="true"></span>
                         {% trans "Day" %}
                     </a>
                 </div>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -19,27 +19,27 @@
             {% endif %}
         {% endfor %}
         <div class="row">
-            <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
+            <div class="col-md-5 col-sm-6 col-xs-12 text-left flip">
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
             </div>
-            <div class="col-sm-4 col-xs-12 text-center">
+            <div class="col-md-2 col-sm-4 col-xs-12 text-center">
                 <input class="datepickerfield form-control" value="{{ date|date:"SHORT_DATE_FORMAT" }}" name="date">
                 <button type="submit" class="js-hidden btn btn-default">
                     {% trans "Go" %}
                 </button>
             </div>
-            <div class="col-sm-4 hidden-xs text-right flip">
+            <div class="col-md-5 col-sm-2 hidden-xs text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before.date.isoformat %}"
-                       class="btn btn-default">
+                       class="btn btn-default" aria-label="{{ before|date:"SHORT_DATE_FORMAT" }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                        {{ before|date:"SHORT_DATE_FORMAT" }}
+                        <span class="hidden-sm">{{ before|date:"SHORT_DATE_FORMAT" }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
                     <a href="?{% url_replace request "date" after.date.isoformat %}"
-                       class="btn btn-default">
-                        {{ after|date:"SHORT_DATE_FORMAT" }}
+                       class="btn btn-default" aria-label="{{ after|date:"SHORT_DATE_FORMAT" }}">
+                        <span class="hidden-sm">{{ after|date:"SHORT_DATE_FORMAT" }}</span>
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                     </a>
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -20,7 +20,7 @@
         {% endfor %}
         <div class="row">
             <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
-                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="week" %}
             </div>
             <div class="col-md-4 col-sm-6 col-xs-12 text-center">
                 <select name="date" class="form-control">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -42,14 +42,14 @@
             </div>
             <div class="col-md-4 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
-                    <a href="?{% url_replace request "date" before|date:"Y-\WW" %}"
+                    <a href="?{% url_replace request "date" before|date:"o-\WW" %}"
                        class="btn btn-default" aria-label="{{ before|date:week_format }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
                         <span class="hidden-sm hidden-xs">{{ before|date:week_format }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
-                    <a href="?{% url_replace request "date" after|date:"Y-\WW" %}"
+                    <a href="?{% url_replace request "date" after|date:"o-\WW" %}"
                        class="btn btn-default" aria-label="{{ after|date:week_format }}">
                         <span class="hidden-sm hidden-xs">{{ after|date:week_format }}</span>
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
@@ -61,14 +61,14 @@
     {% include "pretixpresale/fragment_week_calendar.html" with show_avail=request.organizer.settings.event_list_availability %}
     <div class="col-sm-12 visible-sm visible-xs text-center">
         {% if has_before %}
-            <a href="?{% url_replace request "date" before|date:"Y-\WW" %}"
+            <a href="?{% url_replace request "date" before|date:"o-\WW" %}"
                class="btn btn-default">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
                 {{ before|date:week_format }}
             </a>
         {% endif %}
         {% if has_after %}
-            <a href="?{% url_replace request "date" after|date:"Y-\WW" %}"
+            <a href="?{% url_replace request "date" after|date:"o-\WW" %}"
                class="btn btn-default">
                 {{ after|date:week_format }}
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -14,7 +14,7 @@
     <form class="form-inline" method="get" id="monthselform"
           action="{% eventurl request.organizer "presale:organizer.index" %}">
         {% for f, v in request.GET.items %}
-            {% if f != "week" and f != "year" %}
+            {% if f != "date" %}
                 <input type="hidden" name="{{ f }}" value="{{ v }}">
             {% endif %}
         {% endfor %}
@@ -23,18 +23,18 @@
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
             </div>
             <div class="col-md-4 col-sm-6 col-xs-12 text-center">
-                <select name="week" class="form-control select-calendar-week-short">
-                    {% for w in weeks %}
-                        <option value="{{ w.0.isocalendar.1 }}"
-                                {% if w.0.isocalendar.1 == date.isocalendar.1 %}selected{% endif %}>{% trans "W" %} {{ w.0.isocalendar.1 }}
+                <select name="date" class="form-control">
+                {% for weeks_per_year in weeks %}
+                    <optgroup label="{{ weeks_per_year.0.0.year }}">
+                    {% for w in weeks_per_year %}
+                        <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
+                                {% if w.0.isocalendar.0 == date.isocalendar.0 and w.0.isocalendar.1 == date.isocalendar.1 %}selected{% endif %}>
+                                {{ w.0|date:"WEEK_FORMAT" }}
                             ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{ w.1|date:"SHORT_DATE_FORMAT" }})
                         </option>
                     {% endfor %}
-                </select>
-                <select name="year" class="form-control">
-                    {% for y in years %}
-                        <option value="{{ y }}" {% if y == date.isocalendar.0 %}selected{% endif %}>{{ y }}</option>
-                    {% endfor %}
+                    </optgroup>
+                {% endfor %}
                 </select>
                 <button type="submit" class="js-hidden btn btn-default">
                     {% trans "Go" %}
@@ -42,14 +42,14 @@
             </div>
             <div class="col-md-4 hidden-sm hidden-xs text-right flip">
                 {% if has_before %}
-                    <a href="?{% url_replace request "year" before.isocalendar.0 "week" before.isocalendar.1 %}"
+                    <a href="?{% url_replace request "date" before|date:"Y-\WW" %}"
                        class="btn btn-default">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
                         {{ before|date:week_format }}
                     </a>
                 {% endif %}
                 {% if has_after %}
-                    <a href="?{% url_replace request "year" after.isocalendar.0 "week" after.isocalendar.1 %}"
+                    <a href="?{% url_replace request "date" after|date:"Y-\WW" %}"
                        class="btn btn-default">
                         {{ after|date:week_format }}
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -23,23 +23,20 @@
                 <div class="btn-group" role="group">
                     <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" "" "date" "" %}" type="button"
                        class="btn btn-default">
-                        <span class="fa fa-list" aria-hidden="true"></span>
+                        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
                         {% trans "List" %}
                     </a>
                     <a href="?{% url_replace request "style" "week" "month" "" "old" "" "date" "" %}" type="button"
                        class="btn btn-default active">
-                        <span class="fa fa-calendar" aria-hidden="true"></span>
                         {% trans "Week" %}
                     </a>
                     <a href="?{% url_replace request "style" "calendar" "week" "" "old" "" "year" "" "date" "" %}"
                        type="button"
                        class="btn btn-default">
-                        <span class="fa fa-calendar" aria-hidden="true"></span>
                         {% trans "Month" %}
                     </a>
                     <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
                        class="btn btn-default">
-                        <span class="fa fa-th" aria-hidden="true"></span>
                         {% trans "Day" %}
                     </a>
                 </div>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -22,7 +22,7 @@
             <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="week" %}
             </div>
-            <div class="col-md-4 col-sm-6 col-xs-12 text-center">
+            <div class="col-md-4 col-sm-4 col-xs-8 text-center">
                 <select name="date" class="form-control">
                 {% for weeks_per_year in weeks %}
                     <optgroup label="{{ weeks_per_year.0.0.year }}">
@@ -40,18 +40,18 @@
                     {% trans "Go" %}
                 </button>
             </div>
-            <div class="col-md-4 hidden-sm hidden-xs text-right flip">
+            <div class="col-md-4 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before|date:"Y-\WW" %}"
-                       class="btn btn-default">
+                       class="btn btn-default" aria-label="{{ before|date:week_format }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                        {{ before|date:week_format }}
+                        <span class="hidden-sm hidden-xs">{{ before|date:week_format }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
                     <a href="?{% url_replace request "date" after|date:"Y-\WW" %}"
-                       class="btn btn-default">
-                        {{ after|date:week_format }}
+                       class="btn btn-default" aria-label="{{ after|date:week_format }}">
+                        <span class="hidden-sm hidden-xs">{{ after|date:week_format }}</span>
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                     </a>
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -20,31 +20,7 @@
         {% endfor %}
         <div class="row">
             <div class="col-md-4 col-sm-6 col-xs-12 text-left flip">
-                <div class="btn-group" role="group">
-                    <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" "" "date" "" %}" type="button"
-                       class="btn btn-default">
-                        <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
-                        {% trans "List" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "week" "month" "" "old" "" "date" "" %}" type="button"
-                       class="btn btn-default active">
-                        {% trans "Week" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "calendar" "week" "" "old" "" "year" "" "date" "" %}"
-                       type="button"
-                       class="btn btn-default">
-                        {% trans "Month" %}
-                    </a>
-                    <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
-                       class="btn btn-default">
-                        {% trans "Day" %}
-                    </a>
-                </div>
-                <a href="{% eventurl request.organizer "presale:organizer.ical" %}?{% url_replace request "locale" request.LANGUAGE_CODE "page" "" "old" "" "week" "" "style" "" "month" "" "year" "" %}"
-                   class="btn btn-default">
-                    <span class="fa fa-calendar-plus-o" aria-hidden="true"></span>
-                    {% trans "iCal" %}
-                </a>
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style=request.GET.style|default_if_none:"list" %}
             </div>
             <div class="col-md-4 col-sm-6 col-xs-12 text-center">
                 <select name="week" class="form-control select-calendar-week-short">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -23,7 +23,7 @@
                 {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="week" %}
             </div>
             <div class="col-md-4 col-sm-4 col-xs-8 text-center">
-                <select name="date" class="form-control">
+                <select name="date" class="form-control" aria-label="{% trans "Select week to show" %}">
                 {% for weeks_per_year in weeks %}
                     <optgroup label="{{ weeks_per_year.0.0.year }}">
                     {% for w in weeks_per_year %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -59,16 +59,16 @@
         </div>
     </form>
     {% include "pretixpresale/fragment_week_calendar.html" with show_avail=request.organizer.settings.event_list_availability %}
-    <div class="col-sm-4 visible-xs text-center">
+    <div class="col-sm-12 visible-sm visible-xs text-center">
         {% if has_before %}
-            <a href="?{% url_replace request "year" before.isocalendar.0 "week" before.isocalendar.1 %}"
+            <a href="?{% url_replace request "date" before|date:"Y-\WW" %}"
                class="btn btn-default">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
                 {{ before|date:week_format }}
             </a>
         {% endif %}
         {% if has_after %}
-            <a href="?{% url_replace request "year" after.isocalendar.0 "week" after.isocalendar.1 %}"
+            <a href="?{% url_replace request "date" after|date:"Y-\WW" %}"
                class="btn btn-default">
                 {{ after|date:week_format }}
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -30,7 +30,7 @@
                         <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
                                 {% if w.0.isocalendar.0 == date.isocalendar.0 and w.0.isocalendar.1 == date.isocalendar.1 %}selected{% endif %}>
                                 {{ w.0|date:"WEEK_FORMAT" }}
-                            ({{ w.0|date:"SHORT_DATE_FORMAT" }} – {{ w.1|date:"SHORT_DATE_FORMAT" }})
+                            ({{ w.0|date:"MONTH_DAY_FORMAT" }} – {{ w.1|date:"MONTH_DAY_FORMAT" }})
                         </option>
                     {% endfor %}
                     </optgroup>

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -26,9 +26,14 @@
     {% else %}
         <h3>{% trans "Upcoming events" %}</h3>
     {% endif %}
-    <div>
-        {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="list" %}
+    <div id="monthselform">
+        <div class="row">
+            <div class="col-md-12">
+                {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="list" %}
+            </div>
+        </div>
     </div>
+    {% if events %}
     <div class="event-list">
         <div class="row hidden-xs hidden-sm">
             <div class="col-md-5">
@@ -113,17 +118,13 @@
                     </a>
                 </div>
             </div>
-        {% empty %}
-            {% if "old" in request.GET %}
-                <div class="col-md-12">
-                    <p><em>{% trans "No archived events found." %} <a href="?{% url_replace request "old" "" %}">{% trans "Show upcoming" %}</a></em></p>
-                </div>
-            {% else %}
-                <div class="col-md-12">
-                    <p><em>{% trans "No public upcoming events found." %} <a href="?{% url_replace request "old" "1" %}">{% trans "Show past events" %}</a></em></p>
-                </div>
-            {% endif %}
         {% endfor %}
     </div>
+    {% endif %}
+    {% if "old" in request.GET %}
+        <p><em>{% if not events %}{% trans "No archived events found." %} {% endif %}<a href="?{% url_replace request "old" "" %}">{% trans "Show upcoming" %}</a></em></p>
+    {% else %}
+        <p><em>{% if not events %}{% trans "No public upcoming events found." %} {% endif %}<a href="?{% url_replace request "old" "1" %}">{% trans "Show past events" %}</a></em></p>
+    {% endif %}
     {% include "pretixpresale/pagination.html" %}
 {% endblock %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -30,22 +30,19 @@
         <div class="btn-group" role="group">
             <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" ""  "date" ""%}" type="button"
                     class="btn btn-default active">
-                <span class="fa fa-list" aria-hidden="true"></span>
+                <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
                 {% trans "List" %}
             </a>
             <a href="?{% url_replace request "style" "week" "month" "" "old" "" "page" "" "date" "" %}" type="button"
                     class="btn btn-default">
-                <span class="fa fa-calendar" aria-hidden="true"></span>
                 {% trans "Week" %}
             </a>
             <a href="?{% url_replace request "style" "calendar" "week" "" "old" "" "page" "" "date" "" %}" type="button"
                     class="btn btn-default">
-                <span class="fa fa-calendar" aria-hidden="true"></span>
                 {% trans "Month" %}
             </a>
             <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
                class="btn btn-default">
-                <span class="fa fa-th" aria-hidden="true"></span>
                 {% trans "Day" %}
             </a>
         </div>

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -27,30 +27,7 @@
         <h3>{% trans "Upcoming events" %}</h3>
     {% endif %}
     <div>
-        <div class="btn-group" role="group">
-            <a href="?{% url_replace request "style" "list" "week" "" "year" "" "month" ""  "date" ""%}" type="button"
-                    class="btn btn-default active">
-                <span class="fa fa-list hidden-xs" aria-hidden="true"></span>
-                {% trans "List" %}
-            </a>
-            <a href="?{% url_replace request "style" "week" "month" "" "old" "" "page" "" "date" "" %}" type="button"
-                    class="btn btn-default">
-                {% trans "Week" %}
-            </a>
-            <a href="?{% url_replace request "style" "calendar" "week" "" "old" "" "page" "" "date" "" %}" type="button"
-                    class="btn btn-default">
-                {% trans "Month" %}
-            </a>
-            <a href="?{% url_replace request "style" "day" "week" "" "month" "" "old" "" "page" "" %}" type="button"
-               class="btn btn-default">
-                {% trans "Day" %}
-            </a>
-        </div>
-        <a href="{% eventurl request.organizer "presale:organizer.ical" %}?{% url_replace request "locale" request.LANGUAGE_CODE "page" "" "old" "" "week" "" "style" "" "month" "" "year" "" %}"
-                class="btn btn-default">
-            <span class="fa fa-calendar-plus-o" aria-hidden="true"></span>
-            {% trans "iCal" %}
-        </a>
+        {% include "pretixpresale/fragment_calendar_nav.html" with date=date request=request style="list" %}
     </div>
     <div class="event-list">
         <div class="row hidden-xs hidden-sm">

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -51,11 +51,6 @@
             <span class="fa fa-calendar-plus-o" aria-hidden="true"></span>
             {% trans "iCal" %}
         </a>
-        {% if "old" in request.GET %}
-            <a href="?{% url_replace request "old" "" %}" class="btn btn-link">{% trans "Show upcoming" %}</a>
-        {% else %}
-            <a href="?{% url_replace request "old" "1" %}" class="btn btn-link">{% trans "Show past events" %}</a>
-        {% endif %}
     </div>
     <div class="event-list">
         <div class="row hidden-xs hidden-sm">
@@ -144,11 +139,11 @@
         {% empty %}
             {% if "old" in request.GET %}
                 <div class="col-md-12">
-                    <em>{% trans "No archived events found." %}</em>
+                    <p><em>{% trans "No archived events found." %} <a href="?{% url_replace request "old" "" %}">{% trans "Show upcoming" %}</a></em></p>
                 </div>
             {% else %}
                 <div class="col-md-12">
-                    <em>{% trans "No public upcoming events found." %}</em>
+                    <p><em>{% trans "No public upcoming events found." %} <a href="?{% url_replace request "old" "1" %}">{% trans "Show past events" %}</a></em></p>
                 </div>
             {% endif %}
         {% endfor %}

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -37,7 +37,7 @@ import math
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 from functools import reduce
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 import dateutil
 import isoweek
@@ -47,6 +47,7 @@ from django.core.cache import caches
 from django.db.models import Exists, Max, Min, OuterRef, Q
 from django.db.models.functions import Coalesce, Greatest
 from django.http import Http404, HttpResponse
+from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.formats import date_format, get_format
 from django.utils.timezone import get_current_timezone, now
@@ -609,6 +610,11 @@ class CalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
         self._set_month_year()
+        keys = ("month", "year")
+        if all(k in request.GET for k in keys):
+            get_params = {k: v for k, v in request.GET.items() if k not in keys}
+            get_params["date"] = "%s-%s" % (self.year, self.month)
+            return redirect(self.request.path + "?" + urlencode(get_params))
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -727,10 +727,14 @@ class WeekCalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
         )
 
         ctx['days'] = days_for_template(ebd, week)
-        ctx['weeks'] = [
-            (date_fromisocalendar(self.year, i + 1, 1), date_fromisocalendar(self.year, i + 1, 7))
-            for i in range(53 if date(self.year, 12, 31).isocalendar()[1] == 53 else 52)
-        ]
+        years = (self.year-1, self.year, self.year+1)
+        weeks = []
+        for year in years:
+            weeks += [
+                (date_fromisocalendar(year, i + 1, 1), date_fromisocalendar(year, i + 1, 7))
+                for i in range(53 if date(year, 12, 31).isocalendar()[1] == 53 else 52)
+            ]
+        ctx['weeks'] = [[w for w in weeks if w[0].year == year] for year in years]
         ctx['years'] = range(now().year - 2, now().year + 3)
         ctx['week_format'] = get_format('WEEK_FORMAT')
         if ctx['week_format'] == 'WEEK_FORMAT':

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -231,6 +231,14 @@ class EventListMixin:
             except ValueError:
                 self.year = now().year
                 self.month = now().month
+        elif 'date' in self.request.GET:
+            self.tz = self.request.organizer.timezone
+            try:
+                date = dateutil.parser.parse(self.request.GET.get('date')).date()
+            except ValueError:
+                date = now().astimezone(self.tz).date()
+            self.year = date.year
+            self.month = date.month
         else:
             if hasattr(self.request, 'event'):
                 self._set_month_to_next_subevent()

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -610,6 +610,7 @@ class CalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
         self._set_month_year()
+        # redirect old month-year-URLs to new date-URLs
         keys = ("month", "year")
         if all(k in request.GET for k in keys):
             get_params = {k: v for k, v in request.GET.items() if k not in keys}

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -727,7 +727,7 @@ class WeekCalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
         )
 
         ctx['days'] = days_for_template(ebd, week)
-        years = (self.year-1, self.year, self.year+1)
+        years = (self.year - 1, self.year, self.year + 1)
         weeks = []
         for year in years:
             weeks += [

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -713,7 +713,6 @@ class WeekCalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
                 for i in range(53 if date(year, 12, 31).isocalendar()[1] == 53 else 52)
             ]
         ctx['weeks'] = [[w for w in weeks if w[0].year == year] for year in years]
-        ctx['years'] = range(now().year - 2, now().year + 3)
         ctx['week_format'] = get_format('WEEK_FORMAT')
         if ctx['week_format'] == 'WEEK_FORMAT':
             ctx['week_format'] = WEEK_FORMAT

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -667,7 +667,7 @@ class WeekCalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
         keys = ("week", "year")
         if all(k in request.GET for k in keys):
             get_params = {k: v for k, v in request.GET.items() if k not in keys}
-            get_params["date"] = "%s-W%02d" % (request.GET.get("year"), request.GET.get("week"))
+            get_params["date"] = "%s-W%s" % (request.GET.get("year"), request.GET.get("week"))
             return redirect(self.request.path + "?" + urlencode(get_params))
 
         self._set_week_year()

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -22,6 +22,10 @@ td > .form-group > .checkbox {
   padding-top: 7px;
 }
 
+.form-inline .form-control {
+  max-width: 100%;
+}
+
 .has-success .form-control {
   border-color: #cccccc;
 }

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -33,6 +33,10 @@ a.btn, button.btn {
   margin-right: 10px;
 }
 
+.form-inline .form-control {
+  max-width: 100%;
+}
+
 .form-control.is-focused {
   $color-rgba: rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
   border-color: $input-border-focus;

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -396,7 +396,7 @@ h2 .label {
 }
 
 .event-list {
-    margin-top: 15px;
+    margin-bottom: 15px;
     border-top: 1px solid $table-border-color;
 
     .row {

--- a/src/tests/presale/test_event.py
+++ b/src/tests/presale/test_event.py
@@ -314,7 +314,7 @@ class ItemDisplayTest(EventTestMixin, SoupTest):
         resp = self.client.get('/%s/%s/' % (self.orga.slug, self.event.slug))
         self.assertIn("Foo SE2", resp.rendered_content)
         self.assertNotIn("Foo SE1", resp.rendered_content)
-        resp = self.client.get('/%s/%s/?year=%d&month=%d' % (self.orga.slug, self.event.slug, se1.date_from.year,
+        resp = self.client.get('/%s/%s/?date=%d-%d' % (self.orga.slug, self.event.slug, se1.date_from.year,
                                                              se1.date_from.month))
         self.assertIn("Foo SE1", resp.rendered_content)
         self.assertNotIn("Foo SE2", resp.rendered_content)
@@ -332,7 +332,7 @@ class ItemDisplayTest(EventTestMixin, SoupTest):
         print(resp.rendered_content)
         self.assertIn("Foo SE2", resp.rendered_content)
         self.assertNotIn("Foo SE1", resp.rendered_content)
-        resp = self.client.get('/%s/%s/?year=%d&week=%d' % (self.orga.slug, self.event.slug,
+        resp = self.client.get('/%s/%s/?date=%d-W%d' % (self.orga.slug, self.event.slug,
                                                             se1.date_from.isocalendar()[0],
                                                             se1.date_from.isocalendar()[1]))
         self.assertIn("Foo SE1", resp.rendered_content)

--- a/src/tests/presale/test_event.py
+++ b/src/tests/presale/test_event.py
@@ -314,8 +314,7 @@ class ItemDisplayTest(EventTestMixin, SoupTest):
         resp = self.client.get('/%s/%s/' % (self.orga.slug, self.event.slug))
         self.assertIn("Foo SE2", resp.rendered_content)
         self.assertNotIn("Foo SE1", resp.rendered_content)
-        resp = self.client.get('/%s/%s/?date=%d-%d' % (self.orga.slug, self.event.slug, se1.date_from.year,
-                                                             se1.date_from.month))
+        resp = self.client.get('/%s/%s/?date=%d-%d' % (self.orga.slug, self.event.slug, se1.date_from.year, se1.date_from.month))
         self.assertIn("Foo SE1", resp.rendered_content)
         self.assertNotIn("Foo SE2", resp.rendered_content)
 
@@ -332,9 +331,7 @@ class ItemDisplayTest(EventTestMixin, SoupTest):
         print(resp.rendered_content)
         self.assertIn("Foo SE2", resp.rendered_content)
         self.assertNotIn("Foo SE1", resp.rendered_content)
-        resp = self.client.get('/%s/%s/?date=%d-W%d' % (self.orga.slug, self.event.slug,
-                                                            se1.date_from.isocalendar()[0],
-                                                            se1.date_from.isocalendar()[1]))
+        resp = self.client.get('/%s/%s/?date=%d-W%d' % (self.orga.slug, self.event.slug, se1.date_from.isocalendar()[0], se1.date_from.isocalendar()[1]))
         self.assertIn("Foo SE1", resp.rendered_content)
         self.assertNotIn("Foo SE2", resp.rendered_content)
 

--- a/src/tests/presale/test_organizer_page.py
+++ b/src/tests/presale/test_organizer_page.py
@@ -154,7 +154,7 @@ def test_calendar(env, client):
     r = client.get('/mrmcd/?style=calendar')
     assert 'MRMCD2017' in r.rendered_content
     assert 'September %d' % (now().year + 1) in r.rendered_content
-    r = client.get('/mrmcd/?style=calendar&month=10&year=2017')
+    r = client.get('/mrmcd/?style=calendar&date=2017-10')
     assert 'MRMCD2017' not in r.rendered_content
     assert 'October 2017' in r.rendered_content
 
@@ -173,7 +173,7 @@ def test_week_calendar(env, client):
     e.save()
     r = client.get('/mrmcd/?style=week')
     assert 'MRMCD2017' in r.rendered_content
-    r = client.get('/mrmcd/?style=week&week=2&year=2017')
+    r = client.get('/mrmcd/?style=week&date=2017-W02')
     assert 'MRMCD2017' not in r.rendered_content
 
 


### PR DESCRIPTION
This PR adds several  improvements to the calendar navigation on organizers pages:

- unify GET-parameters to `date` instead of a mix of `week`, `month`, `year` and `date`
- remove calendar-type icons as they do not add distinction. This brings the +iCal button back on the same line most of the time
- move „show upcoming/past events“ links to their corresponding notification texts instead of in the navigation
- on month view, change month/year-selects to a single select
- on week view, change week/year-selects to a single select