### PR TITLE
Add fixed scroll position when navigating calendar views (Z#177488)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
@@ -5,7 +5,7 @@
     <ul class="row calendar-nav">
         <li class="col-sm-4 col-xs-2 text-left flip">
             <a href="?{% url_replace request "date" subevent_list.before|date:"Y-m" %}"
-                    class="btn btn-default" aria-label="{% blocktrans with month=subevent_list.before|date:"F Y" %}Show previous month, {{ month }}{% endblocktrans %}">
+                    class="btn btn-default" data-save-scrollpos aria-label="{% blocktrans with month=subevent_list.before|date:"F Y" %}Show previous month, {{ month }}{% endblocktrans %}">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
                 <span class="hidden-xs">{{ subevent_list.before|date:"F Y" }}</span>
             </a>
@@ -33,7 +33,7 @@
         </li>
         <li class="col-sm-4 col-xs-2 text-right flip">
             <a href="?{% url_replace request "date" subevent_list.after|date:"Y-m" %}"
-                class="btn btn-default" aria-label="{% blocktrans with month=subevent_list.after|date:"F Y" %}Show next month, {{ month }}{% endblocktrans %}">
+                class="btn btn-default" data-save-scrollpos aria-label="{% blocktrans with month=subevent_list.after|date:"F Y" %}Show next month, {{ month }}{% endblocktrans %}">
                 <span class="hidden-xs">{{ subevent_list.after|date:"F Y" }}</span>
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>
             </a>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -5,7 +5,7 @@
     <ul class="row calendar-nav">
         <li class="col-sm-4 col-xs-2 text-left flip">
             <a href="?{% url_replace request "date" subevent_list.before|date:"o-\WW" %}"
-                class="btn btn-default" aria-label="{% blocktrans with week=subevent_list.before|date:subevent_list.week_format %}Show previous week, {{ week }}{% endblocktrans %}">
+                class="btn btn-default" data-save-scrollpos aria-label="{% blocktrans with week=subevent_list.before|date:subevent_list.week_format %}Show previous week, {{ week }}{% endblocktrans %}">
                 <span class="fa fa-arrow-left" aria-hidden="true"></span>
                 <span class="hidden-xs">{{ subevent_list.before|date:subevent_list.week_format }}</span>
             </a>
@@ -37,7 +37,7 @@
         </li>
         <li class="col-sm-4 col-xs-2 text-right flip">
             <a href="?{% url_replace request "date" subevent_list.after|date:"o-\WW" %}"
-                class="btn btn-default" aria-label="{% blocktrans with week=subevent_list.after|date:subevent_list.week_format %}Show next week, {{ week }}{% endblocktrans %}">
+                class="btn btn-default" data-save-scrollpos aria-label="{% blocktrans with week=subevent_list.after|date:subevent_list.week_format %}Show next week, {{ week }}{% endblocktrans %}">
                 <span class="hidden-xs">{{ subevent_list.after|date:subevent_list.week_format }}</span>
                 <span class="fa fa-arrow-right" aria-hidden="true"></span>
             </a>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -38,14 +38,14 @@
             <div class="col-md-5 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before|date:"Y-m" %}"
-                       class="btn btn-default" aria-label="{{ before|date:"F Y" }}">
+                       class="btn btn-default" data-save-scrollpos aria-label="{{ before|date:"F Y" }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
                         <span class="hidden-sm hidden-xs">{{ before|date:"F Y" }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
                     <a href="?{% url_replace request "date" after|date:"Y-m" %}"
-                       class="btn btn-default" aria-label="{{ after|date:"F Y" }}">
+                       class="btn btn-default" data-save-scrollpos aria-label="{{ after|date:"F Y" }}">
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                         <span class="hidden-sm hidden-xs">{{ after|date:"F Y" }}</span>
                     </a>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -31,14 +31,14 @@
             <div class="col-md-5 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before.date.isoformat %}"
-                       class="btn btn-default" aria-label="{{ before|date:"SHORT_DATE_FORMAT" }}">
+                       class="btn btn-default" data-save-scrollpos aria-label="{{ before|date:"SHORT_DATE_FORMAT" }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
                         <span class="hidden-sm hidden-xs">{{ before|date:"SHORT_DATE_FORMAT" }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
                     <a href="?{% url_replace request "date" after.date.isoformat %}"
-                       class="btn btn-default" aria-label="{{ after|date:"SHORT_DATE_FORMAT" }}">
+                       class="btn btn-default" data-save-scrollpos aria-label="{{ after|date:"SHORT_DATE_FORMAT" }}">
                         <span class="hidden-sm hidden-xs">{{ after|date:"SHORT_DATE_FORMAT" }}</span>
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                     </a>

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -43,14 +43,14 @@
             <div class="col-md-4 col-sm-2 col-xs-4 text-right flip">
                 {% if has_before %}
                     <a href="?{% url_replace request "date" before|date:"o-\WW" %}"
-                       class="btn btn-default" aria-label="{{ before|date:week_format }}">
+                       class="btn btn-default" data-save-scrollpos aria-label="{{ before|date:week_format }}">
                         <span class="fa fa-arrow-left" aria-hidden="true"></span>
                         <span class="hidden-sm hidden-xs">{{ before|date:week_format }}</span>
                     </a>
                 {% endif %}
                 {% if has_after %}
                     <a href="?{% url_replace request "date" after|date:"o-\WW" %}"
-                       class="btn btn-default" aria-label="{{ after|date:week_format }}">
+                       class="btn btn-default" data-save-scrollpos aria-label="{{ after|date:week_format }}">
                         <span class="hidden-sm hidden-xs">{{ after|date:week_format }}</span>
                         <span class="fa fa-arrow-right" aria-hidden="true"></span>
                     </a>

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -180,10 +180,10 @@ $(function () {
 
     $("body").removeClass("nojs");
 
-    var scrollpos = localStorage.getItem('scrollpos');
+    var scrollpos = sessionStorage.getItem('scrollpos');
     if (scrollpos) {
         window.scrollTo(0, scrollpos);
-        localStorage.removeItem('scrollpos');
+        sessionStorage.removeItem('scrollpos');
     }
 
     $(".accordion-radio").click(function() {
@@ -327,16 +327,18 @@ $(function () {
             $(this).slideToggle(300).attr("aria-expanded", true);
         });
     }
-    $("[data-save-scrollpos]").click(function () {
-        localStorage.setItem('scrollpos', window.scrollY);
-    });
+    if (sessionStorage) {
+        $("[data-save-scrollpos]").click(function () {
+            sessionStorage.setItem('scrollpos', window.scrollY);
+        });
+    }
     $("#monthselform select").change(function () {
-        localStorage.setItem('scrollpos', window.scrollY);
+        if (sessionStorage) sessionStorage.setItem('scrollpos', window.scrollY);
         this.form.submit();
     });
     $("#monthselform input").on("dp.change", function () {
         if ($(this).data("DateTimePicker")) {  // prevent submit after dp init
-            localStorage.setItem('scrollpos', window.scrollY);
+            if (sessionStorage) sessionStorage.setItem('scrollpos', window.scrollY);
             this.form.submit();
         }
     });

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -180,7 +180,7 @@ $(function () {
 
     $("body").removeClass("nojs");
 
-    var scrollpos = sessionStorage.getItem('scrollpos');
+    var scrollpos = sessionStorage ? sessionStorage.getItem('scrollpos') : 0;
     if (scrollpos) {
         window.scrollTo(0, scrollpos);
         sessionStorage.removeItem('scrollpos');

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -180,6 +180,12 @@ $(function () {
 
     $("body").removeClass("nojs");
 
+    var scrollpos = localStorage.getItem('scrollpos');
+    if (scrollpos) {
+        window.scrollTo(0, scrollpos);
+        localStorage.removeItem('scrollpos');
+    }
+
     $(".accordion-radio").click(function() {
         var $input = $("input", this);
         if (!$input.prop("checked")) $input.prop('checked', true).trigger("change");
@@ -321,12 +327,16 @@ $(function () {
             $(this).slideToggle(300).attr("aria-expanded", true);
         });
     }
-
+    $("[data-save-scrollpos]").click(function () {
+        localStorage.setItem('scrollpos', window.scrollY);
+    });
     $("#monthselform select").change(function () {
-        $(this).closest("form").get(0).submit();
+        localStorage.setItem('scrollpos', window.scrollY);
+        this.form.submit();
     });
     $("#monthselform input").on("dp.change", function () {
         if ($(this).data("DateTimePicker")) {  // prevent submit after dp init
+            localStorage.setItem('scrollpos', window.scrollY);
             this.form.submit();
         }
     });


### PR DESCRIPTION
This was suggested from a customer when navigating the calendar-views. It adds a bit of JavaScript that listens to navigation-events in the top-calendar-navigation (prev/next and date-dropdown) and records the scrollposition. When the next page is loaded it will scroll/jump to the same position. If loading is fast enough (most of the time) it makes for a seamless navigation in the calendar.