### PR TITLE
Docs: Clarify customer name field editing

### DIFF
--- a/doc/api/resources/customers.rst
+++ b/doc/api/resources/customers.rst
@@ -173,8 +173,8 @@ Endpoints
    the resource, other fields will be reset to default. With ``PATCH``, you only need to provide the fields that you
    want to change.
 
-   You can change all fields of the resource except the ``identifier``, ``last_login``, ``date_joined``, ``name``,
-   and ``last_modified`` fields.
+   You can change all fields of the resource except the ``identifier``, ``last_login``, ``date_joined``,
+   ``name`` (which is auto-generated from ``name_parts``), and ``last_modified`` fields.
 
    **Example request**:
 


### PR DESCRIPTION
Upon my first reading, I thought the name of a customer couldn’t be changed, but that’s not correct. PATCH requests that update the name_parts field work fine, and that influences the name field.

I think what the docs are trying to convey is that the name field is never settable because it’s derived from the name_parts field, so update the prose to make that more clear.