### PR TITLE
Wrong URL corrected for change order contents

### DIFF
--- a/doc/api/resources/orders.rst
+++ b/doc/api/resources/orders.rst
@@ -1925,7 +1925,7 @@ otherwise, such as splitting an order or changing fees.
 
    .. sourcecode:: http
 
-      POST /api/v1/organizers/bigevents/events/sampleconf/orders/ABC12/ HTTP/1.1
+      POST /api/v1/organizers/bigevents/events/sampleconf/orders/ABC12/change/ HTTP/1.1
       Host: pretix.eu
       Accept: application/json, text/javascript
       Content-Type: application/json


### PR DESCRIPTION
Wrong URL in example request corrected for change order contents: /change/ was missing at the end