### PR TITLE
Docker: Set AUTOMIGRATE=skip for subprocesses

### DIFF
--- a/deployment/docker/supervisord/base.conf
+++ b/deployment/docker/supervisord/base.conf
@@ -2,6 +2,7 @@
 file=/tmp/supervisor.sock
 
 [supervisord]
+environment = AUTOMIGRATE="skip"
 logfile=/dev/stdout
 logfile_maxbytes=0
 loglevel=info


### PR DESCRIPTION
`/usr/local/bin/pretix` (`deployment/docker/pretix.bash` in git) runs `supervisor`,
at least the `all` and `web` subcommands.

But, the `pretixtask` and `pretixweb` supervisor programs each also run
`/usr/local/bin/pretix taskworker` and `webworker`, respectively.

This means that `/usr/local/bin/pretix` does 3 `pretix migrate` calls,
two of which run in parallel and will likely never migrate anything
(as another migration ran *just before*).

I instrumented my `/usr/local/bin/pretix` with a `set -x` call.

Before this commit, pretix logs 3 migrations and starts in 19 seconds:

```
Jul 29 20:00:57 exo1 systemd[1]: Started pretix.
Jul 29 20:00:58 exo1 docker[46319]: + python3 -m pretix migrate --noinput
Jul 29 20:01:03 exo1 docker[46319]:   No migrations to apply.
Jul 29 20:01:05 exo1 docker[46319]: + python3 -m pretix migrate --noinput
Jul 29 20:01:05 exo1 docker[46319]: + python3 -m pretix migrate --noinput
Jul 29 20:01:16 exo1 docker[46319]: [2022-07-29 20:01:16,958: INFO/MainProcess] celery@226c0a8cba3d ready.
```

After this commit, pretix logs 1 migration and starts in 14 seconds:

```
Jul 29 20:07:15 exo1 systemd[1]: Started pretix.
Jul 29 20:07:15 exo1 docker[46699]: + python3 -m pretix migrate --noinput
Jul 29 20:07:23 exo1 docker[46699]: + '[' skip '!=' skip ']'
Jul 29 20:07:23 exo1 docker[46699]: + '[' skip '!=' skip ']'
Jul 29 20:07:29 exo1 docker[46699]: [2022-07-29 20:07:29,564: INFO/MainProcess] celery@5419323cf4cc ready.
```