### PR TITLE
Limit identifiers (Question, QuestionOption, Customer) to alphanum, dot, dash & underscore

### DIFF
--- a/src/pretix/base/models/customers.py
+++ b/src/pretix/base/models/customers.py
@@ -24,6 +24,7 @@ from django.conf import settings
 from django.contrib.auth.hashers import (
     check_password, is_password_usable, make_password,
 )
+from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import F, Q
 from django.utils.crypto import get_random_string, salted_hmac
@@ -44,7 +45,19 @@ class Customer(LoggedModel):
     """
     id = models.BigAutoField(primary_key=True)
     organizer = models.ForeignKey(Organizer, related_name='customers', on_delete=models.CASCADE)
-    identifier = models.CharField(max_length=190, db_index=True, unique=True)
+    identifier = models.CharField(
+        max_length=190,
+        db_index=True,
+        unique=True,
+        help_text=_('You can enter any value here to make it easier to match the data with other sources. If you do '
+                    'not input one, we will generate one automatically.'),
+        validators=[
+            RegexValidator(
+                regex=r"^[a-zA-Z0-9.\-_]+$",
+                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores."),
+            ),
+        ],
+    )
     email = models.EmailField(db_index=True, null=True, blank=False, verbose_name=_('E-mail'), max_length=190)
     phone = PhoneNumberField(null=True, blank=True, verbose_name=_('Phone number'))
     password = models.CharField(verbose_name=_('Password'), max_length=128)

--- a/src/pretix/base/models/customers.py
+++ b/src/pretix/base/models/customers.py
@@ -53,8 +53,8 @@ class Customer(LoggedModel):
                     'not input one, we will generate one automatically.'),
         validators=[
             RegexValidator(
-                regex=r"^[a-zA-Z0-9.\-_]+$",
-                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores."),
+                regex=r"^[a-zA-Z0-9]([a-zA-Z0-9.\-_]*[a-zA-Z0-9])?$",
+                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores. It must start and end with a letter or number."),
             ),
         ],
     )

--- a/src/pretix/base/models/customers.py
+++ b/src/pretix/base/models/customers.py
@@ -54,7 +54,7 @@ class Customer(LoggedModel):
         validators=[
             RegexValidator(
                 regex=r"^[a-zA-Z0-9]([a-zA-Z0-9.\-_]*[a-zA-Z0-9])?$",
-                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores. It must start and end with a letter or number."),
+                message=_("The identifier may only contain letters, numbers, dots, dashes, and underscores. It must start and end with a letter or number."),
             ),
         ],
     )

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1246,8 +1246,8 @@ class Question(LoggedModel):
                     'not input one, we will generate one automatically.'),
         validators=[
             RegexValidator(
-                regex=r"^[a-zA-Z0-9]([a-zA-Z0-9.\-_]*[a-zA-Z0-9])?$",
-                message=_("The identifier may only contain letters, numbers, dots and dashes. It must start and end with a letter or number."),
+                regex=r"^[a-zA-Z0-9.\-_]+$",
+                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores."),
             ),
         ],
     )
@@ -1467,7 +1467,17 @@ class Question(LoggedModel):
 
 class QuestionOption(models.Model):
     question = models.ForeignKey('Question', related_name='options', on_delete=models.CASCADE)
-    identifier = models.CharField(max_length=190)
+    identifier = models.CharField(
+        max_length=190,
+        help_text=_('You can enter any value here to make it easier to match the data with other sources. If you do '
+                    'not input one, we will generate one automatically.'),
+        validators=[
+            RegexValidator(
+                regex=r"^[a-zA-Z0-9.\-_]+$",
+                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores."),
+            ),
+        ],
+    )
     answer = I18nCharField(verbose_name=_('Answer'))
     position = models.IntegerField(default=0)
 

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1246,7 +1246,7 @@ class Question(LoggedModel):
                     'not input one, we will generate one automatically.'),
         validators=[
             RegexValidator(
-                regex="^[a-zA-Z0-9]([a-zA-Z0-9.\-_]*[a-zA-Z0-9])?$",
+                regex=r"^[a-zA-Z0-9]([a-zA-Z0-9.\-_]*[a-zA-Z0-9])?$",
                 message=_("The identifier may only contain letters, numbers, dots and dashes. It must start and end with a letter or number."),
             ),
         ],

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1243,7 +1243,13 @@ class Question(LoggedModel):
         max_length=190,
         verbose_name=_("Internal identifier"),
         help_text=_('You can enter any value here to make it easier to match the data with other sources. If you do '
-                    'not input one, we will generate one automatically.')
+                    'not input one, we will generate one automatically.'),
+        validators=[
+            RegexValidator(
+                regex="^[a-zA-Z0-9]([a-zA-Z0-9.\-_]*[a-zA-Z0-9])?$",
+                message=_("The identifier may only contain letters, numbers, dots and dashes. It must start and end with a letter or number."),
+            ),
+        ],
     )
     help_text = I18nTextField(
         verbose_name=_("Help text"),

--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1247,7 +1247,7 @@ class Question(LoggedModel):
         validators=[
             RegexValidator(
                 regex=r"^[a-zA-Z0-9.\-_]+$",
-                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores."),
+                message=_("The identifier may only contain letters, numbers, dots, dashes, and underscores."),
             ),
         ],
     )
@@ -1474,7 +1474,7 @@ class QuestionOption(models.Model):
         validators=[
             RegexValidator(
                 regex=r"^[a-zA-Z0-9.\-_]+$",
-                message=_("The identifier may only contain letters, numbers, dots, dashes and underscores."),
+                message=_("The identifier may only contain letters, numbers, dots, dashes, and underscores."),
             ),
         ],
     )


### PR DESCRIPTION
This PR validates question identifiers to only contain alphanum, dot, dash & underscore. It forces identifiers to start and end with an alphanumeric character (currently no real need for this, just to be consistent with event-slug’s constraint).