### PR TITLE
Check-in rules: Add now_isoweekday and minutes_since_last_entry

### DIFF
--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -188,6 +188,7 @@ class CheckinList(LoggedModel):
         # * in pretix.helpers.jsonlogic_boolalg
         # * in checkinrules.js
         # * in libpretixsync
+        # * in pretixscan-ios (in the future)
         top_level_operators = {
             '<', '<=', '>', '>=', '==', '!=', 'inList', 'isBefore', 'isAfter', 'or', 'and'
         }
@@ -195,7 +196,8 @@ class CheckinList(LoggedModel):
             'buildTime', 'objectList', 'lookup', 'var',
         }
         allowed_vars = {
-            'product', 'variation', 'now', 'entries_number', 'entries_today', 'entries_days'
+            'product', 'variation', 'now', 'now_isoweekday', 'entries_number', 'entries_today', 'entries_days',
+            'minutes_since_last_entry',
         }
         if not rules or not isinstance(rules, dict):
             return rules

--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -197,7 +197,7 @@ class CheckinList(LoggedModel):
         }
         allowed_vars = {
             'product', 'variation', 'now', 'now_isoweekday', 'entries_number', 'entries_today', 'entries_days',
-            'minutes_since_last_entry',
+            'minutes_since_last_entry', 'minutes_since_first_entry',
         }
         if not rules or not isinstance(rules, dict):
             return rules

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -253,6 +253,17 @@ def _logic_explain(rules, ev, rule_data):
 
             var_weights[vname] = (w[var] + operator_weights.get(operator, 0) + penalty, abs(compare_to - rule_data[var]))
 
+            if var == 'now_isoweekday':
+                compare_to = {
+                    1: _('Monday'),
+                    2: _('Tuesday'),
+                    3: _('Wednesday'),
+                    4: _('Thursday'),
+                    5: _('Friday'),
+                    6: _('Saturday'),
+                    7: _('Sunday'),
+                }.get(compare_to, compare_to)
+
             if operator == '==':
                 var_texts[vname] = _('{variable} is not {value}').format(variable=l[var], value=compare_to)
             elif operator in ('<', '<='):

--- a/src/pretix/helpers/jsonlogic_query.py
+++ b/src/pretix/helpers/jsonlogic_query.py
@@ -83,10 +83,17 @@ def tolerance(b, tol=None, sign=1):
     return b
 
 
+class PostgresIntervalToEpoch(Func):
+    arity = 1
+
+    def as_sql(self, compiler, connection, function=None, template=None, arg_joiner=None, **extra_context):
+        lhs, lhs_params = compiler.compile(self.source_expressions[0])
+        return '(EXTRACT(epoch FROM (%s))::int)' % lhs, lhs_params
+
+
 def MinutesSince(dt):
     if '.postgresql' in connection.settings_dict['ENGINE']:
-        # TODO
-        pass
+        return PostgresIntervalToEpoch(Value(now()) - dt) / 60
     else:
         # date diffs on MySQL and SQLite are implemented in microseconds by django, so we just cast and convert
         # see https://github.com/django/django/blob/d436554861b9b818994276d7bf110bf03aa565f5/django/db/backends/sqlite3/_functions.py#L291

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
@@ -87,6 +87,10 @@ $(document).ready(function () {
       'label': gettext('Minutes since last entry (-1 on first entry)'),
       'type': 'int',
     },
+    'minutes_since_first_entry': {
+      'label': gettext('Minutes since first entry (-1 on first entry)'),
+      'type': 'int',
+    },
   };
 
   Vue.component('checkin-rule', CheckinRule.default);

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
@@ -67,6 +67,10 @@ $(document).ready(function () {
       'label': gettext('Current date and time'),
       'type': 'datetime',
     },
+    'now_isoweekday': {
+      'label': gettext('Current day of the week (1 = Monday, 7 = Sunday)'),
+      'type': 'int',
+    },
     'entries_number': {
       'label': gettext('Number of previous entries'),
       'type': 'int',
@@ -77,6 +81,10 @@ $(document).ready(function () {
     },
     'entries_days': {
       'label': gettext('Number of days with a previous entry'),
+      'type': 'int',
+    },
+    'minutes_since_last_entry': {
+      'label': gettext('Minutes since last entry (-1 on first entry)'),
       'type': 'int',
     },
   };

--- a/src/tests/base/test_checkin.py
+++ b/src/tests/base/test_checkin.py
@@ -744,14 +744,14 @@ def test_rules_isafter_subevent(position, clist, event):
 def test_rules_time_isoweekday(event, position, clist):
     # Ticket is valid starting at a custom time
     event.settings.timezone = 'Europe/Berlin'
-    clist.rules = {">=": [{"var": "now_isoweekday"}, 6]}
+    clist.rules = {"==": [{"var": "now_isoweekday"}, 6]}
     clist.save()
     with freeze_time("2022-04-06 21:55:00+01:00"):
         assert not OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
         with pytest.raises(CheckInError) as excinfo:
             perform_checkin(position, clist, {})
         assert excinfo.value.code == 'rules'
-        assert 'Minimum week day exceeded' in str(excinfo.value)
+        assert 'week day is not Saturday' in str(excinfo.value)
 
     with freeze_time("2022-04-09 22:05:00+01:00"):
         assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()

--- a/src/tests/base/test_checkin.py
+++ b/src/tests/base/test_checkin.py
@@ -496,7 +496,7 @@ def test_rules_scan_number(position, clist):
 
 
 @pytest.mark.django_db
-def test_rules_scan_minutes(position, clist):
+def test_rules_scan_minutes_since_last(position, clist):
     # Ticket is valid unlimited times, but you always need to wait 3 hours
     clist.allow_multiple_entries = True
     clist.rules = {"or": [{"<=": [{"var": "minutes_since_last_entry"}, -1]}, {">": [{"var": "minutes_since_last_entry"}, 60 * 3]}]}
@@ -516,6 +516,40 @@ def test_rules_scan_minutes(position, clist):
     with freeze_time("2020-01-01 13:01:00"):
         assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
         perform_checkin(position, clist, {})
+
+    with freeze_time("2020-01-01 15:55:00"):
+        assert not OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        with pytest.raises(CheckInError) as excinfo:
+            perform_checkin(position, clist, {})
+        assert excinfo.value.code == 'rules'
+        assert 'Minimum time since last entry' in str(excinfo.value)
+
+    with freeze_time("2020-01-01 16:02:00"):
+        assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        perform_checkin(position, clist, {})
+
+
+@pytest.mark.django_db
+def test_rules_scan_minutes_since_fist(position, clist):
+    # Ticket is valid unlimited times, but you always need to wait 3 hours
+    clist.allow_multiple_entries = True
+    clist.rules = {"or": [{"<=": [{"var": "minutes_since_first_entry"}, -1]}, {"<": [{"var": "minutes_since_first_entry"}, 60 * 3]}]}
+    clist.save()
+
+    with freeze_time("2020-01-01 10:00:00"):
+        assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        perform_checkin(position, clist, {})
+
+    with freeze_time("2020-01-01 12:55:00"):
+        assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        perform_checkin(position, clist, {})
+
+    with freeze_time("2020-01-01 13:01:00"):
+        assert not OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        with pytest.raises(CheckInError) as excinfo:
+            perform_checkin(position, clist, {})
+        assert excinfo.value.code == 'rules'
+        assert 'Maximum time since first entry' in str(excinfo.value)
 
 
 @pytest.mark.django_db

--- a/src/tests/base/test_checkin.py
+++ b/src/tests/base/test_checkin.py
@@ -496,6 +496,29 @@ def test_rules_scan_number(position, clist):
 
 
 @pytest.mark.django_db
+def test_rules_scan_minutes(position, clist):
+    # Ticket is valid unlimited times, but you always need to wait 3 hours
+    clist.allow_multiple_entries = True
+    clist.rules = {"or": [{"<=": [{"var": "minutes_since_last_entry"}, -1]}, {">": [{"var": "minutes_since_last_entry"}, 60 * 3]}]}
+    clist.save()
+
+    with freeze_time("2020-01-01 10:00:00"):
+        assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        perform_checkin(position, clist, {})
+
+    with freeze_time("2020-01-01 12:55:00"):
+        assert not OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        with pytest.raises(CheckInError) as excinfo:
+            perform_checkin(position, clist, {})
+        assert excinfo.value.code == 'rules'
+        assert 'Minimum time since last entry' in str(excinfo.value)
+
+    with freeze_time("2020-01-01 13:01:00"):
+        assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        perform_checkin(position, clist, {})
+
+
+@pytest.mark.django_db
 def test_rules_scan_today(event, position, clist):
     # Ticket is valid three times per day
     event.settings.timezone = 'Europe/Berlin'
@@ -679,6 +702,24 @@ def test_rules_isafter_subevent(position, clist, event):
         assert 'Only allowed after 12:00' in str(excinfo.value)
 
     with freeze_time("2020-02-01 11:01:00"):
+        assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        perform_checkin(position, clist, {})
+
+
+@pytest.mark.django_db
+def test_rules_time_isoweekday(event, position, clist):
+    # Ticket is valid starting at a custom time
+    event.settings.timezone = 'Europe/Berlin'
+    clist.rules = {">=": [{"var": "now_isoweekday"}, 6]}
+    clist.save()
+    with freeze_time("2022-04-06 21:55:00+01:00"):
+        assert not OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
+        with pytest.raises(CheckInError) as excinfo:
+            perform_checkin(position, clist, {})
+        assert excinfo.value.code == 'rules'
+        assert 'Minimum week day exceeded' in str(excinfo.value)
+
+    with freeze_time("2022-04-09 22:05:00+01:00"):
         assert OrderPosition.objects.filter(SQLLogic(clist).apply(clist.rules), pk=position.pk).exists()
         perform_checkin(position, clist, {})
 


### PR DESCRIPTION
- [x] Time since *first* use?
- [x] Time since purchase?
- [x] PostgreSQL support
- [x] More testing
- [x] libpretixsync implementation (https://github.com/pretix/libpretixsync/pull/11)
  - [x] android release
  - [x] desktop release
  - [x] proxy release