### PR TITLE
Improve add-to-cart checkbox for items with max. 1 per order (Z#178704)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -182,7 +182,8 @@
                                                        {% if not ev.presale_is_running %}disabled{% endif %}
                                                        id="variation_{{ item.id }}_{{ var.id }}"
                                                        name="variation_{{ item.id }}_{{ var.id }}"
-                                                       title="{% blocktrans with item=item.name var=var.name %}Do you want to order {{ item }}, {{ var }}?{% endblocktrans %}">
+                                                       aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
+                                                       {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
                                                <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
                                             </label>
                                         {% else %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -179,7 +179,9 @@
 										{% if var.order_max == 1 %}
                                             <label class="item-checkbox-label">
                                                 <input type="checkbox" value="1"
+                                                    {% if item.free_price %}
                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                    {% endif %}
                                                        {% if not ev.presale_is_running %}disabled{% endif %}
                                                        id="variation_{{ item.id }}_{{ var.id }}"
                                                        name="variation_{{ item.id }}_{{ var.id }}"
@@ -306,7 +308,9 @@
 							{% if item.order_max == 1 %}
                                 <label class="item-checkbox-label">
                                     <input type="checkbox" value="1" {% if itemnum == 1 %}checked{% endif %}
+                                        {% if item.free_price %}
                                            data-checked-onchange="price-item-{{ item.pk }}"
+                                        {% endif %}
                                            {% if not ev.presale_is_running %}disabled{% endif %}
                                            name="item_{{ item.id }}" id="item_{{ item.id }}"
                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -183,6 +183,7 @@
                                                        id="variation_{{ item.id }}_{{ var.id }}"
                                                        name="variation_{{ item.id }}_{{ var.id }}"
                                                        title="{% blocktrans with item=item.name var=var.name %}Do you want to order {{ item }}, {{ var }}?{% endblocktrans %}">
+                                               <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
                                             </label>
                                         {% else %}
                                             <input type="number" class="form-control input-item-count" placeholder="0" min="0"
@@ -307,6 +308,7 @@
                                            name="item_{{ item.id }}" id="item_{{ item.id }}"
                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
+                                           <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
                                 </label>
                             {% else %}
                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -179,6 +179,7 @@
 										{% if var.order_max == 1 %}
                                             <label class="item-checkbox-label">
                                                 <input type="checkbox" value="1"
+                                                       data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
                                                        {% if not ev.presale_is_running %}disabled{% endif %}
                                                        id="variation_{{ item.id }}_{{ var.id }}"
                                                        name="variation_{{ item.id }}_{{ var.id }}"
@@ -305,6 +306,7 @@
 							{% if item.order_max == 1 %}
                                 <label class="item-checkbox-label">
                                     <input type="checkbox" value="1" {% if itemnum == 1 %}checked{% endif %}
+                                           data-checked-onchange="price-item-{{ item.pk }}"
                                            {% if not ev.presale_is_running %}disabled{% endif %}
                                            name="item_{{ item.id }}" id="item_{{ item.id }}"
                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -174,7 +174,7 @@
                                     <div class="col-md-2 col-xs-6 availability-box unavailable">
                                         <p><small><a href="#voucher">{% trans "Enter a voucher code below to buy this ticket." %}</a></small></p>
                                     </div>
-                                    {% elif var.cached_availability.0 == 100 %}
+                                {% elif var.cached_availability.0 == 100 %}
                                     <div class="col-md-2 col-xs-6 availability-box available">
 										{% if var.order_max == 1 %}
                                             <label class="item-checkbox-label">

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -636,13 +636,11 @@ $(function () {
     lightbox.init();
 
     // free-range price input auto-check checkbox
-    $(".input-item-price").each(function() {
-        var input = document.getElementById("item_" + this.id.substr("price-item-".length));
-        if (input && input.type == "checkbox") {
-            $(this).on("change", function() {
-                input.checked = true;
-            });
-        }
+    $("[data-checked-onchange]").each(function() {
+        var checkbox = this;
+        $("#" + this.getAttribute("data-checked-onchange")).on("change", function() {
+            checkbox.checked = true;
+        });
     });
 });
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -634,6 +634,16 @@ $(function () {
 
     // Lightbox
     lightbox.init();
+
+    // free-range price input auto-check checkbox
+    $(".input-item-price").each(function() {
+        var input = document.getElementById("item_" + this.id.substr("price-item-".length));
+        if (input && input.type == "checkbox") {
+            $(this).on("change", function() {
+                input.checked = true;
+            });
+        }
+    });
 });
 
 function copy_answers(elements, answers) {

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -31,6 +31,7 @@
     }
     .item-checkbox-label {
         display: block;
+        margin-top: .4em;
     }
 
     .product-description.with-picture {


### PR DESCRIPTION
When having products with a max. quantity of one per order, we render a checkbox instead of a number-input to mark an item to be added to the cart. This checkbox on its own can easily be overlooked, especially combined with a free-price input next to it.

This PR adds an auto-check to the checkbox, when the free-price input is changed as well adds an icon next to the checkbox.