### PR TITLE
PDF Editor: set textfield to ??? to hint at placeholder being unknown

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/editor.js
+++ b/src/pretix/static/pretixcontrol/js/ui/editor.js
@@ -286,7 +286,7 @@ var editor = {
         } else if (key.startsWith('meta:')) {
             return key.substr(5);
         }
-        return $('#toolbox-content option[value='+key+'], #toolbox-content option[data-old-value='+key+']').attr('data-sample') || '';
+        return $('#toolbox-content option[value='+key+'], #toolbox-content option[data-old-value='+key+']').attr('data-sample') || '???';
     },
 
     _load_page: function (page_number, dump) {


### PR DESCRIPTION
When e.g. using answers/questions in editor for tickets/badges/etc. and lateron deleting a question, currently the textfield is not visible in/reachable through the GUI as its content is `""`. Although this artefact in the layout itself does no harm and can be fixed in the editor’s code-view, this PR changes the GUI-behaviour for unknown placeholders to render content as `"???"`.