### PR TITLE
PDF render: enable word-wrap on hyphens (Z#23101879)

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -831,9 +831,10 @@ class Renderer:
             textColor=Color(o['color'][0] / 255, o['color'][1] / 255, o['color'][2] / 255),
             alignment=align_map[o['align']]
         )
+        # add an almost-invisible space &hairsp; after hyphens as word-wrap in ReportLab only works on space chars
         text = conditional_escape(
             self._get_text_content(op, order, o) or "",
-        ).replace("\n", "<br/>\n")
+        ).replace("\n", "<br/>\n").replace("-", "-&hairsp;")
 
         # reportlab does not support RTL, ligature-heavy scripts like Arabic. Therefore, we use ArabicReshaper
         # to resolve all ligatures and python-bidi to switch RTL texts.


### PR DESCRIPTION
In ReportLab the automatic word wrap only works on space characters. When rendering long strings (e.g. names) this creates ugly line-breaks. This PR adds an almost invisible space after hyphen characters to enable word wrapping in words with hyphens. Sadly the „zero width space“ is not supported/not recognized as a word boundary, but the „hair space“ works.

Before:
![Bildschirmfoto 2022-06-21 um 09 12 04](https://user-images.githubusercontent.com/276509/174739802-f2b7c18b-490b-4a86-b4d6-634defadf3b1.png)

After:
![Bildschirmfoto 2022-06-21 um 09 11 22](https://user-images.githubusercontent.com/276509/174739837-ca328d7f-0a45-4141-b9d5-f4559f4bc3c5.png)

