### PR TITLE
Cart: change icon from checkbox to arrow-right for voucher submit

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart_box.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart_box.html
@@ -56,7 +56,7 @@
                                 <input type="text" class="form-control" name="voucher" id="voucher_code" placeholder="{% trans "Voucher code" %}" aria-label="{% trans "Voucher code" %}">
                                 <span class="input-group-btn">
                                     <button class="btn btn-primary" type="submit">
-                                        <span class="fa fa-check" aria-hidden="true"></span><span class="sr-only"> {% trans "Redeem voucher" %}</span>
+                                        <span class="fa fa-arrow-right" aria-hidden="true"></span><span class="sr-only"> {% trans "Redeem voucher" %}</span>
                                     </button>
                                 </span>
                             </div>


### PR DESCRIPTION
As user reports suggest the checkbox icon is not ideal for the submit button when adding a voucher from within the cart. The clearest way would be to use a readable text-label as well, but this could be problematic too as in viewport-width around 480px depending on the length of the translation of „redeem“, the actual voucher input can get quite small so the voucher code in the input will be cut off. Even with just the icon on the button, at 480px viewport-width the voucher code can be cut-off (at least in my tests the last letter was cut off).

Just the word „redeem“:
![Bildschirmfoto 2022-10-04 um 10 46 44](https://user-images.githubusercontent.com/276509/193777491-61a9ed45-acf1-4f68-818a-b11c1583fde5.png)

Or just a pointer (this is what this PR currently implements):
![Bildschirmfoto 2022-10-04 um 10 48 23](https://user-images.githubusercontent.com/276509/193777511-60c3040c-2dbe-4ebf-a458-8ed454fa4d6d.png)
