### PR TITLE
Fix ticket download-date hint when plugins disallow download (Z#23104496)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_downloads.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_downloads.html
@@ -88,7 +88,7 @@
         </p>
         {% endif %}
     </div>
-{% elif not can_download and ticket_download_date %}
+{% elif not can_download and plugins_allow_ticket_download and ticket_download_date %}
     {% if order.status == 'p' %}
         <div class="alert alert-info info-download">
             {% blocktrans trimmed with date=ticket_download_date|date:"SHORT_DATE_FORMAT" %}

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -177,6 +177,7 @@ class TicketPageMixin:
         ctx['order'] = self.order
 
         can_download = all([r for rr, r in allow_ticket_download.send(self.request.event, order=self.order)])
+        ctx['plugins_allow_ticket_download'] = can_download
         if self.request.event.settings.ticket_download_date:
             ctx['ticket_download_date'] = self.order.ticket_download_date
         can_download = (


### PR DESCRIPTION
As discussed this fixes the hint regarding download-date for tickets when plugins disallow the download.