### PR TITLE
API: fix recalc of order total and fees after patch-operations (Z#23101774)

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -2317,6 +2317,7 @@ class OrderChangeManager:
                 self._check_and_lock_memberships()
                 try:
                     self._perform_operations()
+                    self.order.refresh_from_db()
                 except TaxRule.SaleNotAllowed:
                     raise OrderError(self.error_messages['tax_rule_country_blocked'])
             self._recalculate_total_and_payment_fee()

--- a/src/tests/api/test_order_change.py
+++ b/src/tests/api/test_order_change.py
@@ -1673,6 +1673,8 @@ def test_order_change_patch(token_client, organizer, event, order, quota):
         assert p.item == item2
         f.refresh_from_db()
         assert f.value == Decimal('10.00')
+        order.refresh_from_db()
+        assert order.total == Decimal('109.44')
 
 
 @pytest.mark.django_db

--- a/src/tests/base/test_orders.py
+++ b/src/tests/base/test_orders.py
@@ -1388,6 +1388,7 @@ class OrderChangeManagerTests(TestCase):
         assert self.order.total == Decimal('0.00')
         assert self.order.status == Order.STATUS_PAID
         self.order.status = Order.STATUS_PENDING
+        self.order.save()
         self.ocm.cancel(self.op2)
         self.ocm.commit()
         self.order.refresh_from_db()
@@ -1746,6 +1747,7 @@ class OrderChangeManagerTests(TestCase):
 
         ia.vat_id_validated = False
         ia.save()
+        self.order.refresh_from_db()
 
         self.ocm = OrderChangeManager(self.order, None)
         self.ocm.recalculate_taxes()


### PR DESCRIPTION
When changing positions through the API, cached values were used for recalc of order total, etc. This PR fixes it by refreshing order from DB after performing patch operations in API.