### PR TITLE
Add Organizer-Attribute to ical

### DIFF
--- a/src/pretix/presale/ical.py
+++ b/src/pretix/presale/ical.py
@@ -48,6 +48,11 @@ def get_ical(events):
             })
 
         vevent = cal.add('vevent')
+        vevent.add('organizer')
+        vevent.organizer.value = 'mailto:{organizermail}'.format(
+            organizermail=event.settings.get('contact_mail', settings.MAIL_FROM)
+        )
+        vevent.organizer.cn_param = str(event.organizer.name)
         vevent.add('summary').value = str(ev.name)
         vevent.add('dtstamp').value = creation_time
         if ev.location:


### PR DESCRIPTION
Z#2392882

Since this apparently a rather new addition to the ical-standard, one could argue that we should leave the cleartext-mention of the organizer in the event-description intact.