### PR TITLE
Localize customer name_parts in email-context (Z#179923)

### DIFF
--- a/src/pretix/base/models/customers.py
+++ b/src/pretix/base/models/customers.py
@@ -177,10 +177,11 @@ class Customer(LoggedModel):
             'organizer': self.organizer.name,
         }
         name_scheme = PERSON_NAME_SCHEMES[self.organizer.settings.name_scheme]
+        from pretix.base.email import get_name_parts_localized
         for f, l, w in name_scheme['fields']:
             if f == 'full_name':
                 continue
-            ctx['name_%s' % f] = self.name_parts.get(f, '')
+            ctx['name_%s' % f] = get_name_parts_localized(self.name_parts, f)
         return ctx
 
     @property

--- a/src/pretix/base/models/customers.py
+++ b/src/pretix/base/models/customers.py
@@ -172,12 +172,12 @@ class Customer(LoggedModel):
         return salted_hmac(key_salt, payload).hexdigest()
 
     def get_email_context(self):
+        from pretix.base.email import get_name_parts_localized
         ctx = {
             'name': self.name,
             'organizer': self.organizer.name,
         }
         name_scheme = PERSON_NAME_SCHEMES[self.organizer.settings.name_scheme]
-        from pretix.base.email import get_name_parts_localized
         for f, l, w in name_scheme['fields']:
             if f == 'full_name':
                 continue


### PR DESCRIPTION
Due to a circular reference, I cannot import `from pretix.base.email import get_name_parts_localized` in the header area but had to import in the method `get_email_context`. Any other idea?