### PR TITLE
deps: Pillow minimum version 9.1.0

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -205,7 +205,7 @@ setup(
         'packaging',
         'paypalrestsdk==1.13.*',
         'phonenumberslite==8.12.*',
-        'Pillow==9.*',
+        'Pillow==9.1.*',
         'protobuf==3.19.*',
         'psycopg2-binary',
         'pycountry',


### PR DESCRIPTION
The changes introduced in db39b89ae use a constant which isn't available until Pillow 9.1.0.

Reference: https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#constants