### PR TITLE
Calendar view: improve differentiation between events’ states (Z#173939)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -55,15 +55,9 @@
                                             {% if event.time %}
                                                 <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
                                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
-                                                    {% if not show_names|default_if_none:True %}
-                                                        <strong>
-                                                    {% endif %}
                                                     <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }}</time>
                                                     {% if event.event.settings.show_date_to and event.time_end %}
                                                         <span aria-hidden="true">–</span><span class="sr-only">{% trans "until" context "timerange" %}</span> <time datetime="{{ event.time_end|date_fast:"H:i" }}">{{ event.time_end|date_fast:"TIME_FORMAT" }}</time>
-                                                    {% endif %}
-                                                    {% if not show_names|default_if_none:True %}
-                                                        </strong>
                                                     {% endif %}
                                                     {% if multiple_timezones %}
                                                         {{ event.timezone }}

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -71,18 +71,18 @@
                                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                                     {% elif event.event.best_availability_state == 20 %}
-                                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Reserved" %}
+                                                        {% trans "Reserved" %}
                                                     {% elif event.event.best_availability_state < 20 %}
                                                         {% if event.event.has_paid_item %}
-                                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sold out" %}
+                                                            {% trans "Sold out" %}
                                                         {% else %}
-                                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Fully booked" %}
+                                                            {% trans "Fully booked" %}
                                                         {% endif %}
                                                     {% endif %}
                                                 {% elif event.event.presale_is_running %}
                                                     <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
                                                 {% elif event.event.presale_has_ended %}
-                                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sale over" %}
+                                                    {% trans "Sale over" %}
                                                 {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}
                                                     <span class="fa fa-ticket" aria-hidden="true"></span>
                                                     {% with date_human=event.event.presale_start|date_fast:"SHORT_DATE_FORMAT" date_iso=event.event.presale_start|date_fast:"c"  %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -40,15 +40,9 @@
                             {% if event.time %}
                                 <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
-                                    {% if not show_names|default_if_none:True %}
-                                        <strong>
-                                    {% endif %}
                                     <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }}</time>
                                     {% if event.time_end %}
                                         <span aria-hidden="true">–</span><span class="sr-only">{% trans "until" context "timerange" %}</span> <time datetime="{{ event.time_end|date_fast:"H:i" }}">{{ event.time_end|date_fast:"TIME_FORMAT" }}</time>
-                                    {% endif %}
-                                    {% if not show_names|default_if_none:True %}
-                                        </strong>
                                     {% endif %}
                                     {% if multiple_timezones %}
                                         {{ event.timezone }}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -56,18 +56,18 @@
                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                     {% elif event.event.best_availability_state == 20 %}
-                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Reserved" %}
+                                        {% trans "Reserved" %}
                                     {% elif event.event.best_availability_state < 20 %}
                                         {% if event.event.has_paid_item %}
-                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sold out" %}
+                                            {% trans "Sold out" %}
                                         {% else %}
-                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Fully booked" %}
+                                            {% trans "Fully booked" %}
                                         {% endif %}
                                     {% endif %}
                                 {% elif event.event.presale_is_running %}
                                     <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
                                 {% elif event.event.presale_has_ended %}
-                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sale over" %}
+                                    {% trans "Sale over" %}
                                 {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}
                                     <span class="fa fa-ticket" aria-hidden="true"></span>
                                     {% blocktrans with start_date=event.event.presale_start|date_fast:"SHORT_DATE_FORMAT" %}

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -88,6 +88,11 @@
     &.soon > *:first-child {
       font-weight: bold;
     }
+    &.over > *:first-child,
+    &.reserved > *:first-child,
+    &.soldout > *:first-child {
+      text-decoration: line-through
+    }
 
     .event-name {
       display: block;

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -82,8 +82,14 @@
       }
     }
 
-    .event-name {
+
+    &.available > *:first-child,
+    &.continued > *:first-child,
+    &.soon > *:first-child {
       font-weight: bold;
+    }
+
+    .event-name {
       display: block;
     }
     .event-time, .event-status {

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -37,13 +37,13 @@
     }
 
     &.continued, &.over {
-      background: lighten(#767676, 48%);
-      border-color: lighten(#767676, 30%);
-      border-left-color: lighten(#767676, 30%);
+      background: lighten(#767676, 54%);
+      border-color: lighten(#767676, 44%);
+      border-left-color: lighten(#767676, 44%);
       color: #767676;
       &:hover {
-        background: lighten(#767676, 50%);
-        border-color: lighten(#767676, 25%);
+        background: lighten(#767676, 54%);
+        border-color: lighten(#767676, 40%);
       }
     }
 


### PR DESCRIPTION
In calendar view it was hard to distinguish the availability state of events on a first glance especially with some type of color blindness. This tries to fix this by:

- make unavailable events background/border even lighter
- remove ticket-icon (or any icon at all) from unavailable events to make the distinction for „book now“ links with a ticket-icon
- remove bold font on unavailable events
- strike-through first line on unavailable events

Before:
![before](https://user-images.githubusercontent.com/276509/163146125-58de58d4-53e3-4c39-a0b3-04c0c2e94ac2.png)

After:
![after](https://user-images.githubusercontent.com/276509/163146158-631a17b1-7bf3-4b70-a441-e25bdcdd40f5.png)

After (no color):
![after-no-color](https://user-images.githubusercontent.com/276509/163146563-c326bc95-d11b-4e3b-bdb6-6a5fc8da8e0d.png)

After (no red):
![after-no-red](https://user-images.githubusercontent.com/276509/163146578-21f9b69f-0fbe-46e3-9178-bdba873955dc.png)

After (no green):
![after-no-green](https://user-images.githubusercontent.com/276509/163146854-a7b487aa-b074-46d2-aed3-9628b47d14d1.png)

