### PR TITLE
Checkout: label add-ons as free if price is 0 and add-ons are not included in the main product (Z#23101974)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -127,29 +127,29 @@
                                             </del>
                                             <ins><span class="sr-only">{% trans "New price:" %}</span>
                                         {% endif %}
-                                    {% if item.free_price %}
-                                        <div class="input-group input-group-price">
-                                            <span class="input-group-addon">{{ event.currency }}</span>
-                                            <input type="number" class="form-control input-item-price"
-                                                    id="price-variation-{{form.pos.pk}}-{{ item.pk }}-{{ var.pk }}"
-                                                    placeholder="0"
-                                                    min="{% if event.settings.display_net_prices %}{{ var.display_price.net|money_numberfield:event.currency }}{% else %}{{ var.display_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                                    name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}_price"
-                                                    title="{% blocktrans trimmed with item=var.value %}Modify price for {{ item }}{% endblocktrans %}"
-                                                    step="any"
-                                                    value="{% if event.settings.display_net_prices %}{{ var.initial_price.net|money_numberfield:event.currency }}{% else %}{{ var.initial_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                            >
-                                        </div>
-                                    {% elif not var.display_price.gross %}
-                                        <span class="text-uppercase">{% trans "free" context "price" %}</span>
-                                    {% elif event.settings.display_net_prices %}
-                                        {{ var.display_price.net|money:event.currency }}
-                                    {% else %}
-                                        {{ var.display_price.gross|money:event.currency }}
-                                    {% endif %}
-                                    {% if item.original_price or var.original_price %}
-                                        </ins>
-                                    {% endif %}
+                                        {% if item.free_price %}
+                                            <div class="input-group input-group-price">
+                                                <span class="input-group-addon">{{ event.currency }}</span>
+                                                <input type="number" class="form-control input-item-price"
+                                                        id="price-variation-{{form.pos.pk}}-{{ item.pk }}-{{ var.pk }}"
+                                                        placeholder="0"
+                                                        min="{% if event.settings.display_net_prices %}{{ var.display_price.net|money_numberfield:event.currency }}{% else %}{{ var.display_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                                        name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}_price"
+                                                        title="{% blocktrans trimmed with item=var.value %}Modify price for {{ item }}{% endblocktrans %}"
+                                                        step="any"
+                                                        value="{% if event.settings.display_net_prices %}{{ var.initial_price.net|money_numberfield:event.currency }}{% else %}{{ var.initial_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                                >
+                                            </div>
+                                        {% elif not var.display_price.gross %}
+                                            <span class="text-uppercase">{% trans "free" context "price" %}</span>
+                                        {% elif event.settings.display_net_prices %}
+                                            {{ var.display_price.net|money:event.currency }}
+                                        {% else %}
+                                            {{ var.display_price.gross|money:event.currency }}
+                                        {% endif %}
+                                        {% if item.original_price or var.original_price %}
+                                            </ins>
+                                        {% endif %}
                                         {% if item.includes_mixed_tax_rate %}
                                             {% if event.settings.display_net_prices %}
                                                 <small>{% trans "plus taxes" %}</small>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -141,6 +141,7 @@
                                             >
                                         </div>
                                     {% elif not var.display_price.gross %}
+                                        <span class="text-uppercase">{% trans "free" context "price" %}</span>
                                     {% elif event.settings.display_net_prices %}
                                         {{ var.display_price.net|money:event.currency }}
                                     {% else %}
@@ -286,7 +287,7 @@
                                     {% endblocktrans %}</small>
                                 {% endif %}
                             {% else %}
-                                {% trans "FREE" context "price" %}
+                                <span class="text-uppercase">{% trans "free" context "price" %}</span>
                             {% endif %}
                         </p>
                     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -262,7 +262,7 @@
                                                 step="any">
                                     </div>
                                 {% elif not item.display_price.gross %}
-                                    {% trans "FREE" context "price" %}
+                                    <span class="text-uppercase">{% trans "free" context "price" %}</span>
                                 {% elif event.settings.display_net_prices %}
                                     {{ item.display_price.net|money:event.currency }}
                                 {% else %}
@@ -287,7 +287,7 @@
                                     {% endblocktrans %}</small>
                                 {% endif %}
                             {% else %}
-                                <span class="text-uppercase">{% trans "free" context "price" %}</span>
+                                <span class="sr-only">{% trans "free" context "price" %}</span>
                             {% endif %}
                         </p>
                     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -181,6 +181,7 @@
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         data-exclusive-prefix="cp_{{ form.pos.pk }}_variation_{{ item.id }}_"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
+                                                <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
                                             </label>
                                         {% else %}
                                             <input type="number" class="form-control input-item-count" placeholder="0" min="0"
@@ -307,6 +308,7 @@
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                             {% if item.description %} aria-describedby="cp-{{ form.pos.pk }}-item-{{ item.id }}-description"{% endif %}>
+                                            <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
                                 </label>
                             {% else %}
                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -284,7 +284,7 @@
                                     {% endblocktrans %}</small>
                                 {% endif %}
                             {% else %}
-                                <span class="sr-only">{% trans "free" context "price" %}</span>
+                                {% trans "FREE" context "price" %}
                             {% endif %}
                         </p>
                     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -248,23 +248,24 @@
                                     </del>
                                     <ins><span class="sr-only">{% trans "New price:" %}</span>
                                 {% endif %}
-                            {% if item.free_price %}
-                                <div class="input-group input-group-price">
-                                    <span class="input-group-addon">{{ event.currency }}</span>
-                                    <input type="number" class="form-control input-item-price" placeholder="0"
-                                            id="price-item-{{ form.pos.pk }}-{{ item.pk }}"
-                                            min="{% if event.settings.display_net_prices %}{{ item.display_price.net|money_numberfield:event.currency }}{% else %}{{ item.display_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                            name="cp_{{ form.pos.pk }}_item_{{ item.id }}_price"
-                                            title="{% blocktrans trimmed with item=item.name %}Modify price for {{ item }}{% endblocktrans %}"
-                                            value="{% if event.settings.display_net_prices %}{{ item.initial_price.net|money_numberfield:event.currency }}{% else %}{{ item.initial_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                            step="any">
-                                </div>
-                            {% elif not item.display_price.gross %}
-                            {% elif event.settings.display_net_prices %}
-                                {{ item.display_price.net|money:event.currency }}
-                            {% else %}
-                                {{ item.display_price.gross|money:event.currency }}
-                            {% endif %}
+                                {% if item.free_price %}
+                                    <div class="input-group input-group-price">
+                                        <span class="input-group-addon">{{ event.currency }}</span>
+                                        <input type="number" class="form-control input-item-price" placeholder="0"
+                                                id="price-item-{{ form.pos.pk }}-{{ item.pk }}"
+                                                min="{% if event.settings.display_net_prices %}{{ item.display_price.net|money_numberfield:event.currency }}{% else %}{{ item.display_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                                name="cp_{{ form.pos.pk }}_item_{{ item.id }}_price"
+                                                title="{% blocktrans trimmed with item=item.name %}Modify price for {{ item }}{% endblocktrans %}"
+                                                value="{% if event.settings.display_net_prices %}{{ item.initial_price.net|money_numberfield:event.currency }}{% else %}{{ item.initial_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                                step="any">
+                                    </div>
+                                {% elif not item.display_price.gross %}
+                                    {% trans "FREE" context "price" %}
+                                {% elif event.settings.display_net_prices %}
+                                    {{ item.display_price.net|money:event.currency }}
+                                {% else %}
+                                    {{ item.display_price.gross|money:event.currency }}
+                                {% endif %}
                                 {% if item.original_price %}
                                     </ins>
                                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -276,7 +276,7 @@
                             </div>
                             <p>
                         {% elif not item.display_price.gross %}
-                            {% trans "FREE" context "price" %}
+                            <span class="text-uppercase">{% trans "free" context "price" %}</span>
                         {% elif event.settings.display_net_prices %}
                             {{ item.display_price.net|money:event.currency }}
                         {% else %}


### PR DESCRIPTION
~~This PR adds a label „FREE“ in price columns to products that are free – previously addons have not had anything shown if they were free. I see how this works well with all addons being free, but IMHO is a bit confusing if free addons are combined with addons that have a price other than 0.~~

Furthermore this PR adds cart-icons to addons-checkboxes like they are used in the normal product selection. Sorry, if this mixes two only remotely related things into one PR.

UPDATE: this PR adds the label „free“ to addon-products, if their price is 0.00 and if the main product’s setting „price_included“ is set to false. If the main product’s setting „price_included“ is true, everything will stay as is and the label „free“ is only available to screen reader users.