### PR TITLE
Add custom_field in orders API

### DIFF
--- a/doc/api/resources/orders.rst
+++ b/doc/api/resources/orders.rst
@@ -60,6 +60,7 @@ invoice_address                       object                     Invoice address
 ├ state                               string                     Customer state (ISO 3166-2 code). Only supported in
                                                                  AU, BR, CA, CN, MY, MX, and US.
 ├ internal_reference                  string                     Customer's internal reference to be printed on the invoice
+├ custom_field                        string                     Custom invoice address field
 ├ vat_id                              string                     Customer VAT ID
 └ vat_id_validated                    string                     ``true``, if the VAT ID has been validated against the
                                                                  EU VAT service and validation was successful. This only

--- a/src/pretix/api/serializers/order.py
+++ b/src/pretix/api/serializers/order.py
@@ -92,7 +92,7 @@ class InvoiceAddressSerializer(I18nAwareModelSerializer):
     class Meta:
         model = InvoiceAddress
         fields = ('last_modified', 'is_business', 'company', 'name', 'name_parts', 'street', 'zipcode', 'city', 'country',
-                  'state', 'vat_id', 'vat_id_validated', 'internal_reference')
+                  'state', 'vat_id', 'vat_id_validated', 'custom_field', 'internal_reference')
         read_only_fields = ('last_modified',)
 
     def __init__(self, *args, **kwargs):

--- a/src/tests/api/test_order_create.py
+++ b/src/tests/api/test_order_create.py
@@ -172,6 +172,7 @@ ORDER_CREATE_PAYLOAD = {
         "city": "Sample City",
         "country": "NZ",
         "internal_reference": "",
+        "custom_field": None,
         "vat_id": ""
     },
     "positions": [
@@ -320,7 +321,8 @@ def test_order_create_simulate(token_client, organizer, event, item, quota, ques
             'state': '',
             'vat_id': '',
             'vat_id_validated': False,
-            'internal_reference': ''
+            'internal_reference': '',
+            'custom_field': None
         },
         'positions': [
             {

--- a/src/tests/api/test_orders.py
+++ b/src/tests/api/test_orders.py
@@ -114,7 +114,7 @@ def order(event, item, taxrule, question):
         o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
                       tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
         InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
-                                      vat_id="DE123", vat_id_validated=True)
+                                      vat_id="DE123", vat_id_validated=True, custom_field="Custom info")
         op = OrderPosition.objects.create(
             order=o,
             item=item,
@@ -264,6 +264,7 @@ TEST_ORDER_RES = {
         "country": "NZ",
         "state": "",
         "internal_reference": "",
+        "custom_field": "Custom info",
         "vat_id": "DE123",
         "vat_id_validated": True
     },

--- a/src/tests/base/test_shredders.py
+++ b/src/tests/base/test_shredders.py
@@ -222,6 +222,7 @@ def test_invoice_address_shredder(event, order):
             'company': 'Acme Company',
             'country': 'UK',
             'internal_reference': '',
+            'custom_field': None,
             'is_business': False,
             'last_modified': ia.last_modified.isoformat().replace('+00:00', 'Z'),
             'name': '',


### PR DESCRIPTION
Add the `custom_field` in the `order.invoice_address` resource for REST API.