### PR TITLE
Group identical add-ons in cart

### DIFF
--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -177,7 +177,7 @@ class TemplateBasedMailRenderer(BaseHTMLMailRenderer):
                     op.variation,
                     op.subevent,
                     op.attendee_name,
-                    (op.pk if op.addon_to_id else None),
+                    op.addon_to_id,
                     (op.pk if op.has_addons else None)
                 )
             )]

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -1330,6 +1330,10 @@ class AbstractPosition(models.Model):
         else:
             return {}
 
+    @property
+    def item_and_variation(self):
+        return self.item, self.variation
+
     @meta_info_data.setter
     def meta_info_data(self, d):
         self.meta_info = json.dumps(d)

--- a/src/pretix/base/templates/pretixbase/email/order_details.html
+++ b/src/pretix/base/templates/pretixbase/email/order_details.html
@@ -90,13 +90,16 @@
                         {% for groupkey, positions in cart %}
                             <tr>
                                 <td>
-                                    {% if not groupkey.4 %} {# is addon #}
+                                    {% if not groupkey.4 %} {# is not addon #}
                                         {{ positions|length }}x
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if groupkey.4 %} {# is addon #}
                                         +
+                                        {% if positions|length > 1 %}
+                                            {{ positions|length }}x
+                                        {% endif %}
                                     {% endif %}
                                     {{ groupkey.0.name }}{% if groupkey.1 %} – {{ groupkey.1.value }}{% endif %}
                                     {% if groupkey.2 %} {# subevent #}

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
@@ -121,8 +121,9 @@
                                     </label>
                                     <div class="col-md-9 form-control-text">
                                         <ul class="addon-list">
-                                            {% for a in pos.addons.all %}
-                                                <li>{{ a.item.name }}{% if a.variation %} – {{ a.variation.value }}{% endif %}</li>
+                                            {% regroup pos.addons.all by item_and_variation as addons_by_itemvar %}
+                                            {% for group in addons_by_itemvar %}
+                                                <li>{% if group.list|length > 1 %}{{ group.list|length }}&times; {% endif %}{{ group.grouper.0.name }}{% if group.grouper.1 %} – {{ group.grouper.1.value }}{% endif %}</li>
                                             {% endfor %}
                                         </ul>
                                     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -204,8 +204,8 @@
                     {% endfor %}
                 {% endif %}
                 </div>
-            {% elif line.addon_to and line.count == 1 %}
-                <div role="cell" class="count">&nbsp;</div>
+            {% elif line.addon_to %}
+                <div role="cell" class="count">{% if line.count == 1 %}&nbsp;{% else %}{{ line.count }}{% endif %}</div>
                 <div role="cell" class="singleprice price">
                     {% if event.settings.display_net_prices %}
                         {{ line.net_price|money:event.currency }}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -204,7 +204,7 @@
                     {% endfor %}
                 {% endif %}
                 </div>
-            {% elif line.addon_to %}
+            {% elif line.addon_to and line.count == 1 %}
                 <div role="cell" class="count">&nbsp;</div>
                 <div role="cell" class="singleprice price">
                     {% if event.settings.display_net_prices %}

--- a/src/pretix/presale/views/__init__.py
+++ b/src/pretix/presale/views/__init__.py
@@ -185,7 +185,6 @@ class CartMixin:
                     ii = pos.positionid if isinstance(pos, OrderPosition) else pos.pk
                 else:
                     ii = 0
-                print(pos, pos.positionid, i, addon_penalty, ii)
                 return (
                     i, addon_penalty, ii,
                 ) + category_key + item_key + variation_key + (pos.price, (pos.voucher_id or 0), (pos.subevent_id or 0), (pos.seat_id or 0))

--- a/src/pretix/presale/views/__init__.py
+++ b/src/pretix/presale/views/__init__.py
@@ -35,7 +35,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 from decimal import Decimal
-from functools import wraps, partial
+from functools import partial, wraps
 from itertools import groupby
 
 from django.conf import settings

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -12,7 +12,7 @@
     .count form {
         display: inline;
     }
-    .price, .count, .download-desktop {
+    .price, .download-desktop {
         text-align: right;
     }
     .price small,
@@ -55,6 +55,7 @@
     }
     .count {
         width: percentage((2 / $grid-columns));
+        text-align: center;
     }
     .singleprice, .totalprice {
         width: percentage((3 / $grid-columns));


### PR DESCRIPTION
This is an attempt to give a nicer view in the cart if someone buys the exact same addon 5x for the same top-level product, while at the same time keeping all other important properties of the grouping and sorting intact. @wiffbi can you check if you think this breaks anything?