### PR TITLE
paypal/views: Check that resource_type exists on the webhook event payload.

### DIFF
--- a/src/pretix/plugins/paypal/views.py
+++ b/src/pretix/plugins/paypal/views.py
@@ -176,7 +176,7 @@ def webhook(request, *args, **kwargs):
     event_json = json.loads(event_body)
 
     # We do not check the signature, we just use it as a trigger to look the charge up.
-    if event_json['resource_type'] not in ('sale', 'refund'):
+    if not ('resource_type' in event_json) or (event_json['resource_type'] not in ('sale', 'refund')):
         return HttpResponse("Not interested in this resource type", status=200)
 
     if event_json['resource_type'] == 'sale':


### PR DESCRIPTION
Otherwise we get exceptions on webhook calls without resource_type.

Example of this happening:
```
ERROR 2022-03-13 01:29:22,953 django.request log Internal Server Error: /_paypal/webhook/
Traceback (most recent call last):
  File ".../venv.pretix/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File ".../venv.pretix/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File ".../venv.pretix/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File ".../venv.pretix/python3.9/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "~/.pyenv/versions/3.9.10/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File ".../venv.pretix/python3.9/site-packages/pretix/plugins/paypal/views.py", line 179, in webhook
    if event_json['resource_type'] not in ('sale', 'refund'):
KeyError: 'resource_type'
```
Background tasks that hit this error seem to just "stack up" which eventually causes problems.