### PR TITLE
Docs: Make sure data directory is accessible

### DIFF
--- a/doc/admin/installation/docker_smallscale.rst
+++ b/doc/admin/installation/docker_smallscale.rst
@@ -49,11 +49,13 @@ all lines prepended with a ``$`` symbol can also be run by an unprivileged user.
 Data files
 ----------
 
-First of all, you need to create a directory on your server that pretix can use to store data files and make that
-directory writable to the user that runs pretix inside the docker container::
+First of all, you need to create a directory on your server that pretix can use to store data files.
+Make that directory writable to the user that runs pretix inside the docker container.
+Also, make the directory accessible to all other users so any public files can be accessed::
 
     # mkdir /var/pretix-data
     # chown -R 15371:15371 /var/pretix-data
+    # chmod 0751 /var/pretix-data
 
 Database
 --------


### PR DESCRIPTION
Make sure that the data directory of small-scale docker deployments is accessible to the user running nginx inside the container, so static files can be served from there. This is already the default for most Linux distributions, because the umask is usually 022, unless it has been modified inside the current shell.

This change is motivated by #1587.