### PR TITLE
Fix #2556 -- Remove attestation from 2FA-device registration

### DIFF
--- a/src/pretix/control/views/user.py
+++ b/src/pretix/control/views/user.py
@@ -399,7 +399,8 @@ class User2FADeviceConfirmWebAuthnView(RecentAuthenticationRequiredMixin, Templa
             ukey,
             self.request.user.email,
             str(self.request.user),
-            settings.SITE_URL
+            settings.SITE_URL,
+            attestation="none"
         )
         ctx['jsondata'] = json.dumps(make_credential_options.registration_dict)
 


### PR DESCRIPTION
As we currently do not use attestation in 2FA-device registration, we can safely remove it. This circumvents a bug in webkit when registering Touch-ID as 2FA-device on M1 Macs. See https://bugs.webkit.org/show_bug.cgi?id=224042

For more info on why we do not use attestation, see https://fidoalliance.org/fido-technotes-the-truth-about-attestation/