### PR TITLE
Order list export: Add event meta data (Z#2397902)

### DIFF
--- a/src/pretix/base/exporters/orderlist.py
+++ b/src/pretix/base/exporters/orderlist.py
@@ -99,12 +99,6 @@ class OrderListExporter(MultiSheetListExporter):
                  initial=False,
                  required=False
              )),
-            ('include_meta_data',
-             forms.BooleanField(
-                 label=_('Include event meta data'),
-                 initial=False,
-                 required=False
-             )),
             ('group_multiple_choice',
              forms.BooleanField(
                  label=_('Show multiple choice answers grouped in one column'),
@@ -278,9 +272,8 @@ class OrderListExporter(MultiSheetListExporter):
         headers = [
             _('Event slug'),
         ]
-        if form_data.get('include_meta_data'):
-            # get meta_data labels from first cached event
-            headers += [_('Meta: {}').format(l) for l in next(iter(self.event_object_cache.values())).meta_data.keys()]
+        # get meta_data labels from first cached event
+        headers += [_('Meta: {}').format(l) for l in next(iter(self.event_object_cache.values())).meta_data.keys()]
         headers += [
             _('Order code'), _('Order total'), _('Status'), _('Email'), _('Phone number'),
             _('Order date'), _('Order time'), _('Company'), _('Name'),
@@ -358,8 +351,7 @@ class OrderListExporter(MultiSheetListExporter):
             row = [
                 self.event_object_cache[order.event_id].slug,
             ]
-            if form_data.get('include_meta_data'):
-                row += self.event_object_cache[order.event_id].meta_data.values()
+            row += self.event_object_cache[order.event_id].meta_data.values()
             row += [
                 order.code,
                 order.total,
@@ -549,20 +541,17 @@ class OrderListExporter(MultiSheetListExporter):
             'order', 'order__invoice_address', 'order__customer', 'item', 'variation',
             'voucher', 'tax_rule'
         ).prefetch_related(
-            'subevent',
+            'subevent', 'subevent__meta_values',
             'answers', 'answers__question', 'answers__options'
         )
-        if form_data.get('include_meta_data'):
-            qs = qs.prefetch_related('subevent__meta_values')
         if form_data['paid_only']:
             qs = qs.filter(order__status=Order.STATUS_PAID, canceled=False)
 
         qs = self._date_filter(qs, form_data, rel='order__')
 
         has_subevents = self.events.filter(has_subevents=True).exists()
-        if form_data.get('include_meta_data'):
-            # get meta_data labels from first cached event
-            meta_data_labels = [_('Meta: {}').format(l) for l in next(iter(self.event_object_cache.values())).meta_data.keys()]
+        # get meta_data labels from first cached event
+        meta_data_labels = [_('Meta: {}').format(l) for l in next(iter(self.event_object_cache.values())).meta_data.keys()]
 
         headers = [
             _('Event slug'),
@@ -578,8 +567,7 @@ class OrderListExporter(MultiSheetListExporter):
             headers.append(pgettext('subevent', 'Date'))
             headers.append(_('Start date'))
             headers.append(_('End date'))
-            if form_data.get('include_meta_data'):
-                headers += meta_data_labels
+            headers += meta_data_labels
         headers += [
             _('Product'),
             _('Variation'),
@@ -676,14 +664,12 @@ class OrderListExporter(MultiSheetListExporter):
                             row.append(op.subevent.date_to.astimezone(self.event_object_cache[order.event_id].timezone).strftime('%Y-%m-%d %H:%M:%S'))
                         else:
                             row.append('')
-                        if form_data.get('include_meta_data'):
-                            row += op.subevent.meta_data.values()
+                        row += op.subevent.meta_data.values()
                     else:
                         row.append('')
                         row.append('')
                         row.append('')
-                        if form_data.get('include_meta_data'):
-                            row += [''] * len(meta_data_labels)
+                        row += [''] * len(meta_data_labels)
                 row += [
                     str(op.item),
                     str(op.variation) if op.variation else '',

--- a/src/pretix/base/exporters/orderlist.py
+++ b/src/pretix/base/exporters/orderlist.py
@@ -270,8 +270,7 @@ class OrderListExporter(MultiSheetListExporter):
         tax_rates = self._get_all_tax_rates(qs)
 
         headers = [
-            _('Event slug'),
-            _('Order code'), _('Order total'), _('Status'), _('Email'), _('Phone number'),
+            _('Event slug'), _('Order code'), _('Order total'), _('Status'), _('Email'), _('Phone number'),
             _('Order date'), _('Order time'), _('Company'), _('Name'),
         ]
         name_scheme = PERSON_NAME_SCHEMES[self.event.settings.name_scheme] if not self.is_multievent else None
@@ -305,8 +304,7 @@ class OrderListExporter(MultiSheetListExporter):
                 headers.append(_('Paid by {method}').format(method=vn))
 
         # get meta_data labels from first cached event
-        print(list(next(iter(self.event_object_cache.values())).meta_data.keys()))
-        headers += list(next(iter(self.event_object_cache.values())).meta_data.keys())
+        headers += next(iter(self.event_object_cache.values())).meta_data.keys()
         yield headers
 
         full_fee_sum_cache = {
@@ -472,7 +470,7 @@ class OrderListExporter(MultiSheetListExporter):
         headers.append(_('Payment providers'))
 
         # get meta_data labels from first cached event
-        headers += list(next(iter(self.event_object_cache.values())).meta_data.keys())
+        headers += next(iter(self.event_object_cache.values())).meta_data.keys()
         yield headers
 
         yield self.ProgressSetTotal(total=qs.count())
@@ -551,9 +549,6 @@ class OrderListExporter(MultiSheetListExporter):
         qs = self._date_filter(qs, form_data, rel='order__')
 
         has_subevents = self.events.filter(has_subevents=True).exists()
-        # get meta_data labels from first cached event
-        meta_data_labels = list(next(iter(self.event_object_cache.values())).meta_data.keys())
-        print("has_subevents", has_subevents)
 
         headers = [
             _('Event slug'),
@@ -637,6 +632,8 @@ class OrderListExporter(MultiSheetListExporter):
             _('Payment providers'),
         ]
 
+        # get meta_data labels from first cached event
+        meta_data_labels = next(iter(self.event_object_cache.values())).meta_data.keys()
         if has_subevents:
             headers += meta_data_labels
         yield headers

--- a/src/pretix/base/exporters/orderlist.py
+++ b/src/pretix/base/exporters/orderlist.py
@@ -448,6 +448,10 @@ class OrderListExporter(MultiSheetListExporter):
 
         headers = [
             _('Event slug'),
+        ]
+        # get meta_data labels from first cached event
+        headers += [_('Meta: {}').format(l) for l in next(iter(self.event_object_cache.values())).meta_data.keys()]
+        headers += [
             _('Order code'),
             _('Status'),
             _('Email'),
@@ -481,6 +485,9 @@ class OrderListExporter(MultiSheetListExporter):
             tz = pytz.timezone(order.event.settings.timezone)
             row = [
                 self.event_object_cache[order.event_id].slug,
+            ]
+            row += self.event_object_cache[order.event_id].meta_data.values()
+            row += [
                 order.code,
                 _("canceled") if op.canceled else order.get_status_display(),
                 order.email,

--- a/src/tests/api/test_exporters.py
+++ b/src/tests/api/test_exporters.py
@@ -68,6 +68,10 @@ SAMPLE_EXPORTER_CONFIG = {
             "required": False
         },
         {
+            "name": "include_meta_data",
+            "required": False
+        },
+        {
             "name": "group_multiple_choice",
             "required": False
         },

--- a/src/tests/api/test_exporters.py
+++ b/src/tests/api/test_exporters.py
@@ -68,10 +68,6 @@ SAMPLE_EXPORTER_CONFIG = {
             "required": False
         },
         {
-            "name": "include_meta_data",
-            "required": False
-        },
-        {
             "name": "group_multiple_choice",
             "required": False
         },


### PR DESCRIPTION
This PR optionally adds the event’s meta data to the order export and the subevent’s meta data to the order-position export. Should order-fees export should include event’s meta as well?
Meta data columns labels are prefixed with „Meta: “.