### PR TITLE
Fix: make hidden form inputs visible, if invalid

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -25,8 +25,9 @@ function interpolate(fmt, object, named) {
 var form_handlers = function (el) {
     el.find('input, select, textarea').on('invalid', function (e) {
         if (!$(this).is(':visible')) {
-            $(this).closest('.panel').addClass('details-open').attr('open', true).children(':not(summary)').slideDown();
-            this.focus();
+            var panel = $(this).closest('.panel');
+            if (!panel.attr('open')) panel.addClass('details-open').attr('open', true).children(':not(summary)').slideDown();
+            if (!$(document.activeElement).is(':invalid')) this.focus();
         }
     });
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -25,7 +25,7 @@ function interpolate(fmt, object, named) {
 var form_handlers = function (el) {
     el.find('input, select, textarea').on('invalid', function (e) {
         if (!$(this).is(':visible')) {
-            $(this).closest('.panel').find('.panel-heading').trigger('click');
+            $(this).closest('.panel').addClass('details-open').attr('open', true).children(':not(summary)').slideDown();
             this.focus();
         }
     });

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -23,6 +23,13 @@ function interpolate(fmt, object, named) {
 }
 
 var form_handlers = function (el) {
+    el.find('input, select, textarea').on('invalid', function (e) {
+        if (!$(this).is(':visible')) {
+            $(this).closest('.panel').find('.panel-heading').trigger('click');
+            this.focus();
+        }
+    });
+
     el.find(".datetimepicker").each(function () {
         $(this).datetimepicker({
             format: $("body").attr("data-datetimeformat"),


### PR DESCRIPTION
If form inputs are not valid (through means of HTML5 validation) but hidden inside a folded panel, they block form submission, but are not shown. This fix opens the folded panel and brings focus to the element. Note: invalid-events are fired on inputs, so there is no easy way to catch just one global invalid-event per form (one could work with a debounced timeout-callback). When there are multiple invalid fields in a form/panel, this fires multiple events which one could think would be a problem as that would trigger multiple click-events on the same `.panel-heading` and open, then close that panel again. In my tests that is acutally not a problem as the browser seems to debounce those input.focus and click-triggers. Alternatively instead of triggering the click-event on the .panel-heading, one could add the `panel-open` class and set the open-attribute of the `details` element. I prefer the click-event, because this is future proof and does not need to know anything about the internals of opening a panel.
UPDATE: Manually open the panel, if not visible