### PR TITLE
widget: introduce addCloseListener for when close button is clicked.

### DIFF
--- a/doc/user/events/widget.rst
+++ b/doc/user/events/widget.rst
@@ -253,17 +253,20 @@ If you want, you can suppress us loading the widget and/or modify the user data 
 
 If you then later want to trigger loading the widgets, just call ``window.PretixWidget.buildWidgets()``.
 
-Waiting for the widget to load
-------------------------------
+Waiting for the widget to load or close
+---------------------------------------
 
-If you want to run custom JavaScript once the widget is fully loaded, you can register a callback function. Note that
-this function might be run multiple times, for example if you have multiple widgets on a page or if the user switches
-e.g. from an event list to an event detail view::
+If you want to run custom JavaScript once the widget is fully loaded or when it is closed, you can register callback
+functions. Note that these function might be run multiple times, for example if you have multiple widgets on a page
+or if the user switches e.g. from an event list to an event detail view::
 
     <script type="text/javascript">
     window.pretixWidgetCallback = function () {
         window.PretixWidget.addLoadListener(function () {
             console.log("Widget has loaded!");
+        });
+        window.PretixWidget.addCloseListener(function () {
+            console.log("Widget has been closed!");
         });
     }
     </script>

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -747,6 +747,7 @@ Vue.component('pretix-overlay', {
             this.$root.frame_shown = false;
             this.$root.parent.frame_dismissed = true;
             this.$root.parent.reload();
+            this.$root.trigger_close_callback();
         },
         iframeLoaded: function () {
             if (this.$root.frame_loading) {
@@ -1368,6 +1369,13 @@ var shared_root_methods = {
             }
         });
     },
+    trigger_close_callback: function () {
+        this.$nextTick(function () {
+            for (var i = 0; i < window.PretixWidget._closed.length; i++) {
+                window.PretixWidget._closed[i]()
+            }
+        });
+    },
     reload: function () {
         var url;
         if (this.$root.is_button) {
@@ -1791,8 +1799,12 @@ var create_button = function (element) {
 widgetlist = [];
 buttonlist = [];
 window.PretixWidget._loaded = [];
+window.PretixWidget._closed = [];
 window.PretixWidget.addLoadListener = function (f) {
     window.PretixWidget._loaded.push(f);
+}
+window.PretixWidget.addCloseListener = function (f) {
+    window.PretixWidget._closed.push(f);
 }
 window.PretixWidget.buildWidgets = function () {
     document.createElement("pretix-widget");


### PR DESCRIPTION
We are running some tight integration between our own webapp and Pretix, using the Embedable widget. Using `pretixWidgetCallback` and `PretixWidget.addLoadListener` we inject a bunch of code that supplies Pretix with needed info to complete orders with metadata. Currently, there is no method to detect that an order has been completed or that the order process has been aborted. We cannot detect when the widget is closed. 

Instead of hacking into the Vue state or polling for the visibility state of the `div.pretix-widget-frame-inner`, I propose an additional hook which gets called when the widget is closed. This creates possibility of a clean integration between the Vue widget and the app containing it.