### PR TITLE
Improvements to PDF text placeholders

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -492,10 +492,17 @@ def variables_from_questions(sender, *args, **kwargs):
     for q in sender.questions.all():
         if q.type == Question.TYPE_FILE:
             continue
+        d['question_{}'.format(q.identifier)] = {
+            'label': _('Question: {question}').format(question=q.question),
+            'editor_sample': _('<Answer: {question}>').format(question=q.question),
+            'evaluate': partial(get_answer, question_id=q.pk),
+            'migrate_from': 'question_{}'.format(q.pk)
+        }
         d['question_{}'.format(q.pk)] = {
             'label': _('Question: {question}').format(question=q.question),
             'editor_sample': _('<Answer: {question}>').format(question=q.question),
-            'evaluate': partial(get_answer, question_id=q.pk)
+            'evaluate': partial(get_answer, question_id=q.pk),
+            'hidden': True,
         }
     return d
 

--- a/src/pretix/control/templates/pretixcontrol/pdf/index.html
+++ b/src/pretix/control/templates/pretixcontrol/pdf/index.html
@@ -372,7 +372,9 @@
                             <label>{% trans "Content" %}</label><br>
                             <select class="input-block-level form-control" id="toolbox-content">
                                 {% for varname, var in variables.items %}
-                                    <option data-sample="{{ var.editor_sample }}" value="{{ varname }}">{{ var.label }}</option>
+                                    {% if not var.hidden %}
+                                        <option data-sample="{{ var.editor_sample }}" {% if var.migrate_from %}data-old-value="{{ var.migrate_from }}"{% endif %} value="{{ varname }}">{{ var.label }}</option>
+                                    {% endif %}
                                 {% endfor %}
                                 {% for p in request.organizer.meta_properties.all %}
                                     <option value="meta:{{ p.name }}">
@@ -394,6 +396,9 @@
                                     <textarea id="toolbox-content-other-{{ l }}" rows="3" class="input-block-level form-control" title="{{ l }}" lang="{{ l }}"></textarea>
                                 {% endfor %}
                             </div>
+                            <p class="help-block" id="toolbox-content-other-help">
+                                <a href="?placeholders=true" target="_blank">{% trans "Show available placeholders" %}</a>
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/src/pretix/control/templates/pretixcontrol/pdf/placeholders.html
+++ b/src/pretix/control/templates/pretixcontrol/pdf/placeholders.html
@@ -1,0 +1,68 @@
+{% extends "pretixcontrol/event/base.html" %}
+{% load i18n %}
+{% load static %}
+{% load compress %}
+{% block title %}{% trans "PDF Editor" %}{% endblock %}
+{% block custom_header %}
+    {{ block.super }}
+    {% compress css %}
+        <link type="text/css" rel="stylesheet" href="{% static "pretixcontrol/scss/pdfeditor.css" %}">
+    {% endcompress %}
+    <link type="text/css" rel="stylesheet" href="{% url "control:pdf.css" %}">
+{% endblock %}
+{% block content %}
+    <h1>
+        {% trans "PDF Editor" %}
+        <small>{% trans "Available placeholders" %}</small>
+    </h1>
+    <p>
+        {% blocktrans trimmed %}
+            You can use placeholders in custom texts on tickets to enrich your text with individual data. Which
+            placeholders are available depends on your event settings, activated plugins, the selected product,
+            as well as user input.
+            This page lists all placeholders technically available for your event, however most of them can also
+            be empty in some cases depending on configuration.
+        {% endblocktrans %}
+    </p>
+    <div class="table-responsive">
+        <table class="table table-hover table-condensed">
+            <thead>
+            <tr>
+                <th>{% trans "Placeholder" %}</th>
+                <th>{% trans "Description" %}</th>
+                <th>{% trans "Formatting example" %}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for varname, var in variables.items %}
+                {% if not var.hidden %}
+                    <tr>
+                        <td><code>{{ "{" }}{{ varname }}{{ "}" }}</code></td>
+                        <td>{{ var.label }}</td>
+                        <td>{{ var.editor_sample }}</td>
+                    </tr>
+                {% endif %}
+            {% endfor %}
+            {% for p in request.organizer.meta_properties.all %}
+                <tr>
+                    <td><code>{{ "{" }}meta:{{ p.name }}{{ "}" }}</code></td>
+                    <td>
+                        {% trans "Event attribute:" %} {{ p.name }}
+                    </td>
+                    <td></td>
+                </tr>
+            {% endfor %}
+            {% for p in request.event.item_meta_properties.all %}
+                <tr>
+                    <td><code>{{ "{" }}itemmeta:{{ p.name }}{{ "}" }}</code></td>
+                    <td>
+                        {% trans "Item attribute:" %} {{ p.name }}
+                    </td>
+                    <td></td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}
+

--- a/src/pretix/control/views/pdf.py
+++ b/src/pretix/control/views/pdf.py
@@ -33,7 +33,7 @@ from django.core.files.storage import default_storage
 from django.http import (
     FileResponse, HttpResponse, HttpResponseBadRequest, JsonResponse,
 )
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
@@ -65,9 +65,16 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
     title = None
 
     def get(self, request, *args, **kwargs):
+        if 'placeholders' in request.GET:
+            return self.get_placeholders_help(request)
         resp = super().get(request, *args, **kwargs)
         resp._csp_ignore = True
         return resp
+
+    def get_placeholders_help(self, request):
+        ctx = {}
+        ctx['variables'] = self.get_variables()
+        return render(request, 'pretixcontrol/pdf/placeholders.html', ctx)
 
     def process_upload(self):
         f = self.request.FILES.get('background')

--- a/src/pretix/static/pretixcontrol/js/ui/editor.js
+++ b/src/pretix/static/pretixcontrol/js/ui/editor.js
@@ -286,7 +286,7 @@ var editor = {
         } else if (key.startsWith('meta:')) {
             return key.substr(5);
         }
-        return $('#toolbox-content option[value='+key+']').attr('data-sample') || '';
+        return $('#toolbox-content option[value='+key+'], #toolbox-content option[data-old-value='+key+']').attr('data-sample') || '';
     },
 
     _load_page: function (page_number, dump) {
@@ -396,6 +396,7 @@ var editor = {
 
         $("#toolbox-content-other").hide();
         $("#toolbox-content-other-i18n").hide();
+        $("#toolbox-content-other-help").hide();
         $(".add-buttons button").prop('disabled', false);
 
         if (dump) {
@@ -492,9 +493,15 @@ var editor = {
             if (!o.content && o.type == "barcodearea") {
                 o.content = "secret";
             }
-            $("#toolbox-content").val(o.content);
+            var $migrate_to = $("#toolbox-content option[data-old-value='" + o.content + "']");
+            if ($migrate_to.length > 0) {
+                $("#toolbox-content").val($migrate_to.val());
+            } else {
+                $("#toolbox-content").val(o.content);
+            }
             $("#toolbox-content-other").toggle($("#toolbox-content").val() === "other");
             $("#toolbox-content-other-i18n").toggle($("#toolbox-content").val() === "other_i18n");
+            $("#toolbox-content-other-help").toggle($("#toolbox-content").val() === "other" || $("#toolbox-content").val() === "other_i18n");
             if (o.content === "other") {
                 $("#toolbox-content-other").val(o.text);
             } else if (o.content === "other_i18n") {
@@ -537,6 +544,7 @@ var editor = {
 
             $("#toolbox-content-other").toggle($("#toolbox-content").val() === "other");
             $("#toolbox-content-other-i18n").toggle($("#toolbox-content").val() === "other_i18n");
+            $("#toolbox-content-other-help").toggle($("#toolbox-content").val() === "other" || $("#toolbox-content").val() === "other_i18n");
             o.content = $("#toolbox-content").val();
             if ($("#toolbox-content").val() === "other") {
                 o.text = $("#toolbox-content-other").val();
@@ -591,6 +599,7 @@ var editor = {
             o.rotate(parseFloat($("#toolbox-textrotation").val()));
             $("#toolbox-content-other").toggle($("#toolbox-content").val() === "other");
             $("#toolbox-content-other-i18n").toggle($("#toolbox-content").val() === "other_i18n");
+            $("#toolbox-content-other-help").toggle($("#toolbox-content").val() === "other" || $("#toolbox-content").val() === "other_i18n");
             o.content = $("#toolbox-content").val();
             if ($("#toolbox-content").val() === "other") {
                 o.setText($("#toolbox-content-other").val());


### PR DESCRIPTION
We recently introduced placeholders for PDF texts, i.e. you can now use {attendee_name_full_name} as part of a custom text on your ticket.

This PR actually makes that usable:

- It adds a dynamic documentation page listing all placeholders available for an event
- It moves question placeholders from including the question's primary key to including the question's identifier. This has long been a pain point that we need to carefully rewrite the layout JSON when we copy the layout to a new event, since question primary keys are not stable between events. This patch basically adds the new fields and "hides" the old ones, while still retaining full functionality of the old ones. The downside is that for the forseeable future, the API will now expose *both* options to the devices, which seems like an inefficient but safe option. We cannot easily do a migration of all server-known layouts and drop the old fields, because the PDF engine is used by plugins as well (e.g. our pretix-certificates, but maybe also other community users). We should announce a deprecation of the old fields in the release notes.