### PR TITLE
PDF Editor: fix CSS selector for non-alphanum content values

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/editor.js
+++ b/src/pretix/static/pretixcontrol/js/ui/editor.js
@@ -286,7 +286,7 @@ var editor = {
         } else if (key.startsWith('meta:')) {
             return key.substr(5);
         }
-        return $('#toolbox-content option[value='+key+'], #toolbox-content option[data-old-value='+key+']').attr('data-sample') || '???';
+        return $('#toolbox-content option[value="'+key+'"], #toolbox-content option[data-old-value="'+key+'"]').attr('data-sample') || '???';
     },
 
     _load_page: function (page_number, dump) {


### PR DESCRIPTION
Currently there seems to be a bug which allows question identifiers to be non-alphanumeric (at least this behaviour is not intended), which causes this selector to fail. This PR fixes it.