### PR TITLE
Fix JavaScript for custom select2 focus handler

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -565,7 +565,7 @@ var form_handlers = function (el) {
             },
         }).on("select2:select", function () {
             // Allow continuing to select
-            if ($s.hasAttribute("multiple")) {
+            if ($s[0].hasAttribute("multiple")) {
                 window.setTimeout(function () {
                     $s.parent().find('.select2-search__field').focus();
                 }, 50);


### PR DESCRIPTION
When using select2 in pretix-control a JavaScript error is thrown when trying to access `hasAttribute` on a jQuery-object instead of the actual DOM-node.