### PR TITLE
Add static select2 to choice widgets

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -706,7 +706,7 @@ class BaseQuestionsForm(forms.Form):
                     queryset=q.options,
                     label=label, required=required,
                     help_text=help_text,
-                    widget=forms.Select,
+                    widget=forms.Select(attrs={'class': 'select2-static'}),
                     to_field_name='identifier',
                     empty_label='',
                     initial=initial.options.first() if initial else None,

--- a/src/pretix/presale/context.py
+++ b/src/pretix/presale/context.py
@@ -36,7 +36,7 @@ import logging
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.utils import translation
-from django.utils.translation import get_language_info
+from django.utils.translation import get_language_info, get_language
 from django_scopes import get_scope
 from i18nfield.strings import LazyI18nString
 
@@ -169,6 +169,7 @@ def _default_context(request):
     ctx['js_date_format'] = get_javascript_format_without_seconds('DATE_INPUT_FORMATS')
     ctx['js_time_format'] = get_javascript_format_without_seconds('TIME_INPUT_FORMATS')
     ctx['js_locale'] = get_moment_locale()
+    ctx['select2locale'] = get_language()[:2]
     ctx['html_locale'] = translation.get_language_info(get_language_without_region()).get('public_code', translation.get_language())
     ctx['settings'] = pretix_settings
     ctx['django_settings'] = settings

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -44,7 +44,7 @@
     <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">
     <meta name="theme-color" content="{{ settings.primary_color|default:"#3b1c4a" }}">
 </head>
-<body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}">
+<body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}" data-select2-locale="{{ select2locale }}">
 {{ html_page_header|safe }}
 <header>
 {% block above %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_js.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_js.html
@@ -7,6 +7,9 @@
     <script type="text/javascript" src="{% static "js/jquery.formset.js" %}"></script>
     <script type="text/javascript" src="{% static "bootstrap/js/bootstrap.js" %}"></script>
     <script type="text/javascript" src="{% static "datetimepicker/bootstrap-datetimepicker.js" %}"></script>
+    <script type="text/javascript" src="{% static "select2/select2.js" %}"></script>
+    <script type="text/javascript" src="{% static "select2/i18n/de.js" %}"></script>
+    <script type="text/javascript" src="{% static "select2/i18n/en.js" %}"></script>
     <script type="text/javascript" src="{% static "slider/bootstrap-slider.js" %}"></script>
     <script type="text/javascript" src="{% static "cropper/cropper.js" %}"></script>
     <script type="text/javascript" src="{% static "pretixbase/js/details.js" %}"></script>

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -131,6 +131,11 @@ var form_handlers = function (el) {
         });
     });
 
+    el.find('.select2-static').select2({
+      theme: "bootstrap",
+      language: $("body").attr("data-select2-locale"),
+    });
+
     el.find("input[name*=question], select[name*=question]").change(questions_toggle_dependent);
     questions_toggle_dependent();
     questions_init_photos(el);

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -8,6 +8,8 @@ $body-bg: #f5f5f5 !default;
 @import "../../lightbox/css/lightbox.scss";
 @import "../../cropper/cropper.scss";
 @import "../../datetimepicker/_bootstrap-datetimepicker.scss";
+@import "../../select2/select2.scss";
+@import "../../select2/select2_bootstrap.scss";
 @import "../../slider/_bootstrap-slider.scss";
 @import "../../fontawesome/scss/font-awesome.scss";
 


### PR DESCRIPTION
This is a rough proof of concept (the code is mostly copied from pretixcontrol, the custom select2 css from pretixcontrol has not been copied, I have no idea how necessary it is for presale) to add select2 features to single choice questions. This can be refined by only enabling select2 when there are more than a threshold number of choices or by having a setting to enable this on a per-question level (I don't see the harm having this on all the time though).

This uses the in-place version of select2 to gracefully fall back to a normal select with all options available should the user use a non-js client or a screen reader or similar. Even if the question has lots of choices (we regularly have more than 100) it should be efficient enough without requiring the dynamic/server-query based version of select2.

Fixes  #2020