### PR TITLE
PDF: Add event weekday variable

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -157,6 +157,18 @@ class EventMixin:
             ("SHORT_" if short else "") + ("DATETIME_FORMAT" if self.settings.show_times and show_times else "DATE_FORMAT")
         )
 
+    def get_weekday_to_display(self, tz=None, short=False) -> str:
+        """
+        Returns a formatted string containing the weekday of the start date of the event with respect
+        to the current locale.
+        """
+        tz = tz or self.timezone
+        if not self.settings.show_date_to or not self.date_to:
+            return ""
+        return _date(
+            self.date_to.astimezone(tz), ("D" if short else "l")
+        )
+
     def get_date_range_display(self, tz=None, force_show_end=False, as_html=False) -> str:
         """
         Returns a formatted string containing the start date and the end date

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -159,7 +159,7 @@ class EventMixin:
 
     def get_weekday_to_display(self, tz=None, short=False) -> str:
         """
-        Returns a formatted string containing the weekday of the start date of the event with respect
+        Returns a formatted string containing the weekday of the end date of the event with respect
         to the current locale.
         """
         tz = tz or self.timezone

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -123,6 +123,16 @@ class EventMixin:
             ("SHORT_" if short else "") + ("DATETIME_FORMAT" if self.settings.show_times and show_times else "DATE_FORMAT")
         )
 
+    def get_weekday_from_display(self, tz=None, short=False) -> str:
+        """
+        Returns a formatted string containing the weekday of the start date of the event with respect
+        to the current locale.
+        """
+        tz = tz or self.timezone
+        return _date(
+            self.date_from.astimezone(tz), ("D" if short else "l")
+        )
+
     def get_time_from_display(self, tz=None) -> str:
         """
         Returns a formatted string containing the start time of the event, ignoring

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -251,6 +251,11 @@ DEFAULT_VARIABLES = OrderedDict((
         "editor_sample": _("20:00"),
         "evaluate": lambda op, order, ev: ev.get_time_from_display()
     }),
+    ("event_begin_weekday", {
+        "label": _("Event begin weekday"),
+        "editor_sample": _("Friday"),
+        "evaluate": lambda op, order, ev: ev.get_weekday_from_display()
+    }),
     ("event_end", {
         "label": _("Event end date and time"),
         "editor_sample": _("2017-05-31 22:00"),

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -280,6 +280,11 @@ DEFAULT_VARIABLES = OrderedDict((
             "TIME_FORMAT"
         ) if ev.date_to else ""
     }),
+    ("event_end_weekday", {
+        "label": _("Event end weekday"),
+        "editor_sample": _("Friday"),
+        "evaluate": lambda op, order, ev: ev.get_weekday_to_display()
+    }),
     ("event_admission", {
         "label": _("Event admission date and time"),
         "editor_sample": _("2017-05-31 19:00"),


### PR DESCRIPTION
For customer convenience, this adds a new placeholder `event_begin_weekday` and `event_end_weekday` to the PDF editor to allow printing the weekday of the event date to tickets.