### PR TITLE
Fix #2452 -- Disallow invalid values in min_per_order/max_per_order

### DIFF
--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -44,7 +44,7 @@ import dateutil.parser
 import pytz
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
+from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import Q
 from django.utils import formats
@@ -479,12 +479,14 @@ class Item(LoggedModel):
     min_per_order = models.IntegerField(
         verbose_name=_('Minimum amount per order'),
         null=True, blank=True,
+        validators=[MinValueValidator(0)],
         help_text=_('This product can only be bought if it is added to the cart at least this many times. If you keep '
                     'the field empty or set it to 0, there is no special limit for this product.')
     )
     max_per_order = models.IntegerField(
         verbose_name=_('Maximum amount per order'),
         null=True, blank=True,
+        validators=[MinValueValidator(0)],
         help_text=_('This product can only be bought at most this many times within one order. If you keep the field '
                     'empty or set it to 0, there is no special limit for this product. The limit for the maximum '
                     'number of items in the whole order applies regardless.')

--- a/src/pretix/control/forms/item.py
+++ b/src/pretix/control/forms/item.py
@@ -628,8 +628,8 @@ class ItemUpdateForm(I18nModelForm):
             }),
             'generate_tickets': TicketNullBooleanSelect(),
             'show_quota_left': ShowQuotaNullBooleanSelect(),
-            'max_per_order': forms.widgets.NumberInput(attrs={'min':0}),
-            'min_per_order': forms.widgets.NumberInput(attrs={'min':0}),
+            'max_per_order': forms.widgets.NumberInput(attrs={'min': 0}),
+            'min_per_order': forms.widgets.NumberInput(attrs={'min': 0}),
         }
 
 

--- a/src/pretix/control/forms/item.py
+++ b/src/pretix/control/forms/item.py
@@ -627,7 +627,9 @@ class ItemUpdateForm(I18nModelForm):
                 'class': 'scrolling-multiple-choice'
             }),
             'generate_tickets': TicketNullBooleanSelect(),
-            'show_quota_left': ShowQuotaNullBooleanSelect()
+            'show_quota_left': ShowQuotaNullBooleanSelect(),
+            'max_per_order': forms.widgets.NumberInput(attrs={'min':0}),
+            'min_per_order': forms.widgets.NumberInput(attrs={'min':0}),
         }
 
 


### PR DESCRIPTION
This fixes a bug where min_per_order/max_per_order on an item can be set < 0. The fix is in the widget, alternatively we might migrate from `models.IntegerField` to `models.PositiveIntegerField`.