### PR TITLE
Allow to attach files to order confirmation email

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -445,8 +445,10 @@ You can configure the maximum file size for uploading various files::
     max_size_image = 12
     ; Max upload size for favicons in MiB, defaults to 1 MiB
     max_size_favicon = 2
-    ; Max upload size for email attachments in MiB, defaults to 10 MiB
+    ; Max upload size for email attachments of manually sent emails in MiB, defaults to 10 MiB
     max_size_email_attachment = 15
+    ; Max upload size for email attachments of automatically sent emails in MiB, defaults to 1 MiB
+    max_size_email_auto_attachment = 2
     ; Max upload size for other files in MiB, defaults to 10 MiB
     ; This includes all file upload type order questions
     max_size_other = 100

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -950,7 +950,7 @@ class Order(LockModel, LoggedModel):
                   context: Dict[str, Any]=None, log_entry_type: str='pretix.event.order.email.sent',
                   user: User=None, headers: dict=None, sender: str=None, invoices: list=None,
                   auth=None, attach_tickets=False, position: 'OrderPosition'=None, auto_email=True,
-                  attach_ical=False):
+                  attach_ical=False, attach_other_files: list=None):
         """
         Sends an email to the user that placed this order. Basically, this method does two things:
 
@@ -994,7 +994,8 @@ class Order(LockModel, LoggedModel):
                     recipient, subject, template, context,
                     self.event, self.locale, self, headers=headers, sender=sender,
                     invoices=invoices, attach_tickets=attach_tickets,
-                    position=position, auto_email=auto_email, attach_ical=attach_ical
+                    position=position, auto_email=auto_email, attach_ical=attach_ical,
+                    attach_other_files=attach_other_files,
                 )
             except SendMailException:
                 raise
@@ -2316,7 +2317,7 @@ class OrderPosition(AbstractPosition):
     def send_mail(self, subject: str, template: Union[str, LazyI18nString],
                   context: Dict[str, Any]=None, log_entry_type: str='pretix.event.order.email.sent',
                   user: User=None, headers: dict=None, sender: str=None, invoices: list=None,
-                  auth=None, attach_tickets=False, attach_ical=False):
+                  auth=None, attach_tickets=False, attach_ical=False, attach_other_files: list=None):
         """
         Sends an email to the attendee. Basically, this method does two things:
 
@@ -2357,6 +2358,7 @@ class OrderPosition(AbstractPosition):
                     invoices=invoices,
                     attach_tickets=attach_tickets,
                     attach_ical=attach_ical,
+                    attach_other_files=attach_other_files,
                 )
             except SendMailException:
                 raise

--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -75,6 +75,7 @@ from pretix.base.services.tasks import TransactionAwareTask
 from pretix.base.services.tickets import get_tickets_for_order
 from pretix.base.signals import email_filter, global_email_filter
 from pretix.celery_app import app
+from pretix.helpers.hierarkey import clean_filename
 from pretix.multidomain.urlreverse import build_absolute_uri
 from pretix.presale.ical import get_ical
 
@@ -467,7 +468,7 @@ def mail_send_task(self, *args, to: List[str], subject: str, body: str, html: st
                 data = default_storage.open(fname).read()
                 try:
                     email.attach(
-                        re.sub(r'^(.*)(\.[^.]+)(\.[^.]+)$', r'\1\3', os.path.basename(fname)),
+                        clean_filename(os.path.basename(fname)),
                         data,
                         ftype
                     )

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -943,7 +943,7 @@ def _order_placed_email(event: Event, order: Order, pprov: BasePaymentProvider, 
             attach_tickets=True,
             attach_ical=event.settings.mail_attach_ical,
             attach_other_files=filter(lambda a: a, [
-                event.settings.get('mail_attachment_new_order', as_type=str, default='')[7:]
+                event.settings.get('mail_attachment_new_order', as_type=str, default='')[len('file://'):]
             ]),
         )
     except SendMailException:
@@ -963,7 +963,7 @@ def _order_placed_email_attendee(event: Event, order: Order, position: OrderPosi
             position=position,
             attach_ical=event.settings.mail_attach_ical,
             attach_other_files=filter(lambda a: a, [
-                event.settings.get('mail_attachment_new_order', as_type=str, default='')[7:]
+                event.settings.get('mail_attachment_new_order', as_type=str, default='')[len('file://'):]
             ]),
         )
     except SendMailException:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -941,7 +941,10 @@ def _order_placed_email(event: Event, order: Order, pprov: BasePaymentProvider, 
             log_entry,
             invoices=[invoice] if invoice and event.settings.invoice_email_attachment else [],
             attach_tickets=True,
-            attach_ical=event.settings.mail_attach_ical
+            attach_ical=event.settings.mail_attach_ical,
+            attach_other_files=filter(lambda a: a, [
+                event.settings.get('mail_attachment_new_order', as_type=str, default='')[7:]
+            ]),
         )
     except SendMailException:
         logger.exception('Order received email could not be sent')
@@ -958,7 +961,10 @@ def _order_placed_email_attendee(event: Event, order: Order, position: OrderPosi
             invoices=[],
             attach_tickets=True,
             position=position,
-            attach_ical=event.settings.mail_attach_ical
+            attach_ical=event.settings.mail_attach_ical,
+            attach_other_files=filter(lambda a: a, [
+                event.settings.get('mail_attachment_new_order', as_type=str, default='')[7:]
+            ]),
         )
     except SendMailException:
         logger.exception('Order received email could not be sent to attendee')

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1687,6 +1687,30 @@ You can change your order details and view the status of your order at
 Best regards,
 Your {event} team"""))
     },
+    'mail_attachment_new_order': {
+        'default': None,
+        'type': File,
+        'form_class': ExtFileField,
+        'form_kwargs': dict(
+            label=_('Attachment for new orders'),
+            ext_whitelist=(".pdf",),
+            max_size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT,
+            help_text=_('This file will be attached to the first email that we send for every new order. Therefore it will be '
+                        'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
+                        'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
+                        'it to send non-public information as this file might be sent before payment is confirmed or the order '
+                        'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.').format(
+                size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024),
+            )
+        ),
+        'serializer_class': UploadedFileField,
+        'serializer_kwargs': dict(
+            allowed_types=[
+                'application/pdf'
+            ],
+            max_size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT,
+        )
+    },
     'mail_send_order_placed_attendee': {
         'type': bool,
         'default': 'False'

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -837,6 +837,7 @@ class MailSettingsForm(SMTPSettingsMixin, SettingsForm):
         'mail_from_name',
         'mail_attach_ical',
         'mail_attach_tickets',
+        'mail_attachment_new_order',
     ]
 
     mail_sales_channel_placed_paid = forms.MultipleChoiceField(

--- a/src/pretix/control/templates/pretixcontrol/event/mail.html
+++ b/src/pretix/control/templates/pretixcontrol/event/mail.html
@@ -47,6 +47,7 @@
             </fieldset>
             <fieldset>
                 <legend>{% trans "E-mail content" %}</legend>
+                <h4>{% trans "Text" %}</h4>
                 <div class="panel-group" id="questions_group">
                     {% blocktrans asvar title_placed_order %}Placed order{% endblocktrans %}
                     {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="order_placed" title=title_placed_order items="mail_text_order_placed,mail_send_order_placed_attendee,mail_text_order_placed_attendee" exclude="mail_send_order_placed_attendee" %}
@@ -81,6 +82,8 @@
                     {% blocktrans asvar title_require_approval %}Order approval process{% endblocktrans %}
                     {% include "pretixcontrol/event/mail_settings_fragment.html" with pid="ticket_reminder" title=title_require_approval  items="mail_text_order_placed_require_approval,mail_text_order_approved,mail_text_order_approved_free,mail_text_order_denied" %}
                 </div>
+                <h4>{% trans "Attachments" %}</h4>
+                {% bootstrap_field form.mail_attachment_new_order layout="control" %}
             </fieldset>
             <fieldset>
                 <legend>{% trans "SMTP settings" %}</legend>

--- a/src/pretix/helpers/hierarkey.py
+++ b/src/pretix/helpers/hierarkey.py
@@ -1,7 +1,7 @@
 def clean_filename(fname):
     """
     hierarkey.forms.SettingsForm appends a random value to every filename. However, it keeps the
-    extension around "twice". Tis leads to:
+    extension around "twice". This leads to:
 
     "Terms.pdf" → "Terms.pdf.OybgvyAH.pdf"
 

--- a/src/pretix/helpers/hierarkey.py
+++ b/src/pretix/helpers/hierarkey.py
@@ -1,0 +1,17 @@
+def clean_filename(fname):
+    """
+    hierarkey.forms.SettingsForm appends a random value to every filename. However, it keeps the
+    extension around "twice". Tis leads to:
+
+    "Terms.pdf" → "Terms.pdf.OybgvyAH.pdf"
+
+    In pretix Hosted, our storage layer also adds a hash of the file to the filename, so we have
+
+    "Terms.pdf" → "Terms.pdf.OybgvyAH.22c0583727d5bc.pdf"
+
+    This function reverses this operation:
+
+    "Terms.pdf.OybgvyAH.22c0583727d5bc.pdf" → "Terms.pdf"
+    """
+    ext = fname.split('.')[-1]
+    return fname.rsplit(ext, 2)[0] + ext

--- a/src/pretix/helpers/hierarkey.py
+++ b/src/pretix/helpers/hierarkey.py
@@ -1,3 +1,26 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+
+
 def clean_filename(fname):
     """
     hierarkey.forms.SettingsForm appends a random value to every filename. However, it keeps the
@@ -13,5 +36,5 @@ def clean_filename(fname):
 
     "Terms.pdf.OybgvyAH.22c0583727d5bc.pdf" → "Terms.pdf"
     """
-    ext = fname.split('.')[-1]
+    ext = '.' + fname.split('.')[-1]
     return fname.rsplit(ext, 2)[0] + ext

--- a/src/pretix/helpers/hierarkey.py
+++ b/src/pretix/helpers/hierarkey.py
@@ -37,4 +37,4 @@ def clean_filename(fname):
     "Terms.pdf.OybgvyAH.22c0583727d5bc.pdf" → "Terms.pdf"
     """
     ext = '.' + fname.split('.')[-1]
-    return fname.rsplit(ext, 2)[0] + ext
+    return fname.rsplit(ext + ".", 1)[0] + ext

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -854,6 +854,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10 MB
 FILE_UPLOAD_MAX_SIZE_IMAGE = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_image", fallback=10)
 FILE_UPLOAD_MAX_SIZE_FAVICON = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_favicon", fallback=1)
 FILE_UPLOAD_MAX_SIZE_EMAIL_ATTACHMENT = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_email_attachment", fallback=10)
+FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_auto_email_attachment", fallback=1)
 FILE_UPLOAD_MAX_SIZE_OTHER = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_other", fallback=10)
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'  # sadly. we would prefer BigInt, and should use it for all new models but the migration will be hard

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -854,7 +854,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10 MB
 FILE_UPLOAD_MAX_SIZE_IMAGE = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_image", fallback=10)
 FILE_UPLOAD_MAX_SIZE_FAVICON = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_favicon", fallback=1)
 FILE_UPLOAD_MAX_SIZE_EMAIL_ATTACHMENT = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_email_attachment", fallback=10)
-FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_auto_email_attachment", fallback=1)
+FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_email_auto_attachment", fallback=1)
 FILE_UPLOAD_MAX_SIZE_OTHER = 1024 * 1024 * config.getint("pretix_file_upload", "max_size_other", fallback=10)
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'  # sadly. we would prefer BigInt, and should use it for all new models but the migration will be hard


### PR DESCRIPTION
This feature has been requested by users hundreds of times. So far, I always refused. I think it is generally a bad idea, as it will hurt email deliverability of the most important email we send and it will lead to users misusing the feature.

However, after many years, I'm now breaking under the recent pressure applied by multiple customers and implementing it. The two intended use cases are:

* Many customers want to send their terms of service and similar documents, since there might be a legal requirement to do so. Hard to argue with that
* One customer wants to send a 1-page FAQ sheet on the booked event to avoid lots of support overhead

To keep the misuse of this feature small, I applied two restrictions:

* I only added one setting. If we wanted symmetry with the email texts we would need 6 (for the events order_placed, order_free, order_placed_require_approval + the same 3 for the attendee emails).
* I only added support for attaching to the order confirmation email, not to the order paid email, so people can't use this as a very bad replacement for the digital content module.
* I limited file size to 1MB. If your terms of service PDF has more than 1MB, that's a problem you should fix. I'm not sure, this might be a little harsh, but I'm really worried we'll have significant delivery problems otherwise if people upload their 10MB PDF files. Any other opinions here?