### PR TITLE
Stripe Connect: Fix account name retrieval

### DIFF
--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -165,9 +165,15 @@ def oauth_return(request, *args, **kwargs):
             event.settings.payment_stripe_connect_refresh_token = data['refresh_token']
             event.settings.payment_stripe_connect_user_id = data['stripe_user_id']
             event.settings.payment_stripe_merchant_country = account.get('country')
-            if account.get('business_name') or account.get('display_name') or account.get('email'):
+            if (
+                account.get('business_profile', {}).get('name')
+                or account.get('settings', {}).get('dashboard', {}).get('display_name')
+                or account.get('email')
+            ):
                 event.settings.payment_stripe_connect_user_name = (
-                    account.get('business_name') or account.get('display_name') or account.get('email')
+                    account.get('business_profile', {}).get('name')
+                    or account.get('settings', {}).get('dashboard', {}).get('display_name')
+                    or account.get('email')
                 )
 
             if data['livemode']:


### PR DESCRIPTION
I faced today an issue that I was not able to properly connect my test Stripe account using our staging keys: The connect account name was empty.

According to the Stripe API docs, with 2019-02-19 some fields got shuffled around - so according to this, we're lucky this didn't break yet in our faces: https://stripe.com/docs/api/accounts/object

Interestingly enough, even with the new, updated hashed, my API-calls do net yield a `business_profile` or `email`...