### PR TITLE
Fix timezone in email placeholder event_admission_time (Z#23102667)

### DIFF
--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -475,8 +475,11 @@ def base_placeholders(sender, **kwargs):
         ),
         SimpleFunctionalMailTextPlaceholder(
             'event_admission_time', ['event_or_subevent'],
-            lambda event_or_subevent: date_format(event_or_subevent.date_admission, 'TIME_FORMAT') if event_or_subevent.date_admission else '',
-            lambda event: date_format(event.date_admission, 'TIME_FORMAT') if event.date_admission else '',
+            lambda event_or_subevent:
+                date_format(event_or_subevent.date_admission.astimezone(event_or_subevent.timezone), 'TIME_FORMAT')
+                if event_or_subevent.date_admission
+                else '',
+            lambda event: date_format(event.date_admission.astimezone(event.timezone), 'TIME_FORMAT') if event.date_admission else '',
         ),
         SimpleFunctionalMailTextPlaceholder(
             'subevent', ['waiting_list_entry', 'event'],


### PR DESCRIPTION
E-Mail placeholder event_admission_time was missing a `astimezone`. I glanced over the other placeholders in email.py as well and have not spotted any other issues.