### PR TITLE
Fix #555 -- Preselect a single required add-on

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -285,7 +285,7 @@
                             {% if c.max_count == 1 or not c.multi_allowed %}
                                 <label class="item-checkbox-label">
                                     <input type="checkbox" value="1"
-                                            {% if item.initial or c.max_count == 1 and c.min_count == 1 %}checked="checked"{% endif %}
+                                            {% if item.initial or c.max_count == 1 and c.min_count == 1 and c.items|length == 1 %}checked="checked"{% endif %}
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -285,7 +285,7 @@
                             {% if c.max_count == 1 or not c.multi_allowed %}
                                 <label class="item-checkbox-label">
                                     <input type="checkbox" value="1"
-                                            {% if item.initial %}checked="checked"{% endif %}
+                                            {% if item.initial or c.max_count == 1 and c.min_count == 1 %}checked="checked"{% endif %}
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -285,7 +285,12 @@
                             {% if c.max_count == 1 or not c.multi_allowed %}
                                 <label class="item-checkbox-label">
                                     <input type="checkbox" value="1"
-                                            {% if item.initial or c.max_count == 1 and c.min_count == 1 and c.items|length == 1 %}checked="checked"{% endif %}
+                                            {% if c.max_count == 1 and c.min_count == 1 and c.items|length == 1 %}
+                                                checked="checked"
+                                                disabled="disabled"
+                                            {% elif item.initial %}
+                                                checked="checked"
+                                            {% endif %}
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"


### PR DESCRIPTION
If an item contains a single add-on that is also required to be selected, this change autoselects the corresponding checkbox, so users don't have to click it themselves.

TODO:
- [x] Need to make sure no other add-on options exist besides the supposed single one