### PR TITLE
Fix hidden bulk-action filter-form (Z#23108559)

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/checkin/index.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/index.html
@@ -72,10 +72,10 @@
         </div>
     {% else %}
         <form method="post" action="{% url "control:event.orders.checkinlists.bulk_action" event=request.event.slug organizer=request.event.organizer.slug list=checkinlist.pk %}" data-asynctask>
-            <div class="hidden">
-                {{ filter_form.as_p }}
-                <input name="returnquery" type="hidden" value="{{ request.META.QUERY_STRING }}">
-            </div>
+            {% for field in filter_form %}
+                {{ field.as_hidden }}
+            {% endfor %}
+            <input name="returnquery" type="hidden" value="{{ request.META.QUERY_STRING }}">
            {% csrf_token %}
             <div class="table-responsive">
                 <table class="table table-condensed table-hover">

--- a/src/pretix/control/templates/pretixcontrol/organizers/devices.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/devices.html
@@ -57,9 +57,9 @@
         </p>
         <form action="{% url "control:organizer.device.bulk_edit" organizer=request.organizer.slug %}" method="post">
             {% csrf_token %}
-            <div class="hidden">
-                {{ filter_form.as_p }}
-            </div>
+            {% for field in filter_form %}
+                {{ field.as_hidden }}
+            {% endfor %}
             <div class="table-responsive">
                 <table class="table table-condensed table-hover table-quotas">
                     <thead>

--- a/src/pretix/control/templates/pretixcontrol/subevents/index.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/index.html
@@ -72,9 +72,9 @@
         {% endif %}
         <form action="{% url "control:event.subevents.bulkaction"  organizer=request.event.organizer.slug event=request.event.slug %}" method="post">
             {% csrf_token %}
-            <div class="hidden">
-                {{ filter_form.as_p }}
-            </div>
+            {% for field in filter_form %}
+                {{ field.as_hidden }}
+            {% endfor %}
             <div class="table-responsive">
                 <table class="table table-hover table-quotas">
                     <thead>


### PR DESCRIPTION
select2 fails to initialize dropdown for subevents as the filter-form is repeated as-is inside the bulk-action form, which causes two inputs having the same id – which select2 seems to fail and only initialize the last (in this case hidden) one. This PR fixes it by outputting the second, visually hidden form as hidden form-fields.