### PR TITLE
Retain filenames when cloning an event

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -920,10 +920,7 @@ class Event(EventMixin, LoggedModel):
             if s.value.startswith('file://'):
                 fi = default_storage.open(s.value[len('file://'):], 'rb')
                 nonce = get_random_string(length=8)
-                if s.key == 'mail_attachment_new_order':
-                    fname_base = clean_filename(os.path.basename(s.value))
-                else:
-                    fname_base = s.key
+                fname_base = clean_filename(os.path.basename(s.value))
 
                 # TODO: make sure pub is always correct
                 fname = 'pub/%s/%s/%s.%s.%s' % (

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -921,7 +921,7 @@ class Event(EventMixin, LoggedModel):
                 fi = default_storage.open(s.value[len('file://'):], 'rb')
                 nonce = get_random_string(length=8)
                 if s.key == 'mail_attachment_new_order':
-                    fname_base = clean_filename(os.path.basename(s.value[len('file://'):]))
+                    fname_base = clean_filename(os.path.basename(s.value))
                 else:
                     fname_base = s.key
 

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -69,6 +69,7 @@ from pretix.base.reldate import RelativeDateWrapper
 from pretix.base.validators import EventSlugBanlistValidator
 from pretix.helpers.database import GroupConcat
 from pretix.helpers.daterange import daterange
+from pretix.helpers.hierarkey import clean_filename
 from pretix.helpers.json import safe_string
 from pretix.helpers.thumb import get_thumbnail
 
@@ -917,12 +918,18 @@ class Event(EventMixin, LoggedModel):
             s.object = self
             s.pk = None
             if s.value.startswith('file://'):
-                fi = default_storage.open(s.value[7:], 'rb')
+                fi = default_storage.open(s.value[len('file://'):], 'rb')
                 nonce = get_random_string(length=8)
-                # TODO: make sure pub is always correct
-                fname = 'pub/%s/%s/%s.%s.%s' % (
-                    self.organizer.slug, self.slug, s.key, nonce, s.value.split('.')[-1]
-                )
+                if s.key == 'mail_attachment_new_order':
+                    fname_clean = clean_filename(os.path.basename(s.value[len('file://'):]))
+                    fname = 'pub/%s/%s/%s.%s.%s' % (
+                        self.organizer.slug, self.slug, fname_clean, nonce, s.value.split('.')[-1]
+                    )
+                else:
+                    # TODO: make sure pub is always correct
+                    fname = 'pub/%s/%s/%s.%s.%s' % (
+                        self.organizer.slug, self.slug, s.key, nonce, s.value.split('.')[-1]
+                    )
                 newname = default_storage.save(fname, fi)
                 s.value = 'file://' + newname
                 s.save()

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -921,15 +921,14 @@ class Event(EventMixin, LoggedModel):
                 fi = default_storage.open(s.value[len('file://'):], 'rb')
                 nonce = get_random_string(length=8)
                 if s.key == 'mail_attachment_new_order':
-                    fname_clean = clean_filename(os.path.basename(s.value[len('file://'):]))
-                    fname = 'pub/%s/%s/%s.%s.%s' % (
-                        self.organizer.slug, self.slug, fname_clean, nonce, s.value.split('.')[-1]
-                    )
+                    fname_base = clean_filename(os.path.basename(s.value[len('file://'):]))
                 else:
-                    # TODO: make sure pub is always correct
-                    fname = 'pub/%s/%s/%s.%s.%s' % (
-                        self.organizer.slug, self.slug, s.key, nonce, s.value.split('.')[-1]
-                    )
+                    fname_base = s.key
+
+                # TODO: make sure pub is always correct
+                fname = 'pub/%s/%s/%s.%s.%s' % (
+                    self.organizer.slug, self.slug, fname_base, nonce, s.value.split('.')[-1]
+                )
                 newname = default_storage.save(fname, fi)
                 s.value = 'file://' + newname
                 s.save()


### PR DESCRIPTION
attempt to fix #2771 by retaining the original mail_attachment_new_order filename.