### PR TITLE
Add placeholder name_for_salutation to editor/PDF to improve handling of salutation „Mx“

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -570,6 +570,18 @@ def get_variables(event):
             "evaluate": partial(_get_ia_name_part, key)
         }
 
+    concatenation_for_salutation = scheme.get("concatenation_for_salutation", scheme["concatenation"])
+    v['attendee_name_for_salutation'] = {
+        'label': _("Attendee name for salutation"),
+        'editor_sample': _("Mr Doe"),
+        'evaluate': lambda op, order, ev: concatenation_for_salutation(op.attendee_name_parts)
+    }
+    v['invoice_name_for_salutation'] = {
+        'label': _("Invoice name for salutation"),
+        'editor_sample': _("Mr Doe"),
+        'evaluate': lambda op, order, ev: concatenation_for_salutation(order.invoice_address.name_parts if getattr(order, 'invoice_address', None) else {})
+    }
+
     for recv, res in layout_text_variables.send(sender=event):
         v.update(res)
 

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -551,7 +551,7 @@ def get_variables(event):
     v['attendee_name_for_salutation'] = {
         'label': _("Attendee name for salutation"),
         'editor_sample': _("Mr Doe"),
-        'evaluate': lambda op, order, ev: concatenation_for_salutation(op.attendee_name_parts)
+        'evaluate': lambda op, order, ev: concatenation_for_salutation(op.attendee_name_parts or {})
     }
 
     for key, label, weight in scheme['fields']:

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -546,6 +546,14 @@ def get_variables(event):
     v = copy.copy(DEFAULT_VARIABLES)
 
     scheme = PERSON_NAME_SCHEMES[event.settings.name_scheme]
+
+    concatenation_for_salutation = scheme.get("concatenation_for_salutation", scheme["concatenation"])
+    v['attendee_name_for_salutation'] = {
+        'label': _("Attendee name for salutation"),
+        'editor_sample': _("Mr Doe"),
+        'evaluate': lambda op, order, ev: concatenation_for_salutation(op.attendee_name_parts)
+    }
+
     for key, label, weight in scheme['fields']:
         v['attendee_name_%s' % key] = {
             'label': _("Attendee name: {part}").format(part=label),
@@ -563,24 +571,18 @@ def get_variables(event):
     v['invoice_name']['editor_sample'] = scheme['concatenation'](scheme['sample'])
     v['attendee_name']['editor_sample'] = scheme['concatenation'](scheme['sample'])
 
+    v['invoice_name_for_salutation'] = {
+        'label': _("Invoice address name for salutation"),
+        'editor_sample': _("Mr Doe"),
+        'evaluate': lambda op, order, ev: concatenation_for_salutation(order.invoice_address.name_parts if getattr(order, 'invoice_address', None) else {})
+    }
+
     for key, label, weight in scheme['fields']:
         v['invoice_name_%s' % key] = {
             'label': _("Invoice address name: {part}").format(part=label),
             'editor_sample': scheme['sample'][key],
             "evaluate": partial(_get_ia_name_part, key)
         }
-
-    concatenation_for_salutation = scheme.get("concatenation_for_salutation", scheme["concatenation"])
-    v['attendee_name_for_salutation'] = {
-        'label': _("Attendee name for salutation"),
-        'editor_sample': _("Mr Doe"),
-        'evaluate': lambda op, order, ev: concatenation_for_salutation(op.attendee_name_parts)
-    }
-    v['invoice_name_for_salutation'] = {
-        'label': _("Invoice name for salutation"),
-        'editor_sample': _("Mr Doe"),
-        'evaluate': lambda op, order, ev: concatenation_for_salutation(order.invoice_address.name_parts if getattr(order, 'invoice_address', None) else {})
-    }
 
     for recv, res in layout_text_variables.send(sender=event):
         v.update(res)


### PR DESCRIPTION
There is an useful email placeholder `name_for_salutation` which this PR brings to the editor/PDF as well.