### PR TITLE
Fix #2449 -- Format variation-price with Intl.NumberFormat

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -14,6 +14,26 @@ function ngettext(singular, plural, count) {
     return plural;
 }
 
+function formatPrice(price, currency, locale) {
+    if (!window.Intl || !Intl.NumberFormat) return price;
+    if (isNaN(price) && price.replace) {
+        price = price.replace(".", "").replace(",", ".")
+    }
+
+    if (currency === undefined) {
+        currency = $("[data-currency]").data("currency")
+    }
+    if (locale === undefined) {
+        locale = $("[data-locale]").data("locale") || $("[data-pretixlocale]").data("pretixlocale");
+    }
+    var opt = currency ? {style: "currency", currency: currency} : null;
+    try {
+        return new Intl.NumberFormat(locale, opt).format(price)
+    } catch (error) {
+        return price
+    }
+}
+
 var waitingDialog = {
     show: function (message) {
         "use strict";

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -17,7 +17,10 @@ function ngettext(singular, plural, count) {
 function formatPrice(price, currency, locale) {
     if (!window.Intl || !Intl.NumberFormat) return price;
     if (isNaN(price) && price.replace) {
-        price = price.replace(".", "").replace(",", ".")
+        price = price.replace(/\s/g, "")
+        if (price.indexOf(",") > -1) {
+            price = price.replace(/\./g, "").replace(",", ".")
+        }
     }
 
     if (currency === undefined) {

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -38,7 +38,7 @@ function formatPrice(price, currency, locale) {
         // to hopefully get a parsable number
         nf.formatToParts(1234.567).forEach(function(part) {
             if (replacements.hasOwnProperty(part.type)) {
-                priceToFormat = priceToFormat.replaceAll(part.value, replacements[part.key])
+                priceToFormat = priceToFormat.replaceAll(part.value, replacements[part.type])
             }
         });
         if (isNaN(priceToFormat)) return price

--- a/src/pretix/static/pretixcontrol/js/ui/variations.js
+++ b/src/pretix/static/pretixcontrol/js/ui/variations.js
@@ -8,7 +8,13 @@ $(function () {
     function update_variation_summary($el) {
         var var_name = $el.find("input[name*=-value_]").filter(function () {return !!this.value}).first().val();
         var price = $el.find("input[name*=-default_price]").val();
-
+        if (price && window.Intl && Intl.NumberFormat) {
+            var locale = $("[data-pretixlocale]").data("pretixlocale");
+            var currency = $el.find("[name*=-default_price] + .input-group-addon").text();
+            try {
+                price = new Intl.NumberFormat(locale, { style: 'currency', currency: currency}).format(price)
+            } catch (error) {}
+        }
 
         $el.find(".variation-name").text(var_name);
         $el.find(".variation-price").text(price);

--- a/src/pretix/static/pretixcontrol/js/ui/variations.js
+++ b/src/pretix/static/pretixcontrol/js/ui/variations.js
@@ -1,4 +1,4 @@
-/*global $, Morris, gettext*/
+/*global $, Morris, gettext, formatPrice*/
 $(function () {
     // Question view
     if (!$("#item_variations").length) {
@@ -8,12 +8,9 @@ $(function () {
     function update_variation_summary($el) {
         var var_name = $el.find("input[name*=-value_]").filter(function () {return !!this.value}).first().val();
         var price = $el.find("input[name*=-default_price]").val();
-        if (price && window.Intl && Intl.NumberFormat) {
-            var locale = $("[data-pretixlocale]").data("pretixlocale");
+        if (price) {
             var currency = $el.find("[name*=-default_price] + .input-group-addon").text();
-            try {
-                price = new Intl.NumberFormat(locale, { style: 'currency', currency: currency}).format(price)
-            } catch (error) {}
+            price = formatPrice(price, currency);
         }
 
         $el.find(".variation-name").text(var_name);


### PR DESCRIPTION
If Intl.NumberFormat is available, try to format price with locale and currency – all in try-block, in case formatting fails due to unknown currency or locale.