### PR TITLE
Calendar: add label „continued“ to event’s name (Z#2397988)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -24,7 +24,7 @@
                             <p><time datetime="{{ day.date|date_fast:"Y-m-d" }}">{{ day.day }}</time></p>
                             <ul class="events">
                                 {% for event in day.events %}
-                                    <li><a class="event {% if event.continued %}continued{% else %} {% spaceless %}
+                                    <li><a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
     {% if event.event.presale_is_running and show_avail %}
         {% if event.event.best_availability_state == 100 %}
             available
@@ -44,11 +44,12 @@
     {% else %}
         soon
     {% endif %}
-{% endspaceless %}{% endif %}"
+{% endspaceless %}"
                                        href="{{ event.url }}">
                                         {% if show_names|default_if_none:True %}
                                             <span class="event-name">
                                                 {{ event.event.name }}
+                                                {% if event.continued %} <i class="event-name-continued">{% trans "(continued)" %}</i>{% endif %}
                                             </span>
                                         {% endif %}
                                         {% if not event.continued %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
@@ -37,7 +37,7 @@
                 data-offset-shift="{{ event.offset_shift_start }}:{{ event.offset_shift_end }}"
                 data-duration="{{ event.duration_rastered }}"
                 data-concurrency="{{ event.concurrency }}">
-                <a class="event {% if event.continued %}continued{% else %} {% spaceless %}
+                <a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
     {% if event.event.presale_is_running and show_avail %}
         {% if event.event.best_availability_state == 100 %}
             available
@@ -57,11 +57,12 @@
     {% else %}
         soon
     {% endif %}
-{% endspaceless %}{% endif %}"
+{% endspaceless %}"
                    href="{{ event.url }}">
                     {% if show_names|default_if_none:True %}
                         <span class="event-name">
                                 {{ event.event.name }}
+                                {% if event.continued %} <i class="event-name-continued">{% trans "(continued)" %}</i>{% endif %}
                             </span>
                     {% endif %}
                     {% if not event.continued %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -9,7 +9,7 @@
             </summary>
             <ul class="events">
                 {% for event in day.events %}
-                    <li><a class="event {% if event.continued %}continued{% else %} {% spaceless %}
+                    <li><a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
     {% if event.event.presale_is_running and show_avail %}
         {% if event.event.best_availability_state == 100 %}
             available
@@ -29,11 +29,12 @@
     {% else %}
         soon
     {% endif %}
-{% endspaceless %}{% endif %}"
+{% endspaceless %}"
                             href="{{ event.url }}">
                         {% if show_names|default_if_none:True %}
                             <span class="event-name">
                                 {{ event.event.name }}
+                                {% if event.continued %} <i class="event-name-continued">{% trans "(continued)" %}</i>{% endif %}
                             </span>
                         {% endif %}
                         {% if not event.continued %}

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -92,6 +92,9 @@
     .event-name {
       display: block;
     }
+    .event-name-continued {
+      font-weight: normal;
+    }
     .event-time, .event-status {
       display: block;
     }


### PR DESCRIPTION
Continued events in calendar views were colored the same way as events that were over. This PR marks continued events with the word „(continued)“ and keeps the color of the original event (e.g. available, etc.).

Two questions:

1. Should the wording be „(continued)“ or the shortened version „(cont.)“?
2. The word „(continued)“ is set in italic so screen readers should pronounce it differently from the title to make it clear, that the word is not part of the event’s title. Optically IMHO it works as well when set in italic, but I am okay to change it to upright. Technical note: the styling uses a custom CSS-class `.event-name-continued`, which currently only sets the font-weight to normal – maybe instead we should create a global `.font-weight-normal` utility-class as bootstrap4 does?

![Bildschirmfoto 2022-11-14 um 12 30 28](https://user-images.githubusercontent.com/276509/201649299-4f6d8b90-1527-45ff-a498-f6b3e910ba13.png)
![Bildschirmfoto 2022-11-14 um 12 29 59](https://user-images.githubusercontent.com/276509/201649208-094c21b1-d4fe-434d-a36f-547e5c699644.png)
