### PR TITLE
Banktransfer: add help-text to name of account holder

### DIFF
--- a/src/pretix/plugins/banktransfer/payment.py
+++ b/src/pretix/plugins/banktransfer/payment.py
@@ -80,6 +80,7 @@ class BankTransfer(BasePaymentProvider):
             )),
             ('bank_details_sepa_name', forms.CharField(
                 label=_('Name of account holder'),
+                help_text=_('Please note: special characters other than letters, numbers and punctuation can cause problems with some banks.'),
                 widget=forms.TextInput(
                     attrs={
                         'data-display-dependency': '#id_payment_banktransfer_bank_details_type_0',

--- a/src/pretix/plugins/banktransfer/payment.py
+++ b/src/pretix/plugins/banktransfer/payment.py
@@ -80,7 +80,7 @@ class BankTransfer(BasePaymentProvider):
             )),
             ('bank_details_sepa_name', forms.CharField(
                 label=_('Name of account holder'),
-                help_text=_('Please note: special characters other than letters, numbers and punctuation can cause problems with some banks.'),
+                help_text=_('Please note: special characters other than letters, numbers and some punctuation can cause problems with some banks.'),
                 widget=forms.TextInput(
                     attrs={
                         'data-display-dependency': '#id_payment_banktransfer_bank_details_type_0',

--- a/src/pretix/plugins/banktransfer/payment.py
+++ b/src/pretix/plugins/banktransfer/payment.py
@@ -80,7 +80,7 @@ class BankTransfer(BasePaymentProvider):
             )),
             ('bank_details_sepa_name', forms.CharField(
                 label=_('Name of account holder'),
-                help_text=_('Please note: special characters other than letters, numbers and some punctuation can cause problems with some banks.'),
+                help_text=_('Please note: special characters other than letters, numbers, and some punctuation can cause problems with some banks.'),
                 widget=forms.TextInput(
                     attrs={
                         'data-display-dependency': '#id_payment_banktransfer_bank_details_type_0',


### PR DESCRIPTION
Add some help_text regarding special characters in the account holder’s name. Punctuation though is not 100% correct as it seems e.g. ! can cause problems. Maybe use „some punctuation“ instead?