### PR TITLE
Fix order split with add-ons involved

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1527,6 +1527,8 @@ class OrderChangeManager:
             self._invoice_dirty = True
 
         self._operations.append(self.SplitOperation(position))
+        for a in position.addons.all():
+            self._operations.append(self.SplitOperation(a))
 
     def set_addons(self, addons):
         if self._operations:

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -482,6 +482,9 @@ class OrderPositionChangeForm(forms.Form):
         self.fields['tax_rule'].queryset = instance.event.tax_rules.all()
         self.fields['tax_rule'].label_from_instance = self.taxrule_label_from_instance
 
+        if instance.addon_to_id:
+            del self.fields['operation_split']
+
         if not instance.seat and not (
                 instance.item.seat_category_mappings.filter(subevent=instance.subevent).exists()
         ):

--- a/src/pretix/control/templates/pretixcontrol/order/change.html
+++ b/src/pretix/control/templates/pretixcontrol/order/change.html
@@ -202,10 +202,12 @@
                         </div>
 
                         {% bootstrap_field position.form.operation_cancel layout='inline' %}
-                        {% bootstrap_field position.form.operation_split layout='inline' %}
+                        {% if position.form.operation_split %}
+                            {% bootstrap_field position.form.operation_split layout='inline' %}
+                        {% endif %}
                         {% if position.addons.exists %}
                             <em class="text-danger">
-                                {% trans "Removing this position will also remove all add-ons to this position." %}
+                                {% trans "Removing or splitting this position will also remove or split all add-ons to this position." %}
                             </em>
                         {% endif %}
                     </div>

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -1760,7 +1760,7 @@ class OrderChange(OrderView):
                 if p.form.cleaned_data['tax_rule'] and p.form.cleaned_data['tax_rule'] != p.tax_rule:
                     ocm.change_tax_rule(p, p.form.cleaned_data['tax_rule'])
 
-                if p.form.cleaned_data['operation_split']:
+                if p.form.cleaned_data.get('operation_split'):
                     ocm.split(p)
 
                 if p.form.cleaned_data['operation_secret']:


### PR DESCRIPTION
Currently, when splitting orders, you can split a position without its addons, which leads to real weird effects with cross-order-relationships between positions :o This fixes it :)