### PR TITLE
Reduce confusion about customer login with event level domains

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -298,11 +298,13 @@ class CustomerStep(CartMixin, TemplateFlowStep):
             elif request.customer:
                 self.cart_session['customer_mode'] = 'login'
                 self.cart_session['customer'] = request.customer.pk
+                self.cart_session['customer_cart_tied_to_login'] = True
                 return redirect(self.get_next_url(request))
             elif self.login_form.is_valid():
                 customer_login(self.request, self.login_form.get_customer())
                 self.cart_session['customer_mode'] = 'login'
                 self.cart_session['customer'] = self.login_form.get_customer().pk
+                self.cart_session['customer_cart_tied_to_login'] = True
                 return redirect(self.get_next_url(request))
             else:
                 return self.render()
@@ -311,6 +313,7 @@ class CustomerStep(CartMixin, TemplateFlowStep):
                 customer = self.register_form.create()
                 self.cart_session['customer_mode'] = 'login'
                 self.cart_session['customer'] = customer.pk
+                self.cart_session['customer_cart_tied_to_login'] = False
                 return redirect(self.get_next_url(request))
             else:
                 return self.render()

--- a/src/pretix/presale/templates/pretixpresale/fragment_login_status.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_login_status.html
@@ -15,7 +15,7 @@
                 <span class="fa fa-sign-out" aria-hidden="true"></span>
             </a>
         {% else %}
-            <a href="{% abseventurl request.organizer "presale:organizer.customer.login" %}{% if not request.event_domain %}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}{% endif %}">
+            <a href="{% abseventurl request.organizer "presale:organizer.customer.login" %}?next={% if request.event_domain %}{{ request.scheme }}://{{ request.get_host }}{% endif %}{{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}{% if request.event_domain %}&request_cross_domain_customer_auth=true{% endif %}">
                 {% trans "Log in" %}</a>
 
         {% endif %}

--- a/src/pretix/presale/utils.py
+++ b/src/pretix/presale/utils.py
@@ -115,7 +115,7 @@ def update_customer_session_auth_hash(request, customer):
 
 
 def add_customer_to_request(request):
-    if 'cross_domain_customer_auth' in request.GET:
+    if 'cross_domain_customer_auth' in request.GET and request.event_domain:
         # The user is logged in on the main domain and now wants to take their session
         # to a event-specific domain. We validate the one time token received via a
         # query parameter and make sure we invalidate it right away. Then, we look up

--- a/src/pretix/presale/utils.py
+++ b/src/pretix/presale/utils.py
@@ -31,7 +31,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the Apache License 2.0 is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
-
+import re
 import warnings
 from importlib import import_module
 from urllib.parse import urljoin
@@ -48,6 +48,7 @@ from django.utils.functional import SimpleLazyObject
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django.views.defaults import permission_denied
+from django_redis import get_redis_connection
 from django_scopes import scope
 
 from pretix.base.middleware import LocaleMiddleware
@@ -64,17 +65,34 @@ def get_customer(request):
     if not hasattr(request, '_cached_customer'):
         session_key = f'customer_auth_id:{request.organizer.pk}'
         hash_session_key = f'customer_auth_hash:{request.organizer.pk}'
+        dependency_key = f'customer_auth_session_dependency:{request.organizer.pk}'
+
+        # By default, we look at the regular django session
+        session = request.session
+
+        # However, if an event uses a custom domain, the event is at a different domain
+        # than our actual session cookie. The login state is therefore not determined
+        # by our request session, but by the "parent session", the user's session on the
+        # organizer level. This approach guarantees e.g. a global logout feature.
+        if session.get(dependency_key):
+            sparent = SessionStore(session[dependency_key])
+            try:
+                session = sparent.load()
+            except:
+                # parent session no longer exists
+                request._cached_customer = None
+                return
 
         with scope(organizer=request.organizer):
             try:
                 customer = request.organizer.customers.get(
                     is_active=True, is_verified=True,
-                    pk=request.session[session_key]
+                    pk=session[session_key]
                 )
             except (Customer.DoesNotExist, KeyError):
                 request._cached_customer = None
             else:
-                session_hash = request.session.get(hash_session_key)
+                session_hash = session.get(hash_session_key)
                 session_hash_verified = session_hash and constant_time_compare(
                     session_hash,
                     customer.get_session_auth_hash()
@@ -82,7 +100,7 @@ def get_customer(request):
                 if session_hash_verified:
                     request._cached_customer = customer
                 else:
-                    request.session.flush()
+                    session.flush()
                     request._cached_customer = None
 
     return request._cached_customer
@@ -96,12 +114,41 @@ def update_customer_session_auth_hash(request, customer):
 
 
 def add_customer_to_request(request):
+    if 'cross_domain_customer_auth' in request.GET:
+        # The user is logged in on the main domain and now wants to take their session
+        # to a event-specific domain. We validate the one time token received via a
+        # query parameter and make sure we invalidate it right away. Then, we look up
+        # the users session on the main domain and store the dependency between the two
+        # sessions.
+        rc = get_redis_connection("redis")
+        otp = re.sub('[^a-zA-Z0-9]', '', request.GET['cross_domain_customer_auth'])
+        redis_key = f'pretix_customer_cross_domain_auth_{request.organizer.pk}_{otp}'
+        parent_session_key = rc.get(redis_key)
+
+        if parent_session_key:  # not already invalidated, expired, …
+            # Make sure the OTP can't be used again
+            rc.delete(redis_key)
+
+            sparent = SessionStore(parent_session_key.decode())
+            try:
+                sparent.load()
+            except:
+                # parent session no longer exists
+                pass
+            else:
+                dependency_key = f'customer_auth_session_dependency:{request.organizer.pk}'
+                session_key = f'customer_auth_id:{request.organizer.pk}'
+                request.session[dependency_key] = parent_session_key.decode()
+                if session_key in request.session:
+                    del request.session[session_key]
+
     request.customer = SimpleLazyObject(lambda: get_customer(request))
 
 
 def customer_login(request, customer):
     session_key = f'customer_auth_id:{request.organizer.pk}'
     hash_session_key = f'customer_auth_hash:{request.organizer.pk}'
+    dependency_key = f'customer_auth_session_dependency:{request.organizer.pk}'
     session_auth_hash = customer.get_session_auth_hash()
 
     if session_key in request.session:
@@ -114,6 +161,7 @@ def customer_login(request, customer):
     else:
         request.session.cycle_key()
 
+    request.session.pop(dependency_key, None)
     request.session[session_key] = customer.pk
     request.session[hash_session_key] = session_auth_hash
     request.customer = customer
@@ -127,6 +175,12 @@ def customer_login(request, customer):
 def customer_logout(request):
     session_key = f'customer_auth_id:{request.organizer.pk}'
     hash_session_key = f'customer_auth_hash:{request.organizer.pk}'
+    dependency_key = f'customer_auth_session_dependency:{request.organizer.pk}'
+
+    # Remove dependency on parent session
+    request.session.pop(dependency_key, None)
+    # We do not remove the actual parent session as we have no way of e.g. cycling its ID.
+    # Instead, LogoutView will redirect the user to the logout of the parent session.
 
     # Remove user session
     customer_id = request.session.pop(session_key, None)

--- a/src/tests/presale/test_customer.py
+++ b/src/tests/presale/test_customer.py
@@ -22,14 +22,17 @@
 import datetime
 from datetime import timedelta
 from decimal import Decimal
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.core import mail as djmail
 from django.core.signing import dumps
+from django.test import Client
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
 
 from pretix.base.models import Event, Item, Order, OrderPosition, Organizer
+from pretix.multidomain.models import KnownDomain
 from pretix.presale.forms.customer import TokenGenerator
 
 
@@ -412,3 +415,152 @@ def test_login_per_org(env, client):
     })
     assert client.get('/bigevents/account/').status_code == 200
     assert client.get('/demo/account/').status_code == 302
+
+
+@pytest.fixture
+def client2():
+    # We need a second test client instance for cross domain stuff since the test client
+    # does not isolate sessions per-domain like browsers do
+    return Client()
+
+
+def _cross_domain_login(env, client, client2):
+    with scopes_disabled():
+        customer = env[0].customers.create(email='john@example.org', is_verified=True)
+        customer.set_password('foo')
+        customer.save()
+        KnownDomain.objects.create(domainname='org.test', organizer=env[0])
+        KnownDomain.objects.create(domainname='event.test', organizer=env[0], event=env[1])
+
+    # Log in on org domain
+    r = client.post('/account/login?next=https://event.test/redeem&request_cross_domain_customer_auth=true', {
+        'email': 'john@example.org',
+        'password': 'foo',
+    }, HTTP_HOST='org.test')
+    assert r.status_code == 302
+
+    u = urlparse(r.headers['Location'])
+    assert u.netloc == 'event.test'
+    assert u.path == '/redeem'
+    q = parse_qs(u.query)
+    assert 'cross_domain_customer_auth' in q
+
+    # Take session over to event domain
+    r = client2.get(f'/?{u.query}', HTTP_HOST='event.test')
+    assert r.status_code == 200
+    assert b'john@example.org' in r.content
+
+
+@pytest.mark.django_db
+def test_cross_domain_login(env, client, client2):
+    _cross_domain_login(env, client, client2)
+
+    # Logged in on org domain
+    r = client.get('/', HTTP_HOST='event.test')
+    assert r.status_code == 200
+    assert b'john@example.org' in r.content
+
+    # Logged in on event domain
+    r = client2.get('/', HTTP_HOST='org.test')
+    assert r.status_code == 200
+    assert b'john@example.org' in r.content
+
+
+@pytest.mark.django_db
+def test_cross_domain_logout_on_org_domain(env, client, client2):
+    _cross_domain_login(env, client, client2)
+
+    r = client.get('/account/logout', HTTP_HOST='org.test')
+    assert r.status_code == 302
+
+    # Logged out on org domain
+    r = client.get('/', HTTP_HOST='event.test')
+    assert r.status_code == 200
+    assert b'john@example.org' not in r.content
+
+    # Logged out on event domain
+    r = client2.get('/', HTTP_HOST='org.test')
+    assert r.status_code == 200
+    assert b'john@example.org' not in r.content
+
+
+@pytest.mark.django_db
+def test_cross_domain_logout_on_event_domain(env, client, client2):
+    _cross_domain_login(env, client, client2)
+
+    r = client2.get('/account/logout?next=/redeem', HTTP_HOST='event.test')
+    assert r.status_code == 302
+
+    u = urlparse(r.headers['Location'])
+    assert u.netloc == 'org.test'
+    assert u.path == '/account/logout'
+
+    r = client.get(f'{u.path}?{u.query}', HTTP_HOST='org.test')
+    assert r.status_code == 302
+    assert r.headers['Location'] == 'http://event.test/redeem'
+
+    # Logged out on org domain
+    r = client.get('/', HTTP_HOST='event.test')
+    assert r.status_code == 200
+    assert b'john@example.org' not in r.content
+
+    # Logged out on event domain
+    r = client2.get('/', HTTP_HOST='org.test')
+    assert r.status_code == 200
+    assert b'john@example.org' not in r.content
+
+
+@pytest.mark.django_db
+def test_cross_domain_login_otp_only_valid_once(env, client, client2):
+    with scopes_disabled():
+        customer = env[0].customers.create(email='john@example.org', is_verified=True)
+        customer.set_password('foo')
+        customer.save()
+        KnownDomain.objects.create(domainname='org.test', organizer=env[0])
+        KnownDomain.objects.create(domainname='event.test', organizer=env[0], event=env[1])
+
+    # Log in on org domain
+    r = client.post('/account/login?next=https://event.test/redeem&request_cross_domain_customer_auth=true', {
+        'email': 'john@example.org',
+        'password': 'foo',
+    }, HTTP_HOST='org.test')
+    assert r.status_code == 302
+
+    u = urlparse(r.headers['Location'])
+    assert u.netloc == 'event.test'
+    assert u.path == '/redeem'
+    q = parse_qs(u.query)
+    assert 'cross_domain_customer_auth' in q
+
+    # Take session over to event domain
+    r = client.get(f'/?{u.query}', HTTP_HOST='event.test')
+    assert r.status_code == 200
+    assert b'john@example.org' in r.content
+
+    # Try to use again
+    r = client2.get(f'/?{u.query}', HTTP_HOST='event.test')
+    assert r.status_code == 200
+    assert b'john@example.org' not in r.content
+
+
+@pytest.mark.django_db
+def test_cross_domain_login_validate_redirect_url(env, client, client2):
+    with scopes_disabled():
+        customer = env[0].customers.create(email='john@example.org', is_verified=True)
+        customer.set_password('foo')
+        customer.save()
+        KnownDomain.objects.create(domainname='org.test', organizer=env[0])
+        KnownDomain.objects.create(domainname='event.test', organizer=env[0], event=env[1])
+
+    # Log in on org domain
+    r = client.post('/account/login?next=https://evilcorp.test/redeem&request_cross_domain_customer_auth=true', {
+        'email': 'john@example.org',
+        'password': 'foo',
+    }, HTTP_HOST='org.test')
+    assert r.status_code == 302
+
+    u = urlparse(r.headers['Location'])
+    assert u.netloc == 'org.test'
+    assert u.path == '/account/'
+    q = parse_qs(u.query)
+    assert 'cross_domain_customer_auth' not in q


### PR DESCRIPTION
## Problem

Customer account login is an organizer-level thing. Specifically, we offer the login and profile management views as part of the organizer URLs, e.g. ``https://pretix.eu/org/account/login``. However, one can also log in or sign up during checkout. This is all fun while both organizer URLs as well as event URLs are on the same domain, e.g. ``https://pretix.eu/org/`` and ``https://pretix.eu/org/event/`` or ``https://tickets.org.com/`` and ``https://tickets.org.com/event/``.

However, once you use event-specific domains, this becomes incredibly confusing. If you visit ``https://tickets.eventdomain.com`` and click on the "login" button, you will be taken to ``https://tickets.org.com/account/login`` and after you logged in, you will see your profile on ``https://tickets.org.com/account/profile``. If you manually return back to the event, it will still not show you as login, since there's no way to do cookies across entirely different domains.

Similarly, if you start at the event domain and sign in during a purchase in the ``CustomerStep``, you will be logged in on the event-specific domain, but if you click on your name in the navigation to access your profile… you will need to login again, since you're on a different domain.

Also it's pretty unclear what "logout" means with these different levels of logins.

Currently, this is just annoying, but it will become a major blocker if we (or plugins) start adding event-level views that require a valid login.

## Solution

This PR adds a mechanism that allows cross-domain authentication. If you click "login" on the event domain, you will be redirected to the organizer-level login (this is unchanged), but after you logged in, you will now be redirected **back** to the place you came from. This redirect will also pass back a one-time authorization token. (Since all domains are handled by the same server we can do SSO much simpler than with OAuth/OIDC/…)

This token now creates a "child session": Your django session of the event domain now includes a reference to your django session on the organizer domain. On every page load, we check both sessions for validity. This has a major advantage over just logging you in on the second domain as well: If you hit logout on organizer level, you'll instantly be logged out from *all* event domains you ever logged in to with this mechanism, which is an important property.

Additionally, if you created a cart while logged in, we now store a flag in the cart session that makes sure the cart becomes inaccessible if you log out. (We cannot do this unconditionally as this would break the "sign up for a new account while purchasing" user journey.)

There's still one "unclean" situation: You can still log in on the event domain directly by logging in during checkout. Everything would be much cleaner if we'd handle this via the organizer domain as well, but that would require a redirect to a different domain in the middle of your checkout process which is really bad for the ticket purchasing user journey. So for now, we accept that there is still some situation where you could e.g. be logged in to two different accounts (or to the same account with two different sessions) on different domains. We try to reduce the risk of abandoned sessions as much as possible by introducing a redirect in the logout view to make sure you log out both on the domain you clicked logout on as well as the organizer's main domain.