### PR TITLE
Badges: Remove trimBox from background PDF (Z#2398854)

### DIFF
--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -196,6 +196,7 @@ def render_pdf(event, positions, opt):
         )
         for i, (op, r) in enumerate(positions):
             bg_page = copy.copy(r.bg_pdf.getPage(0))
+            bg_page.trimBox = bg_page.mediaBox
             offsetx = opt['margins'][3] + (i % opt['cols']) * opt['offsets'][0]
             offsety = opt['margins'][2] + (opt['rows'] - 1 - i // opt['cols']) * opt['offsets'][1]
             empty_pdf_page.mergeTranslatedPage(


### PR DESCRIPTION
PyPDF 1.27.6 has introduced different handling of trimBox when merging pages – with 1.26 trimBox was ignored when the background-PDF was placed, but since 1.27.6 PDFs with a trimBox got a mask the size of the trimBox (ie. clipped) when merged. As of the release notes, this is intended behaviour for PyPDF, so we need to change the behaviour in our code. This PR sets the trimBox of any background-PDF in badges to the mediaBox.