### PR TITLE
Event cancellation: Fix default email subject translations

### DIFF
--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -844,7 +844,7 @@ class EventCancelForm(forms.Form):
             label=_("Subject"),
             required=True,
             widget_kwargs={'attrs': {'data-display-dependency': '#id_send'}},
-            initial=_('Canceled: {event}'),
+            initial=LazyI18nString.from_gettext(gettext_noop('Canceled: {event}')),
             widget=I18nTextInput,
             locales=self.event.settings.get('locales'),
         )
@@ -870,7 +870,7 @@ class EventCancelForm(forms.Form):
         self.fields['send_waitinglist_subject'] = I18nFormField(
             label=_("Subject"),
             required=True,
-            initial=_('Canceled: {event}'),
+            initial=LazyI18nString.from_gettext(gettext_noop('Canceled: {event}')),
             widget=I18nTextInput,
             widget_kwargs={'attrs': {'data-display-dependency': '#id_send_waitinglist'}},
             locales=self.event.settings.get('locales'),


### PR DESCRIPTION
The initial value for the mail subject were not using `LazyI18nString`s, causing only one field to be filled with the logged in user's current language, which may not correspond (example puts English string in Dutch field):

![scrot-2022-04-04T21:49:22+02:00](https://user-images.githubusercontent.com/904824/161621362-4fd7415e-d81d-4191-8b8a-9d9b170fd233.png)

I'm not familiar with `django-i18nfield`, but I based this patch on the e-mail content fields code directly below, which seem to work.