### PR TITLE
Presale: fix doubled error messages (Z#23104019)

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -191,6 +191,7 @@ function setup_basics(el) {
         else $(":input", this).get(0).focus();
     });
     el.find(".alert-danger").first().each(function() {
+        var container = this;
         var content = $("<ul></ul>").click(function(e) {
             var input = $(e.target.hash).get(0);
             if (input) input.focus();
@@ -199,13 +200,14 @@ function setup_basics(el) {
         });
         $(".has-error").each(function() {
             var target = target = $(":input", this);
-            if (!target || !target.attr("aria-describedby")) return;
-            var desc = $("#" + target.attr("aria-describedby").split(' ', 1)[0]);
+            var desc = target && target.attr("aria-describedby") ? document.getElementById(target.attr("aria-describedby").split(' ', 1)[0]) : null;
+            if (!target || !desc || desc == container) return;
+
             // multi-input fields have a role=group with aria-labelledby
             var label = this.hasAttribute("aria-labelledby") ? $("#" + this.getAttribute("aria-labelledby")) : $("[for="+target.attr("id")+"]");
 
             var $li = $("<li>");
-            $li.text(": " + desc.text())
+            $li.text(": " + desc.textContent)
             $li.prepend($("<a>").attr("href", "#" + target.attr("id")).text(label.get(0).childNodes[0].nodeValue))
             content.append($li);
         });


### PR DESCRIPTION
When entering an unknown/invalid voucher code, the error message was shown twice. The error for the voucher-input was using aria-describedby on the main alert-box at the top, which Javascript uses to display the aria-describedby error-messages for each input, that has errors. That caused the error message for vouchers to appear twice.

This PR checks, if the description is actually the alert box and does not another message to it. Drawback to this is, that in this error message there is no link to go to the input anymore.

Generally error messages around voucher input are not ideal, as the error currently only gets shown at the top of the page but JavaScript focuses the first input with error – which for vouchers is usually so far down the page, that the error message is scrolled out of view. I guess this issue is out of scope for this PR, but we should think about adding the error message closer to the input as well – as we already do with other form inputs. Should I open an issue, so we do not forget about this?