### PR TITLE
Voucher redemption: Raise 404 error if subevent_pk is not an integer

### DIFF
--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -632,7 +632,7 @@ class RedeemView(NoSearchIndexViewMixin, EventViewMixin, CartMixin, TemplateView
             if request.GET.get('subevent'):
                 try:
                     subevent_pk = int(request.GET.get('subevent'))
-                    self.subevent = SubEvent.objects.get(event=request.event, pk=subevent_pk, active=True)
+                    self.subevent = request.event.subevents.get(pk=subevent_pk, active=True)
                 except (ValueError, SubEvent.DoesNotExist):
                     raise Http404(pgettext('subevent', 'We were unable to find the specified date.'))  
 


### PR DESCRIPTION
Due to some malconfiguration it could happen that the subevent-PK submitted via GET-params is not an integer, which currently results in a server error. This fix checks the subevent-GET-param and raises an 404 as if the subevent_pk would not be found.