### PR TITLE
PDF editor: Fix empty preview tab in Chrome

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/editor.js
+++ b/src/pretix/static/pretixcontrol/js/ui/editor.js
@@ -959,10 +959,10 @@ var editor = {
         return false;
     },
 
-    _preview: function () {
+    _preview: function (e) {
         $("#preview-form input[name=data]").val(JSON.stringify(editor.dump()));
         $("#preview-form input[name=background]").val(editor.uploaded_file_id);
-        $("#preview-form").get(0).submit();
+        if (!e || !e.target.form) $("#preview-form").get(0).submit();
     },
 
     _replace_pdf_file: function (url) {


### PR DESCRIPTION
When editing tickets/badges and clicking the preview-button, Chrome opens an empty new tab. This seems to be because of an JavaScript triggered form-submit on a form with target=_blank. As soon as the JS-submit is removed, PDF-preview works – as the button, that triggers the preview, is already a submit-button for that form.