### PR TITLE
Calendar view: make focus-outline visible

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -6,7 +6,7 @@
     font-size: 16px;
   }
   p {
-    margin-bottom: 0;
+    margin-bottom: 3px;
   }
   .events {
     list-style: none;
@@ -23,7 +23,7 @@
     border-left-color: inherit;
 
     padding: 3px 5px;
-    margin-top: 3px;
+    margin-bottom: 3px;
     font-size: 12px;
     overflow-wrap: anywhere;
     text-decoration: none;
@@ -96,7 +96,7 @@
     margin-bottom: 15px;
   }
   h3 {
-    margin-bottom: 5px;
+    margin-bottom: 8px;
     font-weight: bold;
     cursor: pointer;
   }
@@ -105,9 +105,6 @@
   }
   details[open] h3 .fa::before {
     content: $fa-var-caret-down;
-  }
-  .events {
-    overflow: hidden;  /* required for smooth toggle animation */
   }
   .no-events {
     display: none;


### PR DESCRIPTION
In calendar week-view due to margin-collapsing for smooth foldup of week-days, ul.events had a overflow:hidden, which caused the focus-outline to mostly disappear. This changes the margins from top to bottom, so that no overflow:hidden is needed for smooth fold-up of week-days.