### PR TITLE
PPv2: Fix continue button behaviour

### DIFF
--- a/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
+++ b/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
@@ -321,6 +321,23 @@ var pretixpaypal = {
 };
 
 $(function () {
+    // This script is always loaded if paypal is enabled as a payment method, regardless of
+    // whether it is available (it could e.g. be hidden or limited to certain countries).
+    // We do not want to unnecessarily load the sdk.
+    let sdk_needed = false
+    // If we are on a payment method selection page (event.checkout "payment" step or
+    // event.order.pay.change) and paypal/paypal_apm is one of the options, we need the sdk.
+    if ($("input[name=payment][value^='paypal']").length) {
+        sdk_needed = true
+    }
+    // If we are on the (APM) PayView, we need the sdk.
+    if ($('#paypal-button-container').data('paypage')) {
+        sdk_needed = true
+    }
+    if (!sdk_needed) {
+        return
+    }
+
     pretixpaypal.load();
 
     (async() => {

--- a/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
+++ b/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
@@ -85,7 +85,7 @@ var pretixpaypal = {
             pretixpaypal.restore();
         });
 
-        // If paypal is the only payment option, it is preselected and we must disable the continue button until the sdk is ready
+        // If paypal is pre-selected, we must disable the continue button and handle it after SDK is loaded
         if ($("input[name=payment][value^='paypal']").is(':checked')) {
             pretixpaypal.continue_button.prop("disabled", true);
         }
@@ -325,17 +325,9 @@ $(function () {
     // This script is always loaded if paypal is enabled as a payment method, regardless of
     // whether it is available (it could e.g. be hidden or limited to certain countries).
     // We do not want to unnecessarily load the sdk.
-    let sdk_needed = false
-    // If we are on a payment method selection page (event.checkout "payment" step or
-    // event.order.pay.change) and paypal/paypal_apm is one of the options, we need the sdk.
-    if ($("input[name=payment][value^='paypal']").length) {
-        sdk_needed = true
-    }
-    // If we are on the (APM) PayView, we need the sdk.
-    if ($('#paypal-button-container').data('paypage')) {
-        sdk_needed = true
-    }
-    if (!sdk_needed) {
+    // If no paypal/paypal_apm payment option is present and we are not on
+    // the (APM) PayView, then we do not need the SDK.
+    if (!$("input[name=payment][value^='paypal']").length && !$('#paypal-button-container').data('paypage')) {
         return
     }
 

--- a/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
+++ b/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
@@ -73,12 +73,21 @@ var pretixpaypal = {
             pretixpaypal.locale = this.guessLocale();
         }
 
-        // If no payment option is selected, and we're not on the paypage (which doesn't have a continue button),
-        // disable the continue button
-        if (!pretixpaypal.paypage) {
-            if (!pretixpaypal.continue_button[0].form.elements['payment'].value) {
+        $("input[name=payment][value^='paypal']").change(function () {
+            if (pretixpaypal.paypal !== null) {
+                pretixpaypal.renderButton($(this).val());
+            } else {
                 pretixpaypal.continue_button.prop("disabled", true);
             }
+        });
+
+        $("input[name=payment]").not("[value^='paypal']").change(function () {
+            pretixpaypal.restore();
+        });
+
+        // If paypal is the only payment option, it is preselected and we must disable the continue button until the sdk is ready
+        if ($("input[name=payment][value^='paypal']").is(':checked')) {
+            pretixpaypal.continue_button.prop("disabled", true);
         }
 
         // We are setting the cogwheel already here, as the renderAPM() method might take some time to get loaded.
@@ -139,14 +148,6 @@ var pretixpaypal = {
             pretixpaypal.renderAPMs();
         }
 
-        $("input[name=payment][value^='paypal']").change(function () {
-            pretixpaypal.renderButton($(this).val());
-        });
-
-        $("input[name=payment]").not("[value^='paypal']").change(function () {
-            pretixpaypal.restore();
-        });
-
         if ($("input[name=payment][value^='paypal']").is(':checked')) {
             pretixpaypal.renderButton($("input[name=payment][value^='paypal']:checked").val());
         } else if ($(".payment-redo-form").length) {
@@ -162,8 +163,8 @@ var pretixpaypal = {
             $('#paypal-button-container').empty()
             pretixpaypal.continue_button.text(gettext('Continue'));
             pretixpaypal.continue_button.show();
-            pretixpaypal.continue_button.prop("disabled", false);
         }
+        pretixpaypal.continue_button.prop("disabled", false);
     },
 
     renderButton: function (method) {


### PR DESCRIPTION
PPv2 disables the continue button and reenables it after loading the sdk if paypal is the only option (and thus is preselected) or when one of the payment options is selected. This is inconsistent with other payment methods: Usually the continue button is enabled even if no payment option is selected. This also breaks the checkout process in one case:

If 1) paypal is enabled as a payment method, 2) paypal is not available (because it is hidden, limited to certain countries, ...) and 3) there is exactly one payment method available, PPv2 disables the continue button with no way for the user to enable it:
![127 0 0 1_8000_test_test2_checkout_payment_](https://user-images.githubusercontent.com/18755629/192659351-fd346875-4815-44ca-85b4-fdd60430f235.png)
The user cannot generate a `change` event, since the sole radio button is preselected and cannot be unselected.

This change fixes the inconsistent behaviour and the broken checkout process. It also prevents unnecessary loading of the sdk, if paypal is not avilable.
