### PR TITLE
Fix alignment of checkout success message (Z#2399724)

### DIFF
--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -569,16 +569,17 @@ td > .dl-horizontal {
         width: 70%;
         margin: auto;
 
-        .fa {
+        & > .fa {
             float: left;
             margin-right: 30px;
+            margin-left: 0;
         }
 
         h2 {
             padding-top: 25px;
         }
 
-        p {
+        & > * {
             margin-left: 158px;
         }
     }

--- a/src/pretix/static/pretixpresale/scss/_rtl.scss
+++ b/src/pretix/static/pretixpresale/scss/_rtl.scss
@@ -30,12 +30,12 @@ html.rtl {
     padding-right: 20px;
     padding-left: 0;
   }
-  .thank-you .fa {
+  .thank-you > .fa {
     float: right;
     margin-left: 30px;
     margin-right: 0;
   }
-  .thank-you p {
+  .thank-you > * {
     margin-right: 158px;
     margin-left: 0;
   }

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -290,16 +290,17 @@ body.loading .container {
         margin-right: auto;
         margin-bottom: 3em;
 
-        .fa {
+        & > .fa {
             float: left;
             margin-right: 30px;
+            margin-left: 0;
         }
 
         h2 {
             padding-top: 35px;
         }
 
-        p {
+        & > * {
             margin-left: 158px;
         }
     }


### PR DESCRIPTION
When a customized checkout_success_text is used, that has other elements than `<p>`, the alignment was off. This PR fixes the alignment for all types of elements, that are a direct child of the thank-you-element `.thank-you > *`.