### PR TITLE
Add the _voucher_code field to the add to cart form

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -253,6 +253,9 @@
                             <input type="hidden" name="price_{{ line.item.id }}"
                                     value="{% if event.settings.display_net_prices %}{{ line.bundle_sum_net }}{% else %}{{ line.bundle_sum }}{% endif %}" />
                         {% endif %}
+                        {% if line.voucher %}
+                            <input type="hidden" name="_voucher_code" value="{{ line.voucher.code }}">
+                        {% endif %}
                         <button class="btn btn-mini btn-link {% if line.seat %}btn-invisible{% endif %}" title="{% blocktrans with item=line.item %}Add one more {{item}} to your cart{% endblocktrans %}" {% if line.seat %}disabled{% endif %}>
                             <i class="fa fa-plus" aria-hidden="true"></i>
                             <span class="sr-only">{% blocktrans with item=line.item count=line.count %}Add one more {{item}} to your cart. You currently have {{ count }} in your cart.{% endblocktrans %}</span>


### PR DESCRIPTION
As mentioned in #2258, currently a user won't be able to add an item via the plus button in the cart view, when this item requires a voucher.
This PR fixes this issue, by adding the "_voucher_code" field to the form the plus button uses to add an item to the cart.