### PR TITLE
Group identical lines on invoice PDF

### DIFF
--- a/src/pretix/base/invoice.py
+++ b/src/pretix/base/invoice.py
@@ -582,7 +582,7 @@ class ClassicInvoiceRenderer(BaseReportlabInvoiceRenderer):
             else:
                 if len(lines) > 1:
                     single_price_line = pgettext('invoice', 'Single price: {price}').format(
-                        money_filter(gross_value, self.invoice.event.currency),
+                        price=money_filter(gross_value, self.invoice.event.currency),
                     )
                     description = description + "\n" + single_price_line
                 tdata.append((

--- a/src/pretix/base/services/invoices.py
+++ b/src/pretix/base/services/invoices.py
@@ -452,17 +452,19 @@ def build_preview_invoice_pdf(event):
 
         if event.tax_rules.exists():
             for i, tr in enumerate(event.tax_rules.all()):
-                tax = tr.tax(Decimal('100.00'), base_price_is='gross')
-                InvoiceLine.objects.create(
-                    invoice=invoice, description=_("Sample product {}").format(i + 1),
-                    gross_value=tax.gross, tax_value=tax.tax,
-                    tax_rate=tax.rate
-                )
+                for j in range(150):
+                    tax = tr.tax(Decimal('100.00'), base_price_is='gross')
+                    InvoiceLine.objects.create(
+                        invoice=invoice, description=_("Sample product {}").format(i + 1),
+                        gross_value=tax.gross, tax_value=tax.tax,
+                        tax_rate=tax.rate
+                    )
         else:
-            InvoiceLine.objects.create(
-                invoice=invoice, description=_("Sample product A"),
-                gross_value=100, tax_value=0, tax_rate=0
-            )
+            for i in range(150):
+                InvoiceLine.objects.create(
+                    invoice=invoice, description=_("Sample product A"),
+                    gross_value=100, tax_value=0, tax_rate=0
+                )
 
         return event.invoice_renderer.generate(invoice)
 


### PR DESCRIPTION
Our data model for invoices will likely forever stay at a one-line-per-orderposition model, but there's no reason to render hundreds of lines in the PDF. We've recently changed this in https://github.com/pretix/pretixprint-android/pull/47 for POS receipts already.

The downside is that it makes the data model less "visible" and the XLSX export or ZUGFeRD data will be different from the PDF… That's annoying, but I think printing less pages of PDF is still worth it?