### PR TITLE
Fix guard in mail service

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -579,7 +579,7 @@ def mail_send_task(self, *args, to: List[str], subject: str, body: str, html: st
                             }
                         )
                     raise e
-            if logger:
+            if log_target:
                 log_target.log_action(
                     'pretix.email.error',
                     data={


### PR DESCRIPTION
I'm guessing this is a typo as `logger` is not used in the condition body.