### PR TITLE
Fix -- Custom favicon not showing correctly in Safari (#Z181607)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -27,6 +27,8 @@
         <link rel="icon" type="image/png" sizes="32x32" href="{{ settings.favicon|thumb:'32x32^' }}">
         <link rel="icon" type="image/png" sizes="194x194" href="{{ settings.favicon|thumb:'194x194^' }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ settings.favicon|thumb:'16x16^' }}">
+        <link rel="icon" type="image/png" sizes="192x192" href="{% settings.favicon|thumb:'192x192^' %}">
+        <link rel="apple-touch-icon" sizes="180x180" href="{% settings.favicon|thumb:'180x180^' %}">
     {% elif development_warning or debug_warning %}
         <link rel="shortcut icon" href="{% static "pretixbase/img/favicon-debug.ico" %}">
     {% else %}
@@ -35,9 +37,9 @@
         <link rel="icon" type="image/png" sizes="32x32" href="{% static "pretixbase/img/icons/favicon-32x32.png" %}">
         <link rel="icon" type="image/png" sizes="194x194" href="{% static "pretixbase/img/icons/favicon-194x194.png" %}">
         <link rel="icon" type="image/png" sizes="16x16" href="{% static "pretixbase/img/icons/favicon-16x16.png" %}">
+        <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
+        <link rel="apple-touch-icon" sizes="180x180" href="{% static "pretixbase/img/icons/apple-touch-icon.png" %}">
     {% endif %}
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static "pretixbase/img/icons/apple-touch-icon.png" %}">
-    <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
     <link rel="manifest" href="{% url "presale:site.webmanifest" %}">
     <meta name="msapplication-TileColor" content="{{ settings.primary_color|default:"#3b1c4a" }}">
     <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -39,7 +39,6 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{% static "pretixbase/img/icons/apple-touch-icon.png" %}">
     <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
     <link rel="manifest" href="{% url "presale:site.webmanifest" %}">
-    <link rel="mask-icon" href="{% static "pretixbase/img/icons/safari-pinned-tab.svg" %}" color="{{ settings.primary_color|default:"#3b1c4a" }}">
     <meta name="msapplication-TileColor" content="{{ settings.primary_color|default:"#3b1c4a" }}">
     <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">
     <meta name="theme-color" content="{{ settings.primary_color|default:"#3b1c4a" }}">

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -24,7 +24,6 @@
     {% if settings.favicon %}
         <link rel="icon" href="{{ settings.favicon|thumb:'16x16^' }}">
         <link rel="shortcut icon" href="{{ settings.favicon|thumb:'16x16^' }}">
-        <link rel="icon" type="image/png" sizes="194x194" href="{{ settings.favicon|thumb:'194x194^' }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ settings.favicon|thumb:'16x16^' }}">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ settings.favicon|thumb:'32x32^' }}">
         <link rel="icon" type="image/png" sizes="192x192" href="{% settings.favicon|thumb:'192x192^' %}">
@@ -34,7 +33,6 @@
     {% else %}
         <link rel="icon" href="{% static "pretixbase/img/favicon.ico" %}">
         <link rel="shortcut icon" href="{% static "pretixbase/img/favicon.ico" %}">
-        <link rel="icon" type="image/png" sizes="194x194" href="{% static "pretixbase/img/icons/favicon-194x194.png" %}">
         <link rel="icon" type="image/png" sizes="16x16" href="{% static "pretixbase/img/icons/favicon-16x16.png" %}">
         <link rel="icon" type="image/png" sizes="32x32" href="{% static "pretixbase/img/icons/favicon-32x32.png" %}">
         <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -24,9 +24,9 @@
     {% if settings.favicon %}
         <link rel="icon" href="{{ settings.favicon|thumb:'16x16^' }}">
         <link rel="shortcut icon" href="{{ settings.favicon|thumb:'16x16^' }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ settings.favicon|thumb:'32x32^' }}">
         <link rel="icon" type="image/png" sizes="194x194" href="{{ settings.favicon|thumb:'194x194^' }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ settings.favicon|thumb:'16x16^' }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ settings.favicon|thumb:'32x32^' }}">
         <link rel="icon" type="image/png" sizes="192x192" href="{% settings.favicon|thumb:'192x192^' %}">
         <link rel="apple-touch-icon" sizes="180x180" href="{% settings.favicon|thumb:'180x180^' %}">
     {% elif development_warning or debug_warning %}
@@ -34,9 +34,9 @@
     {% else %}
         <link rel="icon" href="{% static "pretixbase/img/favicon.ico" %}">
         <link rel="shortcut icon" href="{% static "pretixbase/img/favicon.ico" %}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{% static "pretixbase/img/icons/favicon-32x32.png" %}">
         <link rel="icon" type="image/png" sizes="194x194" href="{% static "pretixbase/img/icons/favicon-194x194.png" %}">
         <link rel="icon" type="image/png" sizes="16x16" href="{% static "pretixbase/img/icons/favicon-16x16.png" %}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{% static "pretixbase/img/icons/favicon-32x32.png" %}">
         <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
         <link rel="apple-touch-icon" sizes="180x180" href="{% static "pretixbase/img/icons/apple-touch-icon.png" %}">
     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -26,8 +26,8 @@
         <link rel="shortcut icon" href="{{ settings.favicon|thumb:'16x16^' }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ settings.favicon|thumb:'16x16^' }}">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ settings.favicon|thumb:'32x32^' }}">
-        <link rel="icon" type="image/png" sizes="192x192" href="{% settings.favicon|thumb:'192x192^' %}">
-        <link rel="apple-touch-icon" sizes="180x180" href="{% settings.favicon|thumb:'180x180^' %}">
+        <link rel="icon" type="image/png" sizes="192x192" href="{{ settings.favicon|thumb:'192x192^' }}">
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ settings.favicon|thumb:'180x180^' }}">
     {% elif development_warning or debug_warning %}
         <link rel="shortcut icon" href="{% static "pretixbase/img/favicon-debug.ico" %}">
     {% else %}


### PR DESCRIPTION
This PR fixes some favicon URLs not using the custom favicon.

Furthermore it removes the unnecessary 194x194-size, which makes only sense, if a custom favicon for e.g. Android Chrome with e.g. a drop-shadow were designed, that we do not expect to be shown anywhere else. As this is not the case with neither default pretix-icons nor the generated custom icons, we can safely remove this icon size.

The same with mask-icon, as Safari >12 can use a normal favicon instead – even apple.com does not use the mask-icon anymore.

If we at some point drop support for older IEs, we could also drop the `<link rel="shortcut icon"` line. IMHO it currently does not hurt much to keep it in for now.