### PR TITLE
Fix discount for distinct dates when only certain products are allowed (Z#23107419)

### DIFF
--- a/src/pretix/base/models/discount.py
+++ b/src/pretix/base/models/discount.py
@@ -327,7 +327,7 @@ class Discount(LoggedModel):
                 candidates = []
                 cardinality = None
                 for se, l in subevent_to_idx.items():
-                    l = [ll for ll in l if ll not in current_group]
+                    l = [ll for ll in l if ll in initial_candidates and ll not in current_group]
                     if cardinality and len(l) != cardinality:
                         continue
                     if se not in {positions[idx][1] for idx in current_group}:


### PR DESCRIPTION
When a discount needs discounted products to be from different dates from an event series, the product-filter for this discount (`initial_candidates`) was not applied. This PR fixes this.

AFAICT tests in tests/base/test_pricing_discount.py currently do not test for the product filter at all. Is this somewhere else or something we should add?