### PR TITLE
Set default ticket layout QR code content explicitly to secret

### DIFF
--- a/src/pretix/plugins/ticketoutputpdf/models.py
+++ b/src/pretix/plugins/ticketoutputpdf/models.py
@@ -202,7 +202,8 @@ DEFAULT_TICKET_LAYOUT = '''[{
     "type":"barcodearea",
     "left":"130.40",
     "bottom":"204.50",
-    "size":"64.00"
+    "size":"64.00",
+    "content":"secret"
 },
 {
     "type":"poweredby",


### PR DESCRIPTION
Our rendering implementation uses `"content":"secret"` as fallback if not set - but the default layout should set it explicitly.

Serverside: https://github.com/pretix/pretix/blob/5992abcb7dc9ead95a127f90c1a7c720a73ca1e8/src/pretix/base/pdf.py#L703
pretixPRINT: https://github.com/pretix/pretixprint-android/commit/432910737526cb620196e0a11496427e8165569d#diff-5a85c6bb47e2357b72ff645c0b59f99044653b5b17e9601fe696af8d9a97534fR72