### PR TITLE
Clarify cart order

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -2671,7 +2671,7 @@ class CartPosition(AbstractPosition):
         if self.addon_to_id:
             return self.addon_to.sort_key + (1 if self.is_bundled else 2,) + sort_key
         else:
-            return sort_key + (0,) + sort_key
+            return sort_key
 
     def update_listed_price_and_voucher(self, voucher_only=False, max_discount=None):
         from pretix.base.services.pricing import (

--- a/src/pretix/base/views/mixins.py
+++ b/src/pretix/base/views/mixins.py
@@ -44,16 +44,6 @@ class BaseQuestionsViewMixin:
     form_class = BaseQuestionsForm
     all_optional = False
 
-    @staticmethod
-    def _keyfunc(pos):
-        # Sort addons after the item they are an addon to
-        if isinstance(pos, OrderPosition):
-            i = pos.addon_to.positionid if pos.addon_to else pos.positionid
-        else:
-            i = pos.addon_to.pk if pos.addon_to else pos.pk
-        addon_penalty = 1 if pos.addon_to else 0
-        return i, addon_penalty, pos.pk
-
     @cached_property
     def _positions_for_questions(self):
         raise NotImplementedError()

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -497,9 +497,9 @@ class AddOnsStep(CartMixin, AsyncAction, TemplateFlowStep):
         formset = []
         quota_cache = {}
         item_cache = {}
-        for cartpos in get_cart(self.request).filter(addon_to__isnull=True).prefetch_related(
+        for cartpos in sorted(get_cart(self.request).filter(addon_to__isnull=True).prefetch_related(
             'item__addons', 'item__addons__addon_category', 'addons', 'addons__variation',
-        ).order_by('pk'):
+        ), key=lambda c: c.sort_key):
             formsetentry = {
                 'pos': cartpos,
                 'item': cartpos.item,

--- a/src/pretix/presale/views/questions.py
+++ b/src/pretix/presale/views/questions.py
@@ -46,7 +46,7 @@ class QuestionsViewMixin(BaseQuestionsViewMixin):
     @cached_property
     def _positions_for_questions(self):
         cart = get_cart(self.request)
-        return sorted(list(cart), key=self._keyfunc)
+        return sorted(list(cart), key=lambda cp: cp.sort_key)
 
     def question_form_kwargs(self, cr):
         d = {


### PR DESCRIPTION
Cart order in pretix was confusing:

- In situations where we can group positions, we sorted by order of categories, items, …
- In situations where we can't group positions, we sorted by order of addition to the cart

With this PR, we'll always sort by order of categories/items/… to be consistent.

### old text of this PR

A customer complained that by going back and forth in the checkout process and changing the number of add-on products, you can create very weird groupings in the cart such as this:

![image006](https://user-images.githubusercontent.com/64280/194512471-365670f9-785b-4bdc-887f-b0265d05a8bf.png)

This PR makes the cart view completely ignore "chronological" order and strictly sort by the sorting attributes of the products and variations involved, with one exception: Bundled products are always sorted before add-on products.

The same sorting is applied when submitting the order and computing the ``positionid`` attributes to avoid bad grouping and sorting in the order later on.

There's one downside to all this, which is that the ``position`` attribute of ``ItemAddOn`` is now completely ignored in the cart, only the ``position`` attribute of the ``ItemCategory`` itself is respected. The order of ``ItemAddOn``s is only relevant for the display in the add-on step it self now. People will complain about this as well, but I think it's a fair trade-off.