### PR TITLE
Introduce a hidden setting to toggle between "common" and "official" country names

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -87,7 +87,7 @@ from pretix.control.forms import (
     ExtFileField, ExtValidationMixin, SizeValidationMixin, SplitDateTimeField,
 )
 from pretix.helpers.countries import (
-    CachedCountries, get_phone_prefixes_sorted_and_localized,
+    get_cached_countries_class, get_phone_prefixes_sorted_and_localized,
 )
 from pretix.helpers.escapejson import escapejson_attr
 from pretix.helpers.i18n import get_format_without_seconds
@@ -630,7 +630,7 @@ class BaseQuestionsForm(forms.Form):
             )
             country = (cartpos.country if cartpos else orderpos.country) or guess_country(event)
             add_fields['country'] = CountryField(
-                countries=CachedCountries
+                countries=get_cached_countries_class(common_names=event.settings.country_names_common),
             ).formfield(
                 required=event.settings.attendee_addresses_required and not self.all_optional,
                 label=_('Country'),
@@ -726,7 +726,7 @@ class BaseQuestionsForm(forms.Form):
                 )
             elif q.type == Question.TYPE_COUNTRYCODE:
                 field = CountryField(
-                    countries=CachedCountries,
+                    countries=get_cached_countries_class(common_names=event.settings.country_names_common),
                     blank=True, null=True, blank_label=' ',
                 ).formfield(
                     label=label, required=required,
@@ -974,7 +974,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
                 str(_('If you are registered in Switzerland, you can enter your UID instead.')),
             ])
 
-        self.fields['country'].choices = CachedCountries()
+        self.fields['country'].choices = get_cached_countries_class(event.settings.country_names_common)()
 
         c = [('', pgettext_lazy('address', 'Select state'))]
         fprefix = self.prefix + '-' if self.prefix else ''

--- a/src/pretix/base/models/invoices.py
+++ b/src/pretix/base/models/invoices.py
@@ -46,6 +46,7 @@ from django.utils.translation import pgettext
 from django_scopes import ScopedManager
 
 from pretix.base.settings import COUNTRIES_WITH_STATE_IN_ADDRESS
+from pretix.base.templatetags.country import country_name
 from pretix.helpers.countries import FastCountryField
 
 
@@ -181,7 +182,7 @@ class Invoice(models.Model):
             self.invoice_from_name,
             self.invoice_from,
             (self.invoice_from_zipcode or "") + " " + (self.invoice_from_city or ""),
-            self.invoice_from_country.name if self.invoice_from_country else "",
+            country_name(self.invoice_from_country, self.event.settings.country_names_common),
             pgettext("invoice", "VAT-ID: %s") % self.invoice_from_vat_id if self.invoice_from_vat_id else "",
             taxidrow,
         ]
@@ -193,7 +194,7 @@ class Invoice(models.Model):
             self.invoice_from_name,
             self.invoice_from,
             (self.invoice_from_zipcode or "") + " " + (self.invoice_from_city or ""),
-            self.invoice_from_country.name if self.invoice_from_country else "",
+            country_name(self.invoice_from_country, self.event.settings.country_names_common),
         ]
         return '\n'.join([p.strip() for p in parts if p and p.strip()])
 
@@ -219,7 +220,7 @@ class Invoice(models.Model):
             self.invoice_to_name,
             self.invoice_to_street,
             ((self.invoice_to_zipcode or "") + " " + (self.invoice_to_city or "") + " " + (state_name or "")).strip(),
-            self.invoice_to_country.name if self.invoice_to_country else "",
+            country_name(self.invoice_to_country, self.event.settings.country_names_common),
         ]
         return '\n'.join([p.strip() for p in parts if p and p.strip()])
 

--- a/src/pretix/base/services/invoices.py
+++ b/src/pretix/base/services/invoices.py
@@ -62,6 +62,7 @@ from pretix.base.models.tax import EU_CURRENCIES
 from pretix.base.services.tasks import TransactionAwareTask
 from pretix.base.settings import GlobalSettingsObject
 from pretix.base.signals import invoice_line_text, periodic_task
+from pretix.base.templatetags.country import country_name
 from pretix.celery_app import app
 from pretix.helpers.database import rolledback_transaction
 from pretix.helpers.models import modelcopy
@@ -122,7 +123,7 @@ def build_invoice(invoice: Invoice) -> Invoice:
             invoice.invoice_to = "\n".join(
                 a.strip() for a in addr_template.format(
                     i=ia,
-                    country=ia.country.name if ia.country else ia.country_old,
+                    country=country_name(ia.country, invoice.event.settings.country_names_common) if ia.country else ia.country_old,
                     state=ia.state_for_address
                 ).split("\n") if a.strip()
             )

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2604,6 +2604,14 @@ Your {organizer} team"""))
             help_text=_('This will be displayed on the organizer homepage.')
         )
     },
+    'country_names_common': {
+        # Hidden setting to toggle things like ("Taiwan" vs "Taiwan (Province of China)" or "Russia" vs
+        # "Russian Federation". Can be turned to False on request for diplomacy-sensitive users.
+        'default': 'True',
+        'type': bool,
+        'serializer_class': serializers.BooleanField,
+        'serializer_kwargs': {},
+    },
     'name_scheme': {
         'default': 'full',  # default for new events is 'given_family'
         'type': str,

--- a/src/pretix/base/templatetags/country.py
+++ b/src/pretix/base/templatetags/country.py
@@ -1,0 +1,39 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+
+from django import template
+from django_countries.fields import Country
+
+from pretix.helpers.countries import get_cached_countries_class
+
+register = template.Library()
+
+
+@register.filter("country_name")
+def country_name(country: Country, common_names=True):
+    if not country:
+        return ''
+    if not isinstance(country, Country):
+        country = Country(country)
+
+    klass = get_cached_countries_class(common_names=common_names)
+    return klass().name(country.code)

--- a/src/pretix/control/templates/pretixcontrol/order/index.html
+++ b/src/pretix/control/templates/pretixcontrol/order/index.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load eventurl %}
 {% load money %}
+{% load country %}
 {% load rich_text %}
 {% load safelink %}
 {% load eventsignal %}
@@ -498,7 +499,7 @@
                                                 {% if line.street or line.zipcode or line.city or line.country %}
                                                     {{ line.street|default_if_none:""|linebreaksbr }}<br>
                                                     {{ line.zipcode|default_if_none:"" }} {{ line.city|default_if_none:"" }}<br>
-                                                    {{ line.country.name|default_if_none:"" }}
+                                                    {{ line.country|country_name:request.event.settings.country_names_common }}
                                                     {% if line.state %}<br>{{ line.state }}{% endif %}
                                                 {% else %}
                                                     <em>{% trans "not answered" %}</em>
@@ -889,7 +890,9 @@
                                     <dt>{% trans "ZIP code and city" %}</dt>
                                     <dd>{{ order.invoice_address.zipcode }} {{ order.invoice_address.city }}</dd>
                                     <dt>{% trans "Country" %}</dt>
-                                    <dd>{{ order.invoice_address.country.name|default:order.invoice_address.country_old }}</dd>
+                                    <dd>
+                                        {{ order.invoice_address.country|country_name:request.event.settings.country_names_common|default:order.invoice_address.country_old }}
+                                    </dd>
                                     {% if order.invoice_address.state %}
                                         <dt>{% trans "State" context "address" %}</dt>
                                         <dd>{{ order.invoice_address.state_name }}</dd>

--- a/src/pretix/helpers/countries.py
+++ b/src/pretix/helpers/countries.py
@@ -36,6 +36,7 @@ _collator = pyuca.Collator()
 class CachedCountries(Countries):
     _cached_lists = {}
     cache_subkey = None
+    common_names = True
 
     def __iter__(self):
         """
@@ -43,7 +44,7 @@ class CachedCountries(Countries):
         django-countries performs a unicode-aware sorting based on pyuca which is incredibly
         slow.
         """
-        cache_key = "countries:all:{}".format(get_language_without_region())
+        cache_key = "countries:all:{}:{}".format(get_language_without_region(), self.common_names)
         if self.cache_subkey:
             cache_key += ":" + self.cache_subkey
         if cache_key in self._cached_lists:
@@ -76,6 +77,17 @@ class CachedCountries(Countries):
             country_name = name
         country_name = force_str(country_name)
         return CountryTuple(code, country_name)
+
+
+class CachedCountriesOfficialNames(CachedCountries):
+    common_names = False
+
+
+def get_cached_countries_class(common_names=True):
+    if common_names:
+        return CachedCountries
+    else:
+        return CachedCountriesOfficialNames
 
 
 class FastCountryField(CountryField):

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -62,6 +62,7 @@ from pretix.base.services.memberships import validate_memberships_in_order
 from pretix.base.services.orders import perform_order
 from pretix.base.settings import PERSON_NAME_SCHEMES
 from pretix.base.signals import validate_cart_addons
+from pretix.base.templatetags.country import country_name
 from pretix.base.templatetags.phone_format import phone_format
 from pretix.base.templatetags.rich_text import rich_text_snippet
 from pretix.base.views.tasks import AsyncAction
@@ -1023,7 +1024,7 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                 for a in addresses:
                     data = {
                         "_pk": a.pk,
-                        "_country_for_address": a.country.name,
+                        "_country_for_address": country_name(a.country, self.event.settings.country_names_common),
                         "_state_for_address": a.state_for_address,
                         "_name": a.name,
                         "is_business": "business" if a.is_business else "individual",

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -1,6 +1,7 @@
 {% extends "pretixpresale/event/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load country %}
 {% load eventurl %}
 {% load eventsignal %}
 {% block title %}{% trans "Review order" %}{% endblock %}
@@ -86,7 +87,7 @@
                                 <dt>{% trans "ZIP code and city" %}</dt>
                                 <dd>{{ addr.zipcode }} {{ addr.city }}</dd>
                                 <dt>{% trans "Country" %}</dt>
-                                <dd>{{ addr.country.name }}</dd>
+                                <dd>{{ addr.country|country_name:request.event.settings.country_names_common }}</dd>
                                 {% if addr.state %}
                                     <dt>{% trans "State" context "address" %}</dt>
                                     <dd>{{ addr.state_name }}</dd>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -2,6 +2,7 @@
 {% load eventurl %}
 {% load safelink %}
 {% load rich_text %}
+{% load country %}
 {% load money %}
 {% blocktrans asvar s_taxes %}taxes{% endblocktrans %}
 <div role="table" aria-label="{% trans "Your cart" %}" aria-describedby="{% if cart.is_ordered %}cart-description{% else%}cart-deadline{% endif %}" aria-rowcount="{{ cart.positions|length|add:2 }}">
@@ -167,7 +168,7 @@
                                         <span data-toggle="tooltip" title="{% trans "Attendee address" %}">
                                             {{ line.street|default_if_none:""|linebreaksbr }}<br>
                                             {{ line.zipcode|default_if_none:"" }} {{ line.city|default_if_none:"" }}<br>
-                                            {{ line.country.name|default_if_none:"" }}
+                                            {{ line.country|country_name:event.settings.country_names_common }}
                                             {% if line.state %}<br>{{ line.state }}{% endif %}
                                         </span>
                                     </dd>

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load eventsignal %}
 {% load money %}
+{% load country %}
 {% load expiresformat %}
 {% load eventurl %}
 {% load phone_format %}
@@ -324,7 +325,9 @@
                             <dt>{% trans "ZIP code and city" %}</dt>
                             <dd>{{ order.invoice_address.zipcode }} {{ order.invoice_address.city }}</dd>
                             <dt>{% trans "Country" %}</dt>
-                            <dd>{{ order.invoice_address.country.name|default:order.invoice_address.country_old }}</dd>
+                            <dd>
+                                {{ order.invoice_address.country|country_name:request.event.settings.country_names_common|default:order.invoice_address.country_old }}
+                            </dd>
                             {% if order.invoice_address.state %}
                                 <dt>{% trans "State" context "address" %}</dt>
                                 <dd>{{ order.invoice_address.state_name }}</dd>


### PR DESCRIPTION
django-countries has a list of "common" names for some countries that override the ISO list, e.g.

Russian Federation → Russia
Taiwan (Province of China) → Taiwan
Korea (Republic of) → South Korea

This is usually useful, but can be offensive in some situations, because "being a country" is somehow not binary.

pretix will continue to use the "common" names by default, but this introduces a hidden setting to revert to the official ones if needed.

It does not replace *all* occurrences, but most. Some would take much effort (e.g. description of attendee profiles in the customer account), and I don't think they're as important. I'm mostly concerned about all places where the field is explicitly named "Country". In a postal address, it could be anything. :wink: