### PR TITLE
Fix: WEEK_FORMAT fallback in calender week-views

### DIFF
--- a/src/pretix/helpers/formats/fr/__init__.py
+++ b/src/pretix/helpers/formats/fr/__init__.py
@@ -1,0 +1,21 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#

--- a/src/pretix/helpers/formats/fr/formats.py
+++ b/src/pretix/helpers/formats/fr/formats.py
@@ -1,0 +1,25 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+
+# Date according to https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+WEEK_FORMAT = '\\S W/o'
+WEEK_DAY_FORMAT = 'D, j.n.'

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -23,7 +23,7 @@
                     {% for w in weeks_per_year %}
                         <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
                                 {% if w.0.isocalendar.0 == subevent_list.date.isocalendar.0 and w.0.isocalendar.1 == subevent_list.date.isocalendar.1 %}selected{% endif %}>
-                                {{ w.0|date:"WEEK_FORMAT" }}
+                                {{ w.0|date:week_format }}
                             ({{ w.0|date:"MONTH_DAY_FORMAT" }} – {{ w.1|date:"MONTH_DAY_FORMAT" }})
                         </option>
                     {% endfor %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -23,7 +23,7 @@
                     {% for w in weeks_per_year %}
                         <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
                                 {% if w.0.isocalendar.0 == subevent_list.date.isocalendar.0 and w.0.isocalendar.1 == subevent_list.date.isocalendar.1 %}selected{% endif %}>
-                                {{ w.0|date:week_format }}
+                                {{ w.0|date:subevent_list.week_format }}
                             ({{ w.0|date:"MONTH_DAY_FORMAT" }} – {{ w.1|date:"MONTH_DAY_FORMAT" }})
                         </option>
                     {% endfor %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -29,7 +29,7 @@
                     {% for w in weeks_per_year %}
                         <option value="{{ w.0.isocalendar.0 }}-W{{ w.0.isocalendar.1 }}"
                                 {% if w.0.isocalendar.0 == date.isocalendar.0 and w.0.isocalendar.1 == date.isocalendar.1 %}selected{% endif %}>
-                                {{ w.0|date:"WEEK_FORMAT" }}
+                                {{ w.0|date:week_format }}
                             ({{ w.0|date:"MONTH_DAY_FORMAT" }} – {{ w.1|date:"MONTH_DAY_FORMAT" }})
                         </option>
                     {% endfor %}

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -63,7 +63,7 @@ from pretix.base.models import (
 from pretix.base.services.quotas import QuotaAvailability
 from pretix.helpers.compat import date_fromisocalendar
 from pretix.helpers.daterange import daterange
-from pretix.helpers.formats.de.formats import WEEK_FORMAT
+from pretix.helpers.formats.en.formats import WEEK_FORMAT
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.presale.ical import get_ical
 from pretix.presale.views import OrganizerViewMixin


### PR DESCRIPTION
Calendar week-views use `WEEK_FORMAT` to format the date as a week of the year. If the chosen language did not have a `WEEK_FORMAT` set, `WEEK_FORMAT` was used literally as the format-string, which created very long, strange date-formatting.

Also added a french `WEEK_FORMAT`.