### PR TITLE
Event cancellation: Allow allow creating manual refunds for all orders

### DIFF
--- a/src/pretix/base/services/cancelevent.py
+++ b/src/pretix/base/services/cancelevent.py
@@ -214,8 +214,8 @@ def cancel_event(self, event: Event, subevent: int, auto_refund: bool,
             refund_amount = o.payment_refund_sum
 
             try:
-                if auto_refund:
-                    _try_auto_refund(o.pk, manual_refund=manual_refund, allow_partial=True,
+                if auto_refund or manual_refund:
+                    _try_auto_refund(o.pk, auto_refund=auto_refund, manual_refund=manual_refund, allow_partial=True,
                                      source=OrderRefund.REFUND_SOURCE_ADMIN, refund_as_giftcard=refund_as_giftcard,
                                      giftcard_expires=giftcard_expires, giftcard_conditions=giftcard_conditions,
                                      comment=gettext('Event canceled'))
@@ -272,8 +272,8 @@ def cancel_event(self, event: Event, subevent: int, auto_refund: bool,
             ocm.commit()
             refund_amount = o.payment_refund_sum - o.total
 
-            if auto_refund:
-                _try_auto_refund(o.pk, manual_refund=manual_refund, allow_partial=True,
+            if auto_refund or manual_refund:
+                _try_auto_refund(o.pk, auto_refund=auto_refund, manual_refund=manual_refund, allow_partial=True,
                                  source=OrderRefund.REFUND_SOURCE_ADMIN, refund_as_giftcard=refund_as_giftcard,
                                  giftcard_expires=giftcard_expires, giftcard_conditions=giftcard_conditions,
                                  comment=gettext('Event canceled'))

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -2383,7 +2383,8 @@ def perform_order(self, event: Event, payment_provider: str, positions: List[str
 _unset = object()
 
 
-def _try_auto_refund(order, manual_refund=False, allow_partial=False, source=OrderRefund.REFUND_SOURCE_BUYER,
+def _try_auto_refund(order, auto_refund=True, manual_refund=False, allow_partial=False,
+                     source=OrderRefund.REFUND_SOURCE_BUYER,
                      refund_as_giftcard=False, giftcard_expires=_unset, giftcard_conditions=None, comment=None):
     notify_admin = False
     error = False
@@ -2393,9 +2394,9 @@ def _try_auto_refund(order, manual_refund=False, allow_partial=False, source=Ord
     if refund_amount <= Decimal('0.00'):
         return
 
+    can_auto_refund_sum = 0
+
     if refund_as_giftcard:
-        proposals = {}
-        can_auto_refund = True
         can_auto_refund_sum = refund_amount
         with transaction.atomic():
             giftcard = order.event.organizer.issued_gift_cards.create(
@@ -2435,42 +2436,41 @@ def _try_auto_refund(order, manual_refund=False, allow_partial=False, source=Ord
                 if r.state != OrderRefund.REFUND_STATE_DONE:
                     notify_admin = True
 
-    else:
+    elif auto_refund:
         proposals = order.propose_auto_refunds(refund_amount)
         can_auto_refund_sum = sum(proposals.values())
-        can_auto_refund = (allow_partial and can_auto_refund_sum) or can_auto_refund_sum == refund_amount
-    if can_auto_refund:
-        for p, value in proposals.items():
-            with transaction.atomic():
-                r = order.refunds.create(
-                    payment=p,
-                    source=source,
-                    state=OrderRefund.REFUND_STATE_CREATED,
-                    amount=value,
-                    comment=comment,
-                    provider=p.provider
-                )
-                order.log_action('pretix.event.order.refund.created', {
-                    'local_id': r.local_id,
-                    'provider': r.provider,
-                })
-
-            try:
-                r.payment_provider.execute_refund(r)
-            except PaymentException as e:
+        if (allow_partial and can_auto_refund_sum) or can_auto_refund_sum == refund_amount:
+            for p, value in proposals.items():
                 with transaction.atomic():
-                    r.state = OrderRefund.REFUND_STATE_FAILED
-                    r.save()
-                    order.log_action('pretix.event.order.refund.failed', {
+                    r = order.refunds.create(
+                        payment=p,
+                        source=source,
+                        state=OrderRefund.REFUND_STATE_CREATED,
+                        amount=value,
+                        comment=comment,
+                        provider=p.provider
+                    )
+                    order.log_action('pretix.event.order.refund.created', {
                         'local_id': r.local_id,
                         'provider': r.provider,
-                        'error': str(e)
                     })
-                error = True
-                notify_admin = True
-            else:
-                if r.state not in (OrderRefund.REFUND_STATE_TRANSIT, OrderRefund.REFUND_STATE_DONE):
+
+                try:
+                    r.payment_provider.execute_refund(r)
+                except PaymentException as e:
+                    with transaction.atomic():
+                        r.state = OrderRefund.REFUND_STATE_FAILED
+                        r.save()
+                        order.log_action('pretix.event.order.refund.failed', {
+                            'local_id': r.local_id,
+                            'provider': r.provider,
+                            'error': str(e)
+                        })
+                    error = True
                     notify_admin = True
+                else:
+                    if r.state not in (OrderRefund.REFUND_STATE_TRANSIT, OrderRefund.REFUND_STATE_DONE):
+                        notify_admin = True
 
     if refund_amount - can_auto_refund_sum > Decimal('0.00'):
         if manual_refund:

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -746,16 +746,17 @@ class EventCancelForm(forms.Form):
     auto_refund = forms.BooleanField(
         label=_('Automatically refund money if possible'),
         initial=True,
-        required=False
+        required=False,
+        help_text=_('Only available for payment method that support automatic refunds.')
     )
     manual_refund = forms.BooleanField(
-        label=_('Create manual refund if the payment method does not support automatic refunds'),
-        widget=forms.CheckboxInput(attrs={'data-display-dependency': '#id_auto_refund'}),
+        label=_('Create refund in the manual refund to-do list'),
         initial=True,
         required=False,
-        help_text=_('If checked, all payments with a payment method not supporting automatic refunds will be on your '
-                    'manual refund to-do list. Do not check if you want to refund some of the orders by offsetting '
-                    'with different orders or issuing gift cards.')
+        help_text=_('Manual refunds will be created which will be listed in the manual refund to-do list. '
+                    'When combined with the automatic refund functionally, only payments with a payment method not '
+                    'supporting automatic refunds will be on your manual refund to-do list. Do not check if you want '
+                    'to refund some of the orders by offsetting with different orders or issuing gift cards.')
     )
     refund_as_giftcard = forms.BooleanField(
         label=_('Refund order value to a gift card instead instead of the original payment method'),


### PR DESCRIPTION
Implementation as discussed in #2522

![scrot-2022-03-10T16:18:48+01:00](https://user-images.githubusercontent.com/904824/157693524-29225fb7-26d2-4936-8374-1688b8148ab5.png)

Note that the diff is a little larger, however the refund creation using `proposals` just has been indented. This is because I've simplified the control flow a little bit. The giftcard senario guarded by `refund_as_giftcard` was not using the `proposals` at all, so I've move the loop into the else clause. This means `can_auto_refund` is no longer needed.
