### PR TITLE
bump css-inline from 0.7.x to 0.8.x to allow for successful arm64 installs.

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -165,7 +165,7 @@ setup(
         'celery==4.4.*',
         'chardet==5.0.*',
         'cryptography>=3.4.2',
-        'css-inline==0.7.*',
+        'css-inline==0.8.*',
         'defusedcsv>=1.1.0',
         'dj-static',
         'Django==3.2.*',


### PR DESCRIPTION
This fixes the issues encountered in #2681 in which currently an install of pretix fails on arm64 systems as wheels for arm64 weren't added until this [commit](https://github.com/Stranger6667/css-inline/commit/559e43aaf3787d8bc0d460ed30cc5dbb2935b2bd). 

Currently, it falls back to wanting to compile `css-inline` with rust, however certain compiler options aren't passed in order to get a functioning `css-inline`. Thankfully with `0.8.0` and on, a properly compiled package is available for arm64. 
