### PR TITLE
Fix details/summary marker on privacy-modal being shown twice

### DIFF
--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -220,10 +220,11 @@ body.loading .container {
         }
         details {
             & > summary {
-                list-style: inherit;
+                list-style: none;
             }
-            & > summary::-webkit-details-marker {
-                display: inherit;
+            & > summary::-webkit-details-marker,
+            & > summary::marker {
+                display: none;
             }
             margin-bottom: 10px;
         }


### PR DESCRIPTION
At least on Safari the details/summary in privacy-modal show the marker/chevron twice. This PR updates the CSS to always hide it.

![Bildschirmfoto 2022-02-22 um 13 46 19](https://user-images.githubusercontent.com/276509/155135739-502cd991-c0d0-4948-a846-1c600a43214d.png)

