### PR TITLE
Set default for SITE_URL to localhost:8000

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -170,7 +170,7 @@ PRETIX_SESSION_TIMEOUT_RELATIVE = 3600 * 3
 PRETIX_SESSION_TIMEOUT_ABSOLUTE = 3600 * 12
 PRETIX_PRIMARY_COLOR = '#8E44B3'
 
-SITE_URL = config.get('pretix', 'url', fallback='http://localhost')
+SITE_URL = config.get('pretix', 'url', fallback='http://localhost:8000')
 if SITE_URL.endswith('/'):
     SITE_URL = SITE_URL[:-1]
 


### PR DESCRIPTION
This matches the default listening port of `python manage.py runserver`, which the pretix development guide recommends using: https://docs.pretix.eu/en/latest/development/setup.html#run-the-development-server