### PR TITLE
Unicode-aware sorting of phone prefixes

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -41,7 +41,6 @@ from io import BytesIO
 import dateutil.parser
 import pycountry
 import pytz
-from babel import Locale
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -52,7 +51,6 @@ from django.core.validators import (
 )
 from django.db.models import QuerySet
 from django.forms import Select, widgets
-from django.utils import translation
 from django.utils.formats import date_format
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
@@ -87,7 +85,7 @@ from pretix.base.templatetags.rich_text import rich_text
 from pretix.control.forms import (
     ExtFileField, ExtValidationMixin, SizeValidationMixin, SplitDateTimeField,
 )
-from pretix.helpers.countries import CachedCountries
+from pretix.helpers.countries import CachedCountries, get_phone_prefixes_sorted_and_localized
 from pretix.helpers.escapejson import escapejson_attr
 from pretix.helpers.i18n import get_format_without_seconds
 from pretix.presale.signals import question_form_fields
@@ -264,17 +262,13 @@ class WrappedPhonePrefixSelect(Select):
 
     def __init__(self, initial=None):
         choices = [("", "---------")]
-        language = get_babel_locale()  # changed from default implementation that used the django locale
-        locale = Locale(translation.to_locale(language))
+
         for prefix, values in _COUNTRY_CODE_TO_REGION_CODE.items():
-            prefix = "+%d" % prefix
             if initial and initial in values:
+                prefix = "+%d" % prefix
                 self.initial = prefix
-            for country_code in values:
-                country_name = locale.territories.get(country_code)
-                if country_name:
-                    choices.append((prefix, "{} {}".format(country_name, prefix)))
-        super().__init__(choices=sorted(choices, key=lambda item: item[1]), attrs={'aria-label': pgettext_lazy('phonenumber', 'International area code')})
+        choices += get_phone_prefixes_sorted_and_localized()
+        super().__init__(choices=choices, attrs={'aria-label': pgettext_lazy('phonenumber', 'International area code')})
 
     def render(self, name, value, *args, **kwargs):
         return super().render(name, value or self.initial, *args, **kwargs)


### PR DESCRIPTION
This will put Österreich between Oman and Pakistan as expected, instead of to the end of the list. Should also highly improve country sorting for entirely-non-latin scripts like Arabic.