### PR TITLE
Fix paypal disabling continue button (Z#23110784)

### DIFF
--- a/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
+++ b/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
@@ -312,7 +312,6 @@ var pretixpaypal = {
             'tr_TR',
         ]
         let lang = $("body").attr("data-locale").split('-')[0];
-        console.log(allowed_locales.find(element => element.startsWith(lang)));
         return allowed_locales.find(element => element.startsWith(lang));
     }
 };

--- a/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
+++ b/src/pretix/plugins/paypal2/static/pretixplugins/paypal2/pretix-paypal.js
@@ -72,8 +72,10 @@ var pretixpaypal = {
             pretixpaypal.currency = $("body").attr("data-currency");
             pretixpaypal.locale = this.guessLocale();
         }
-
-        pretixpaypal.continue_button.prop("disabled", true);
+        // if no payment option is selected, disable the continue button
+        if (!pretixpaypal.continue_button[0].form.elements['payment'].value) {
+            pretixpaypal.continue_button.prop("disabled", true);
+        }
 
         // We are setting the cogwheel already here, as the renderAPM() method might take some time to get loaded.
         let apmtextselector = $("label[for=input_payment_paypal_apm]");


### PR DESCRIPTION
During checkout when navigating back and forth between steps, the payment options can initially be selected. When PayPal was included, it disabled the continue-button even if a payment option was initially selected. This PR fixes this. I tested in console as I do not have a working PayPal setup. It would be great if someone with a PayPal-setup could test this. Thanks!