### PR TITLE
Make template tag getitem not fail if field does not exist

### DIFF
--- a/src/pretix/control/templatetags/getitem.py
+++ b/src/pretix/control/templatetags/getitem.py
@@ -29,4 +29,7 @@ def getitem_filter(value, itemname):
     if not value:
         return ''
 
+    if itemname not in value:
+        return ''
+
     return value[itemname]


### PR DESCRIPTION
Tiny change for the `getitem` template tag to not come down crashing if the requested key is not in the dictionary.

For current usage this change should not have any adverse effects, for new developments this brings adds the possibility of chaining the `|getitem` with `|default`.