### PR TITLE
api: allow changing customer password

### DIFF
--- a/doc/api/resources/customers.rst
+++ b/doc/api/resources/customers.rst
@@ -26,8 +26,9 @@ date_joined                           datetime                   Date and time o
 locale                                string                     Preferred language of the customer
 last_modified                         datetime                   Date and time of modification of the record
 notes                                 string                     Internal notes and comments (or ``null``)
-password                              string                     Can only be set during creation of a new customer, will
-                                                                 not be included in any responses.
+password                              string                     Can be set during creation of a new customer, or
+                                                                 changed when updating a customer. Will not be included
+                                                                 in any responses.
 ===================================== ========================== =======================================================
 
 .. versionadded:: 4.0
@@ -35,6 +36,10 @@ password                              string                     Can only be set
 .. versionchanged:: 4.3
 
    Passwords can now be set through the API during customer creation.
+
+.. versionchanged:: 4.13
+
+   Passwords can now be changed through the API.
 
 Endpoints
 ---------

--- a/src/pretix/api/serializers/organizer.py
+++ b/src/pretix/api/serializers/organizer.py
@@ -72,7 +72,19 @@ class CustomerSerializer(I18nAwareModelSerializer):
     class Meta:
         model = Customer
         fields = ('identifier', 'external_identifier', 'email', 'name', 'name_parts', 'is_active', 'is_verified', 'last_login', 'date_joined',
-                  'locale', 'last_modified', 'notes')
+                  'locale', 'last_modified', 'notes', 'password')
+        extra_kwargs = {
+            "password": {"write_only": True},
+        }
+
+    def update(self, instance, validated_data):
+        for attr, value in validated_data.items():
+            if attr == 'password':
+                instance.set_password(value)
+            else:
+                setattr(instance, attr, value)
+        instance.save()
+        return instance
 
 
 class CustomerCreateSerializer(CustomerSerializer):

--- a/src/tests/api/test_customers.py
+++ b/src/tests/api/test_customers.py
@@ -133,11 +133,13 @@ def test_customer_patch(token_client, organizer, customer):
         format='json',
         data={
             'email': 'blubb@example.org',
+            'password': 'qux',
         }
     )
     assert resp.status_code == 200
     customer.refresh_from_db()
     assert customer.email == 'blubb@example.org'
+    assert customer.check_password('qux')
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
To connect pretix to an external source-of-truth for customer accounts, setting the password at account creation time is a good first step (https://github.com/pretix/pretix/pull/2758).

In order to implement a password reset feature, we also need to change an existing customer’s password, which this PR implements.