### PR TITLE
Rework locking mechanism

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -658,12 +658,7 @@ class Event(EventMixin, LoggedModel):
         return ObjectRelatedCache(self)
 
     def lock(self):
-        """
-        Returns a contextmanager that can be used to lock an event for bookings.
-        """
-        from pretix.base.services import locking
-
-        return locking.LockManager(self)
+        raise NotImplementedError("this method has been removed")
 
     def get_mail_backend(self, timeout=None, force_custom=False):
         """

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -75,7 +75,6 @@ from pretix.base.email import get_email_context
 from pretix.base.i18n import language
 from pretix.base.models import Customer, User
 from pretix.base.reldate import RelativeDateWrapper
-from pretix.base.services.locking import LOCK_TIMEOUT, NoLockManager
 from pretix.base.settings import PERSON_NAME_SCHEMES
 from pretix.base.signals import order_gracefully_delete
 

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -57,7 +57,7 @@ from pretix.base.models.orders import OrderFee
 from pretix.base.models.tax import TAXED_ZERO, TaxedPrice, TaxRule
 from pretix.base.reldate import RelativeDateWrapper
 from pretix.base.services.checkin import _save_answers
-from pretix.base.services.locking import LockTimeoutException, NoLockManager
+from pretix.base.services.locking import lock_objects, LockTimeoutException
 from pretix.base.services.pricing import get_price
 from pretix.base.services.quotas import QuotaAvailability
 from pretix.base.services.tasks import ProfiledEventTask
@@ -887,7 +887,19 @@ class CartManager:
                     )
         return err
 
+    @transaction.atomic(durable=True)
     def _perform_operations(self):
+        full_lock_required = any(getattr(o, 'seat', False) for o in self._operations) and self.event.settings.seating_minimal_distance > 0
+        if full_lock_required:
+            # We lock the entire event in this case since we don't want to deal with fine-granular locking
+            # in the case of seating distance enforcement
+            lock_objects([self.event])
+        else:
+            lock_objects(
+                [q for q, d in self._quota_diff.items() if q.size is not None and d > 0] +
+                [v for v, d in self._voucher_use_diff.items() if d > 0] +
+                [getattr(o, 'seat', False) for o in self._operations if getattr(o, 'seat', False)]
+            )
         vouchers_ok = self._get_voucher_availability()
         quotas_ok = self._get_quota_availability()
         err = None
@@ -1064,20 +1076,6 @@ class CartManager:
         CartPosition.objects.bulk_create([p for p in new_cart_positions if not getattr(p, '_answers', None) and not p.pk])
         return err
 
-    def _require_locking(self):
-        if self._voucher_use_diff:
-            # If any vouchers are used, we lock to make sure we don't redeem them to often
-            return True
-
-        if self._quota_diff and any(q.size is not None for q in self._quota_diff):
-            # If any quotas are affected that are not unlimited, we lock
-            return True
-
-        if any(getattr(o, 'seat', False) for o in self._operations):
-            return True
-
-        return False
-
     def commit(self):
         self._check_presale_dates()
         self._check_max_cart_size()
@@ -1085,19 +1083,13 @@ class CartManager:
 
         err = self._delete_out_of_timeframe()
         err = self.extend_expired_positions() or err
+        self.now_dt = now()
 
-        lockfn = NoLockManager
-        if self._require_locking():
-            lockfn = self.event.lock
+        self._extend_expiry_of_valid_existing_positions()
+        err = self._perform_operations() or err
 
-        with lockfn() as now_dt:
-            with transaction.atomic():
-                self.now_dt = now_dt
-                self._extend_expiry_of_valid_existing_positions()
-                err = self._perform_operations() or err
-
-            if err:
-                raise CartError(err)
+        if err:
+            raise CartError(err)
 
 
 def update_tax_rates(event: Event, cart_id: str, invoice_address: InvoiceAddress):

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -31,10 +31,10 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the Apache License 2.0 is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
-
 from collections import Counter, defaultdict, namedtuple
 from datetime import datetime, time, timedelta
 from decimal import Decimal
+from time import sleep
 from typing import List, Optional
 
 from celery.exceptions import MaxRetriesExceededError
@@ -68,6 +68,7 @@ from pretix.celery_app import app
 from pretix.presale.signals import (
     checkout_confirm_messages, fee_calculation_for_cart,
 )
+from pretix.testutils.middleware import storage as debug_storage
 
 
 class CartError(Exception):
@@ -897,6 +898,9 @@ class CartManager:
         self._operations.sort(key=lambda a: self.order[type(a)])
         seats_seen = set()
 
+        if 'sleep-after-quota-check' in debug_storage.debugflags:
+            sleep(2)
+
         for iop, op in enumerate(self._operations):
             if isinstance(op, self.RemoveOperation):
                 if op.position.expires > self.now_dt:
@@ -1091,6 +1095,7 @@ class CartManager:
                 self.now_dt = now_dt
                 self._extend_expiry_of_valid_existing_positions()
                 err = self._perform_operations() or err
+
             if err:
                 raise CartError(err)
 

--- a/src/pretix/base/services/locking.py
+++ b/src/pretix/base/services/locking.py
@@ -59,7 +59,7 @@ def pg_lock_key(obj):
     if not keyspace:
         raise ValueError(f"No key space defined for locking objects of type {type(obj)}")
     assert isinstance(objectid, int)
-    key = objectid << 10 & keyspace
+    key = (objectid << 10) | keyspace
     return key
 
 

--- a/src/pretix/base/services/locking.py
+++ b/src/pretix/base/services/locking.py
@@ -42,6 +42,7 @@ from django.db import transaction
 from django.utils.timezone import now
 
 from pretix.base.models import EventLock
+from pretix.testutils.middleware import storage as debug_storage
 
 logger = logging.getLogger('pretix.base.locking')
 LOCK_TIMEOUT = 120
@@ -91,6 +92,8 @@ def lock_event(event):
     """
     if hasattr(event, '_lock') and event._lock:
         return True
+    if 'skip-locking' in debug_storage.debugflags:
+        return True
 
     if settings.HAS_REDIS:
         return lock_event_redis(event)
@@ -106,6 +109,8 @@ def release_event(event):
 
     :raises LockReleaseException: if we do not own the lock
     """
+    if 'skip-locking' in debug_storage.debugflags:
+        return True
     if not hasattr(event, '_lock') or not event._lock:
         raise LockReleaseException('Lock is not owned by this thread')
     if settings.HAS_REDIS:

--- a/src/pretix/base/services/locking.py
+++ b/src/pretix/base/services/locking.py
@@ -33,19 +33,59 @@
 # License for the specific language governing permissions and limitations under the License.
 
 import logging
-import time
-import uuid
-from datetime import timedelta
+from itertools import groupby
 
 from django.conf import settings
-from django.db import transaction
+from django.db import connection, DatabaseError
 from django.utils.timezone import now
 
-from pretix.base.models import EventLock
+from pretix.base.models import Event, Seat, Quota, Voucher, Membership
 from pretix.testutils.middleware import storage as debug_storage
 
 logger = logging.getLogger('pretix.base.locking')
-LOCK_TIMEOUT = 120
+LOCK_ACQUISITION_TIMEOUT = 3
+KEY_SPACES = {
+    Event: 1,
+    Quota: 2,
+    Seat: 3,
+    Voucher: 4,
+    Membership: 5
+}
+
+
+def pg_lock_key(obj):
+    keyspace = KEY_SPACES.get(type(obj))
+    objectid = obj.pk
+    if not keyspace:
+        raise ValueError(f"No key space defined for locking objects of type {type(obj)}")
+    assert isinstance(objectid, int)
+    key = objectid << 10 & keyspace
+    return key
+
+
+class LockTimeoutException(Exception):
+    pass
+
+
+def lock_objects(objects):
+    if not objects or 'skip-locking' in debug_storage.debugflags:
+        return
+    if not connection.in_atomic_block:
+        raise RuntimeError(
+            "You cannot create locks outside of an transaction"
+        )
+    if 'postgresql' in settings.DATABASES['default']['ENGINE']:
+        keys = sorted([pg_lock_key(obj) for obj in objects])
+        calls = ", ".join([f"pg_advisory_xact_lock({k})" for k in keys])
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"SET LOCAL lock_timeout = '{LOCK_ACQUISITION_TIMEOUT}s';")
+                cursor.execute(f"SELECT {calls};")
+        except DatabaseError:
+            raise LockTimeoutException()
+    else:
+        for model, instances in groupby(objects, key=lambda o: type(o)):
+            model.objects.select_for_update().get(pk__in=[o.pk for o in instances])
 
 
 class NoLockManager:
@@ -58,132 +98,3 @@ class NoLockManager:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None:
             return False
-
-
-class LockManager:
-    def __init__(self, event):
-        self.event = event
-
-    def __enter__(self):
-        lock_event(self.event)
-        return now()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        release_event(self.event)
-        if exc_type is not None:
-            return False
-
-
-class LockTimeoutException(Exception):
-    pass
-
-
-class LockReleaseException(Exception):
-    pass
-
-
-def lock_event(event):
-    """
-    Issue a lock on this event so nobody can book tickets for this event until
-    you release the lock. Will retry 5 times on failure.
-
-    :raises LockTimeoutException: if the event is locked every time we try
-                                  to obtain the lock
-    """
-    if hasattr(event, '_lock') and event._lock:
-        return True
-    if 'skip-locking' in debug_storage.debugflags:
-        return True
-
-    if settings.HAS_REDIS:
-        return lock_event_redis(event)
-    else:
-        return lock_event_db(event)
-
-
-def release_event(event):
-    """
-    Release a lock placed by :py:meth:`lock()`. If the parameter force is not set to ``True``,
-    the lock will only be released if it was issued in _this_ python
-    representation of the database object.
-
-    :raises LockReleaseException: if we do not own the lock
-    """
-    if 'skip-locking' in debug_storage.debugflags:
-        return True
-    if not hasattr(event, '_lock') or not event._lock:
-        raise LockReleaseException('Lock is not owned by this thread')
-    if settings.HAS_REDIS:
-        return release_event_redis(event)
-    else:
-        return release_event_db(event)
-
-
-def lock_event_db(event):
-    retries = 5
-    for i in range(retries):
-        with transaction.atomic():
-            dt = now()
-            l, created = EventLock.objects.get_or_create(event=event.id)
-            if created:
-                event._lock = l
-                return True
-            elif l.date < now() - timedelta(seconds=LOCK_TIMEOUT):
-                newtoken = str(uuid.uuid4())
-                updated = EventLock.objects.filter(event=event.id, token=l.token).update(date=dt, token=newtoken)
-                if updated:
-                    l.token = newtoken
-                    event._lock = l
-                    return True
-        time.sleep(2 ** i / 100)
-    raise LockTimeoutException()
-
-
-@transaction.atomic
-def release_event_db(event):
-    if not hasattr(event, '_lock') or not event._lock:
-        raise LockReleaseException('Lock is not owned by this thread')
-    try:
-        lock = EventLock.objects.get(event=event.id, token=event._lock.token)
-        lock.delete()
-        event._lock = None
-    except EventLock.DoesNotExist:
-        raise LockReleaseException('Lock is no longer owned by this thread')
-
-
-def redis_lock_from_event(event):
-    from django_redis import get_redis_connection
-    from redis.lock import Lock
-
-    if not hasattr(event, '_lock') or not event._lock:
-        rc = get_redis_connection("redis")
-        event._lock = Lock(redis=rc, name='pretix_event_%s' % event.id, timeout=LOCK_TIMEOUT)
-    return event._lock
-
-
-def lock_event_redis(event):
-    from redis.exceptions import RedisError
-
-    lock = redis_lock_from_event(event)
-    retries = 5
-    for i in range(retries):
-        try:
-            if lock.acquire(False):
-                return True
-        except RedisError:
-            logger.exception('Error locking an event')
-            raise LockTimeoutException()
-        time.sleep(2 ** i / 100)
-    raise LockTimeoutException()
-
-
-def release_event_redis(event):
-    from redis import RedisError
-
-    lock = redis_lock_from_event(event)
-    try:
-        lock.release()
-    except RedisError:
-        logger.exception('Error releasing an event lock')
-        raise LockTimeoutException()
-    event._lock = None

--- a/src/pretix/base/services/quotas.py
+++ b/src/pretix/base/services/quotas.py
@@ -188,7 +188,7 @@ class QuotaAvailability:
             update[q.event_id].append(q)
 
         for eventid, quotas in update.items():
-            rc.hmset(f'quotas:{eventid}:availabilitycache', {
+            rc.hset(f'quotas:{eventid}:availabilitycache', mapping={
                 str(q.id): ",".join(
                     [str(i) for i in self.results[q]] +
                     [str(int(time.time()))]

--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -48,7 +48,7 @@ from django.utils import translation
 from django.utils.crypto import get_random_string
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.http import is_safe_url, url_has_allowed_host_and_scheme
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import now
 from django.utils.translation import gettext as _
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -82,7 +82,7 @@ except:
 class CartActionMixin:
 
     def get_next_url(self):
-        if "next" in self.request.GET and is_safe_url(self.request.GET.get("next"), allowed_hosts=None):
+        if "next" in self.request.GET and url_has_allowed_host_and_scheme(self.request.GET.get("next"), allowed_hosts=None):
             u = self.request.GET.get('next')
         else:
             kwargs = {}
@@ -105,7 +105,7 @@ class CartActionMixin:
         return self.get_next_url()
 
     def get_error_url(self):
-        if "next_error" in self.request.GET and is_safe_url(self.request.GET.get("next_error"), allowed_hosts=None):
+        if "next_error" in self.request.GET and url_has_allowed_host_and_scheme(self.request.GET.get("next_error"), allowed_hosts=None):
             u = self.request.GET.get('next_error')
             if '?' in u:
                 u += '&require_cookie=true'

--- a/src/pretix/testutils/middleware.py
+++ b/src/pretix/testutils/middleware.py
@@ -13,4 +13,8 @@ class DebugFlagMiddleware:
             storage.debugflags = request.GET.getlist('_debug_flag')
         else:
             storage.debugflags = []
+
+        if 'skip-csrf' in storage.debugflags:
+            request.csrf_processing_done = True
+
         return self.get_response(request)

--- a/src/pretix/testutils/middleware.py
+++ b/src/pretix/testutils/middleware.py
@@ -1,0 +1,16 @@
+import threading
+
+storage = threading.local()
+storage.debugflags = []
+
+
+class DebugFlagMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if '_debug_flag' in request.GET:
+            storage.debugflags = request.GET.getlist('_debug_flag')
+        else:
+            storage.debugflags = []
+        return self.get_response(request)

--- a/src/pretix/testutils/settings.py
+++ b/src/pretix/testutils/settings.py
@@ -69,16 +69,22 @@ CELERY_TASK_ALWAYS_EAGER = True
 # Don't use redis
 SESSION_ENGINE = "django.contrib.sessions.backends.db"
 HAS_REDIS = False
+ORIGINAL_CACHES = CACHES
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     }
 }
+
+# Set databases
 DATABASE_REPLICA = 'default'
+DATABASES['default']['CONN_MAX_AGE'] = 0
+DATABASES.pop('replica', None)
+
+MIDDLEWARE.insert(0, 'pretix.testutils.middleware.DebugFlagMiddleware')
+
 
 # Don't run migrations
-
-
 class DisableMigrations(object):
 
     def __contains__(self, item):

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -30,6 +30,8 @@ filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango40Warning:hijack
     ignore::django.utils.deprecation.RemovedInDjango40Warning:django_otp
     ignore::django.utils.deprecation.RemovedInDjango40Warning:compressor
+    ignore:teardown:pytest.PytestWarning
+    ignore:avoid running initialization queries:RuntimeWarning
 
 
 [coverage:run]

--- a/src/setup.py
+++ b/src/setup.py
@@ -233,6 +233,7 @@ setup(
     ],
     extras_require={
         'dev': [
+            'aiohttp==3.8.*',
             'coverage',
             'coveralls',
             'django-debug-toolbar==3.2.*',
@@ -243,6 +244,7 @@ setup(
             'potypo',
             'pycodestyle==2.5.*',
             'pyflakes>=2.1,<2.5',
+            'pytest-asyncio',
             'pytest-cache',
             'pytest-cov',
             'pytest-django==4.*',

--- a/src/tests/concurrency_tests/conftest.py
+++ b/src/tests/concurrency_tests/conftest.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+
+import pytest
+from django.utils.timezone import now
+from django_redis import get_redis_connection
+from django_scopes import scopes_disabled
+from pytz import UTC
+
+from pretix.base.models import Event, Item, Organizer, Quota
+
+
+@pytest.fixture(autouse=True)
+def autoskip(request, settings):
+    if 'redis' not in settings.ORIGINAL_CACHES:
+        pytest.skip("can only be run with redis")
+    if 'sqlite3' in settings.DATABASES['default']['ENGINE']:
+        pytest.skip("cannot be run on sqlite")
+    if not request.config.getvalue("reuse_db"):
+        pytest.skip("only works with --reuse-db due to some weird connection handling bug")
+
+
+@pytest.fixture(autouse=True)
+def cleared_redis(settings):
+    settings.HAS_REDIS = True
+    settings.CACHES = settings.ORIGINAL_CACHES
+    redis = get_redis_connection("redis")
+    redis.flushall()
+
+
+@pytest.fixture
+@scopes_disabled()
+def organizer():
+    return Organizer.objects.create(name='Dummy', slug='dummy')
+
+
+@pytest.fixture
+@scopes_disabled()
+def event(organizer):
+    e = Event.objects.create(
+        organizer=organizer, name='Dummy', slug='dummy',
+        date_from=datetime(2017, 12, 27, 10, 0, 0, tzinfo=UTC),
+        presale_end=now() + timedelta(days=300),
+        plugins='pretix.plugins.banktransfer,pretix.plugins.ticketoutputpdf',
+        is_public=True, live=True
+    )
+    e.item_meta_properties.create(name="day", default="Monday")
+    e.settings.timezone = 'Europe/Berlin'
+    return e
+
+
+@pytest.fixture
+@scopes_disabled()
+def item(event):
+    return Item.objects.create(
+        event=event,
+        name='Regular ticket',
+        default_price=0,
+    )
+
+
+@pytest.fixture
+@scopes_disabled()
+def quota(event, item):
+    q = Quota.objects.create(
+        event=event,
+        size=10,
+        name='Regular tickets'
+    )
+    q.items.add(item)
+    return q
+
+
+@pytest.fixture(name='live_server', scope='function')
+def _live_server(live_server):
+    # See https://github.com/pytest-dev/pytest-django/issues/454
+    return live_server

--- a/src/tests/concurrency_tests/test_cart_creation_locking.py
+++ b/src/tests/concurrency_tests/test_cart_creation_locking.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import aiohttp
+import pytest
+from asgiref.sync import sync_to_async
+from django_scopes import scopes_disabled
+from lxml import html
+
+from pretix.base.models import CartPosition
+
+
+@pytest.fixture
+async def session(live_server, event):
+    async with aiohttp.ClientSession() as session:
+        r = await session.get(
+            f"{live_server}/{event.organizer.slug}/{event.slug}/",
+        )
+        text = await r.text()
+        tree = html.fromstring(text)
+        csrftoken = tree.find('.//input[@name="csrfmiddlewaretoken"]').get('value')
+        yield session, csrftoken
+
+
+async def post(session, url, data):
+    async with session.post(url, data=data) as response:
+        return await response.text()
+
+
+@pytest.mark.asyncio
+async def test_quota_race_condition_happens_if_we_disable_locks(live_server, session, event, item, quota):
+    # This test exists to ensure that our test setup makes sense. If it fails, all tests down below
+    # might be useless.
+    session, csrftoken = session
+    quota.size = 1
+    await sync_to_async(quota.save)()
+
+    url = f"/{event.organizer.slug}/{event.slug}/cart/add?_debug_flag=skip-locking&_debug_flag=sleep-after-quota-check"
+    payload = {
+        f'item_{item.pk}': '1',
+        'csrfmiddlewaretoken': csrftoken,
+    }
+
+    r1, r2 = await asyncio.gather(
+        post(session, f"{live_server}{url}", data=payload),
+        post(session, f"{live_server}{url}", data=payload)
+    )
+    assert ['alert-success' in r1, 'alert-success' in r2].count(True) == 2
+    with scopes_disabled():
+        assert await sync_to_async(CartPosition.objects.filter(item=item).count)() == 2
+
+
+@pytest.mark.asyncio
+async def test_cart_race_condition_prevented_by_locks(live_server, session, event, item, quota):
+    session, csrftoken = session
+    quota.size = 1
+    await sync_to_async(quota.save)()
+
+    url = f"/{event.organizer.slug}/{event.slug}/cart/add?_debug_flag=sleep-after-quota-check"
+    payload = {
+        f'item_{item.pk}': '1',
+        'csrfmiddlewaretoken': csrftoken,
+    }
+
+    r1, r2 = await asyncio.gather(
+        post(session, f"{live_server}{url}", data=payload),
+        post(session, f"{live_server}{url}", data=payload)
+    )
+    assert ['alert-success' in r1, 'alert-success' in r2].count(True) == 1
+    with scopes_disabled():
+        assert await sync_to_async(CartPosition.objects.filter(item=item).count)() == 1


### PR DESCRIPTION
### Background

One of pretix's core objectives as a ticketing system could be described as the management of scarce
resources. Specifically, the following types of scarce-ness exist in pretix:

* Quotas can limit the number of tickets available
* Seats can only be booked once
* Vouchers can only be used a limited number of times
* Some memberships can only be used a limited number of times

For all of these, it is critical that we prevent race conditions. While for some events it wouldn't be a
big deal to sell a ticket more or less, for some it would be problematic and selling the same seat twice
would always be catastropic.

### Current approach

We currently use a locking mechanism utilizing redis. Basically, whenever you do some operation that
reduces quota, you have to write:

```
with event.lock():
    perform_change()
```

While being a very simple approach, there are a few important drawbacks. The obvious one is that it
limits throughput by a lot since no more than two changes can be handled at the same time **per event**.
This puts an upper limit on the number of tickets sold per event. Generally, every kind of locking will
give us some limitation on this. We've thought about locking that only kicks in if the event is about to
be sold out etc, but every approach so far had new important drawbacks.

However, even if we accept some limit on throughput, we can question the decision of an event-wide lock.
This choice was made in the early days of pretix when the alternative of a per-quota lock seemed pretty
complex. However, our most complex code paths (order management and cart management) today use a design
pattern ("quota diff") that make it very simple to predict which quotas will be affected.

The event-wide lock is especially problematic in the event series use case that has become more common
for pretix. There's absolutely no need to lock the entire event series when a ticket for a specific date
is being booked.

The other drawback is that it lives outside of the database's transaction management. This leads to
very non-obvious things you need to think about when working with the codebase. For example, it would
be dangerous to write

```
with transaction.atomic():
	with event.lock():
		check_quota()
		create_ticket()
	do_other_stuff()
```

If thread B is running ``check_quota()`` while thread A is still running ``do_other_stuff()``, thread B
will not yet see the ticket created by thread A and will think there are still more tickets available
than actually are. You always need to stack ``transaction.atomic()`` inside ``event.lock()``:


```
with event.lock():
	with transaction.atomic():
		check_quota()
		create_ticket()
		do_other_stuff()
```

This creates longer locking times and thus less overall througput, but that is likely unavoidable.

While our current codebase does this right in the most import places (CartManager, perform_order), we
also do it wrong in other places (OrderChangeManager). But even if you try to do it right, it can be
really hard -- what if ``with event.lock()`` is in an utility function that is called by a view which
might have already started a transaction? Ooops.
(Recent Django versions brought as ``transaction.atomic(durable=True)`` which we can use to at least fail loudly in this case.)

But if we already need to be this carefull synchronizing locks and database transactions and every lock
must be in place *at least* until the next `COMMIT` – why don't we use the database for locking in the
first place?

### New approach

Putting the locks on the database level allows us to make the transaction handling much easier. Theoretically,
you can imagine it like this:

```
with transaction.atomic(durable=True):
	quotas = Quota.objects.select_for_update().filter(...)
	check_quota(quotas)
	create_ticket()
	do_other_stuff()
```

The lock will automatically be released at the end of transaction. The database will also take care of cleaning
up the lock behind us if the transaction fails and is rolled back, we no longer need to deal with the case
of crashing workers ourselves.

Using row-level locks on the specific quotas also resolves the "problem" of event-wide locks and thus the event
series use case. For a seated event with unlimited quota we can even just skip the quota-level locks and only do
seat-level locks.

Actually using ``SELECT FOR UPDATE`` might be okay for vouchers, since we're actually going to update their
``redeemed`` attribute, but is otherwise not the best idea, since (a) we don't actually want to interfere with
admins updating the quota and (b) PostgreSQL writes row-level locks to disk, causing high write load and possibility
of table bloat etc.

Instead, we're using PostgreSQL's amazing feature of [advisory locks](https://www.postgresql.org/docs/11/explicit-locking.html#ADVISORY-LOCKS)
which are handled in-memory.
There is no equivalent on MariaDB/MySQL, so on these databases we will need to actually ``SELECT FOR UPDATE``.
Since PostgreSQL is our recommended database and we want users to move off MariaDB/MySQL in the long run, I don't
really care about the performance impact there, as long as it *works*.

(As an interesting side note, we *need* the database to run in  ``READ COMMITTED`` isolation mode, which is also
the default. If you'd use the -- seemingly better -- isolation mode ``REPEATABLE READ``, we could not prevent
the knowb race conditions.)

### Testing

As a first step to implementing this, I created a way to run automated tests that provoke race conditions. For this purpose
I've injected a mechanism of "debug flags" that trigger behaviour like artificial wait times in some strategic places in the
code base. Then, the test suite runs a live server and submits multiple HTTP requests at the same time and tries to get the
server to sell too many tickets.

The test setup is slow and a little bit fragile, so we should not consider this part of our standard test suite, but maybe
we find a stable way to run them on the CI or at least run them before releases etc.

To run the tests locally, first create a new config file referencing your PostgreSQL and redis servers.
Note that the redis database will be cleared by the tests:

```
[database]
backend=postgresql
name=pretix_tests
user=raphael
password=pretix
host=::1
port=5432

[redis]
location=redis://127.0.0.1:6379/7
sessions=false
```

Then, run the tests like this:

```
PRETIX_CONFIG_FILE=pretix_postgres_tests.cfg py.test tests/concurrency_tests/ --reruns 0 --reuse-db
```

Due to some bug in the testing stack, this will leave a test database around that you need to wipe before you can run the
tests again:
```
dropdb test_pretix_tests
```

### Performance

To verify this has positive performance impact I've set up a beefy pretix cluster so we're not limited
by any computation resources but only by the locking mechanism. To ease implementation I've only ran the
load test on the ``/cart/add`` endpoint, unlike previous load tests where we tested the entire ordering
process. However, ``/cart/add`` is by far the most important part, since we don't care about the performance
of template rendering, email sending, etc for this case and in the regular case we only requie a lock
at cart creation time, not at order time (if the cart is still valid).

The sample cart consisted of one product which was affected by one quota (1 lock).

As a baseline, I first ran the test on the master branch (7a4db8ea2). The maximum result was 877 operations
per minute, but 30-50 % of requests yielded in a user-visible error due to a lock acquisition timeout:

```
    200 virtual users in 8 workers for 120s
	OK: 1754 / ERR: 988.

	400 virtual users in 8 workers for 120s
	OK: 1703 / ERR: 1580.

	600 virtual users in 8 workers for 120s
	OK: 1619 / ERR: 1555.
```

Then, I ran the same tests on the patched commit 362d8222c. The throughput was up to 31% higher with 1159
operations per minute, and there were almost no errors at all:

```
    200 virtual users in 8 workers for 120s
	OK: 2299 / ERR: 0.

	400 virtual users in 8 workers for 120s
	OK: 2165 / ERR: 0.

	600 virtual users in 8 workers for 120s
	OK: 2085 / ERR: 0.
```

Note that we likely could tune the number of errors in both cases by playing with lock acquisition timeouts,
but it's still an impressive results.

Then, I created additional quotas that affect the product, leading to 10 and then 20 locks acquired per request.
The throughput unfortunately decreased significantly, so the cost of the individual locks seems to be significant:

```
	200 virtual users in 8 workers for 120s but with 10 locks per request
	OK: 1900 / ERR: 0.

	200 virtual users in 8 workers for 120s but with 20 locks per request
	OK: 1518 / ERR: 0.
```

This means this might be a performance downgrade for events with very complex setups of for people buying many tickets
at once.

However, I've verified that this only impacts the locked objects, not other ones. For this, I've cloned the event twice
and ran the last load test in parallel on all three events -- with the same result as above.

### Open questions

* How do we deal with locking if the "minimum distance between used seats" is used? This would sometimes require
  locking a large number of seats. We might want to fall back to event-level locks in this scenario.

* One of the relevant functions is ``OrderPayment.confirm()``. However, this one is called from lots and lots of plugin
  code of different structure and quality. Some of this plugin code (a) already requires durable transactions and locking
  mechanisms to deal with other race conditions and (b) runs for a long time since it makes external API calls. We need to
  audit this code and figure out if there is a way to be safe and quick at the same time here.

* We're currently inconsistent with when we call plugin hooks. For example, ``order_placed`` is called after ``COMMIT`` but
  before we release the lock (which would no longer be possible) while ``order_paid`` is called after we released the lock.
  Do we know of any plugins relying on this behaviour or can we change it? How do we want to change it?

### Risks

* There is an upper limit of the number of locks a PostgreSQL cluster can store at the same time which is given by
  ``max_locks_per_transaction * (max_connections + max_prepared_transactions)``. We might need to increase 
  ``max_locks_per_transaction`` beyond its default of 64 if we expect lots of large carts.

* There is the above-mentioned risk of a performance degradation for large carts with seats or non-homogenous products.

* There is a risk of [deadlocks](https://www.postgresql.org/docs/11/explicit-locking.html#LOCKING-DEADLOCKS) which can be avoided
  by creating all locks in the same order. The current patch ensures that, as long as there is only one lock function call per
  transaction (which is unfortunate, since it would be great to be able calling the function multiple times safely, but we can live
  with that).

* There is a risk of connection starvation, i.e. almost all of our database connections waiting to acquire a lock and not being
  able to answer unrelated requests. As we currently use one database connection per Django thread, this is not so different from
  the current behaviour, but in a setup that uses pgBouncer (as one probably should) it might be a problem. We can limit the impact
  by setting  ``lock_timeout`` before we try to acquire locks and have the client retry to mix things up a little bit.

### Todo list

- [ ] Verify approach on MariaDB
- [ ] Run tests on CI
- [ ] CartManager
  - [x] locking
  - [x] tests with quota
  - [ ] tests with seat
  - [ ] tests with voucher
- [ ] perform_order
  - [ ] locking
  - [ ] tests
  - [ ] tests with quota
  - [ ] tests with seat
  - [ ] tests with voucher
  - [ ] tests with membership
- [ ] reactivate_order
  - [ ] locking
  - [ ] tests
- [ ] extend_order
  - [ ] locking
  - [ ] tests
- [ ] mark_order_expired
  - [ ] locking
  - [ ] tests
- [ ] deny_order
  - [ ] remove locking
- [ ] cancel_order
  - [ ] remove locking
- [ ] OrderChangeManager
  - [ ] locking
  - [ ] tests
- [ ] OrderPayment.confirm
  - [ ] locking
  - [ ] tests
- [ ] Waiting list assign_automatically
  - [ ] locking
  - [ ] tests
- [ ] Voucher (bulk) creation
  - [ ] locking
  - [ ] tests
- [ ] Voucher update
  - [ ] locking
  - [ ] tests
- [ ] Order import
  - [ ] locking
  - [ ] tests
- [ ] API: Create order
  - [ ] locking
  - [ ] tests
- [ ] API: Create cart position
  - [ ] locking
  - [ ] tests
- [ ] API: Create voucher
  - [ ] locking
  - [ ] tests
- [ ] API: Update voucher
  - [ ] locking
  - [ ] tests
- [ ] API: Bulk-create voucher
  - [ ] locking
  - [ ] tests
- [ ] Plugin: Offline Sales
  - [ ] locking
  - [ ] tests
- [ ] Seat radius blocking?
- [ ] handling of order and cart expiry times?
- [ ] Invoice numbering might also need locks? → separate PR

