### PR TITLE
Fix #2434 -- Disallow manually setting SecretKeySettingsField to *****

### DIFF
--- a/src/pretix/base/forms/__init__.py
+++ b/src/pretix/base/forms/__init__.py
@@ -115,7 +115,7 @@ class SettingsForm(i18nfield.forms.I18nFormMixin, HierarkeyForm):
     def save(self):
         for k, v in self.cleaned_data.items():
             if isinstance(self.fields.get(k), SecretKeySettingsField) and self.cleaned_data.get(k) == SECRET_REDACTED:
-                self.cleaned_data[k] = self.initial[k] if k in self.initial else ""
+                self.cleaned_data[k] = self.initial[k]
         return super().save()
 
     def clean(self):

--- a/src/pretix/base/forms/__init__.py
+++ b/src/pretix/base/forms/__init__.py
@@ -38,6 +38,7 @@ import i18nfield.forms
 from django import forms
 from django.forms.models import ModelFormMetaclass
 from django.utils.crypto import get_random_string
+from django.utils.translation import gettext_lazy as _
 from formtools.wizard.views import SessionWizardView
 from hierarkey.forms import HierarkeyForm
 
@@ -128,6 +129,9 @@ class SettingsForm(i18nfield.forms.I18nFormMixin, HierarkeyForm):
         # at all, it will be considered a changed value and stored. We do not want that, as it makes it very hard to add
         # languages to an organizer/event later on. So we trick it and make sure nothing gets changed in that situation.
         for name, field in self.fields.items():
+            if isinstance(field, SecretKeySettingsField) and d.get(name) == SECRET_REDACTED and not self.initial.get(name):
+                self.add_error(name, _('Due to technical reasons you cannot set inputs, that need to be masked (e.g. passwords), to %(value)s.') % {'value': SECRET_REDACTED})
+
             if isinstance(field, i18nfield.forms.I18nFormField):
                 value = d.get(name)
                 if not value:

--- a/src/pretix/base/forms/__init__.py
+++ b/src/pretix/base/forms/__init__.py
@@ -115,7 +115,7 @@ class SettingsForm(i18nfield.forms.I18nFormMixin, HierarkeyForm):
     def save(self):
         for k, v in self.cleaned_data.items():
             if isinstance(self.fields.get(k), SecretKeySettingsField) and self.cleaned_data.get(k) == SECRET_REDACTED:
-                self.cleaned_data[k] = self.initial[k]
+                self.cleaned_data[k] = self.initial[k] if k in self.initial else ""
         return super().save()
 
     def clean(self):

--- a/src/pretix/base/forms/__init__.py
+++ b/src/pretix/base/forms/__init__.py
@@ -130,7 +130,10 @@ class SettingsForm(i18nfield.forms.I18nFormMixin, HierarkeyForm):
         # languages to an organizer/event later on. So we trick it and make sure nothing gets changed in that situation.
         for name, field in self.fields.items():
             if isinstance(field, SecretKeySettingsField) and d.get(name) == SECRET_REDACTED and not self.initial.get(name):
-                self.add_error(name, _('Due to technical reasons you cannot set inputs, that need to be masked (e.g. passwords), to %(value)s.') % {'value': SECRET_REDACTED})
+                self.add_error(
+                    name,
+                    _('Due to technical reasons you cannot set inputs, that need to be masked (e.g. passwords), to %(value)s.') % {'value': SECRET_REDACTED}
+                )
 
             if isinstance(field, i18nfield.forms.I18nFormField):
                 value = d.get(name)


### PR DESCRIPTION
When entering `*****` in a SecretKeySettingsField pretix will throw an error when no initial value is set for that SecretKeySettingsField.