### PR TITLE
Add the .mta file extension for Volksbank's MT940

### DIFF
--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -396,7 +396,7 @@ class ImportView(ListView):
         elif 'file' in self.request.FILES and (
             '.txt' in self.request.FILES.get('file').name.lower()
             or '.sta' in self.request.FILES.get('file').name.lower()
-            or '.mta' in self.request.FILES.get('file').name.lower() # Volksbank's structure
+            or '.mta' in self.request.FILES.get('file').name.lower()  # Volksbank's structure
             or '.swi' in self.request.FILES.get('file').name.lower()  # Rabobank's MT940 Structured
         ):
             return self.process_mt940()

--- a/src/pretix/plugins/banktransfer/views.py
+++ b/src/pretix/plugins/banktransfer/views.py
@@ -396,6 +396,7 @@ class ImportView(ListView):
         elif 'file' in self.request.FILES and (
             '.txt' in self.request.FILES.get('file').name.lower()
             or '.sta' in self.request.FILES.get('file').name.lower()
+            or '.mta' in self.request.FILES.get('file').name.lower() # Volksbank's structure
             or '.swi' in self.request.FILES.get('file').name.lower()  # Rabobank's MT940 Structured
         ):
             return self.process_mt940()


### PR DESCRIPTION
Volksbank's in Germany are exporting MT940-Documents with the file extension ".mta" instead of ".sta". While the format is valid, pretix would mark those files as invalid, as long the user does not rename it to one of the allowed.

This PR adds the .mta file to the list of recognized file extensions in the banktransfer plugin.