### PR TITLE
checkout: fix initial membership selection with only one choice

### DIFF
--- a/src/pretix/presale/forms/checkout.py
+++ b/src/pretix/presale/forms/checkout.py
@@ -221,15 +221,13 @@ class MembershipForm(forms.Form):
         else:
             types = self.position.item.require_membership_types.all()
 
-        initial = None
-
         memberships = [
             m for m in self.memberships
             if m.is_valid(ev) and m.membership_type in types
         ]
 
         if len(memberships) == 1:
-            initial = str(memberships[0].pk)
+            self.initial['membership'] = str(memberships[0].pk)
 
         self.fields['membership'] = forms.ChoiceField(
             label=_('Membership'),
@@ -237,7 +235,6 @@ class MembershipForm(forms.Form):
                 (str(m.pk), self._label_from_instance(m))
                 for m in memberships
             ],
-            initial=initial,
             widget=forms.RadioSelect,
         )
         self.is_empty = not memberships


### PR DESCRIPTION
Before this commit:
![before](https://user-images.githubusercontent.com/55506/181369198-0499edc7-fe8d-413e-be08-aa545dd661e1.jpg)

With this commit:
![after](https://user-images.githubusercontent.com/55506/181369226-aea4992d-4d76-4fc7-b116-30ee0c24f005.jpg)
