### PR TITLE
API: Allow to send activation email when creating customers

### DIFF
--- a/doc/api/resources/customers.rst
+++ b/doc/api/resources/customers.rst
@@ -131,7 +131,9 @@ Endpoints
 
 .. http:post:: /api/v1/organizers/(organizer)/customers/
 
-   Creates a new customer
+   Creates a new customer. In addition to the fields defined on the resource, you can pass the field ``send_email``
+   to control whether the system should send an account activation email with a password reset link (defaults to
+   ``false``).
 
    **Example request**:
 
@@ -143,7 +145,8 @@ Endpoints
       Content-Type: application/json
 
       {
-        "email": "test@example.org"
+        "email": "test@example.org",
+        "send_email": true
       }
 
    **Example response**:

--- a/src/pretix/api/serializers/organizer.py
+++ b/src/pretix/api/serializers/organizer.py
@@ -75,6 +75,14 @@ class CustomerSerializer(I18nAwareModelSerializer):
                   'locale', 'last_modified', 'notes')
 
 
+class CustomerCreateSerializer(CustomerSerializer):
+    send_email = serializers.BooleanField(default=False, required=False, allow_null=True)
+
+    class Meta:
+        model = Customer
+        fields = CustomerSerializer.Meta.fields + ('send_email',)
+
+
 class MembershipTypeSerializer(I18nAwareModelSerializer):
 
     class Meta:

--- a/src/pretix/base/models/customers.py
+++ b/src/pretix/base/models/customers.py
@@ -216,6 +216,27 @@ class Customer(LoggedModel):
             testmode=testmode,
         )
 
+    def send_activation_mail(self):
+        from pretix.base.services.mail import mail
+        from pretix.multidomain.urlreverse import build_absolute_uri
+        from pretix.presale.forms.customer import TokenGenerator
+
+        ctx = self.get_email_context()
+        token = TokenGenerator().make_token(self)
+        ctx['url'] = build_absolute_uri(
+            self.organizer,
+            'presale:organizer.customer.activate'
+        ) + '?id=' + self.identifier + '&token=' + token
+        mail(
+            self.email,
+            _('Activate your account at {organizer}').format(organizer=self.organizer.name),
+            self.organizer.settings.mail_text_customer_registration,
+            ctx,
+            locale=self.locale,
+            customer=self,
+            organizer=self.organizer,
+        )
+
 
 class AttendeeProfile(models.Model):
     customer = models.ForeignKey(

--- a/src/pretix/presale/forms/customer.py
+++ b/src/pretix/presale/forms/customer.py
@@ -41,9 +41,7 @@ from pretix.base.forms.questions import (
 )
 from pretix.base.i18n import get_language_without_region
 from pretix.base.models import Customer
-from pretix.base.services.mail import mail
 from pretix.helpers.http import get_client_ip
-from pretix.multidomain.urlreverse import build_absolute_uri
 
 
 class TokenGenerator(PasswordResetTokenGenerator):
@@ -268,19 +266,7 @@ class RegistrationForm(forms.Form):
         customer.set_unusable_password()
         customer.save()
         customer.log_action('pretix.customer.created', {})
-        ctx = customer.get_email_context()
-        token = TokenGenerator().make_token(customer)
-        ctx['url'] = build_absolute_uri(self.request.organizer,
-                                        'presale:organizer.customer.activate') + '?id=' + customer.identifier + '&token=' + token
-        mail(
-            customer.email,
-            _('Activate your account at {organizer}').format(organizer=self.request.organizer.name),
-            self.request.organizer.settings.mail_text_customer_registration,
-            ctx,
-            locale=customer.locale,
-            customer=customer,
-            organizer=self.request.organizer,
-        )
+        customer.send_activation_mail()
         return customer
 
 


### PR DESCRIPTION
Before this commit, customers whose accounts were created via the API would not
get any email, and would not be able to log in until they followed the reset
password flow — not a great experience overall.

With this commit, customers created via the API get the same activation email
that they would get when using the account creation form.