### PR TITLE
WIP: add answer options through client-side csv-file processing

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/items/question_edit.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question_edit.html
@@ -118,6 +118,10 @@
                             <button type="button" class="btn btn-default" data-formset-add>
                                 <i class="fa fa-plus"></i> {% trans "Add a new option" %}</button>
                         </p>
+                        <p>
+                            {% trans "or add options from a csv file" %}
+                            <input type="file" id="add-options-csv" accept=".csv" aria-label="{% trans "csv file with answer options" %}">
+                        </p>
                     </div>
                 </div>
             </fieldset>

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -119,6 +119,25 @@ var form_handlers = function (el) {
         form_handlers($(event.target));
     });
 
+    el.find("#add-options-csv").on("change", function(event) {
+        var formset = $(this).closest('.formset');
+        var addOptionButton = formset.find("button[data-formset-add]");
+        for (const file of event.target.files) {
+            const reader = new FileReader();
+            reader.addEventListener('load', (event) => {
+                event.target.result.split(/\r?\n/).forEach(function(line) {
+                    if (!line) return;
+                    var values = line.split(/[;,\t]/);
+                    addOptionButton.trigger("click");
+                    formset.find("[data-formset-body]>*:last-child").find("[type=text], textarea").each(function(i) {
+                        if (values[i]) this.value = values[i];
+                    });
+                });
+            });
+            reader.readAsText(file);
+        }
+    });
+
     // Vouchers
     el.find("#voucher-bulk-codes-generate").click(function () {
         var num = $("#voucher-bulk-codes-num").val();


### PR DESCRIPTION
This PR adds the option to „upload“ a CSV-file to add answer options when creating/editing a question of type „Choose one/multiple from a list“. This is done by „parsing“ a local file-input. Parsing is currently very limited, it is actually just a regex split on `[;,\t]` – so currently not more than a hack and just a proof of concept to do this client-side.

Should I investige further to e.g. improve CSV-parsing – or include something like https://www.papaparse.com? What about fails matching CSV-columns with number of language inputs? There currently is no way to mix&match csv-columns to inputs, etc. So overall, this feels very very basic and – again – very hacky.