### PR TITLE
Change npm install call in setup.py

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -92,7 +92,7 @@ def npm_install():
         node_prefix = os.path.join(here, 'pretix', 'static.dist', 'node_prefix')
         os.makedirs(node_prefix, exist_ok=True)
         copy_tree(os.path.join(here, 'pretix', 'static', 'npm_dir'), node_prefix)
-        subprocess.check_call(['npm', 'install', '--prefix=' + node_prefix])
+        subprocess.check_call(['npm', 'install'], shell=True, cwd=node_prefix)
         npm_installed = True
 
 


### PR DESCRIPTION
Fixes two problems: Windows python needs shell=True to find npm, and npm needs to be executed from within the directory with the package.json.
The second problem seems to should have existed everywhere, but for some reason the command appears to have worked on Linux?
Note: Using cwd= neatly circumvents potential escaping problems introduced by shell=True.