### PR TITLE
Bump version of the Stripe API

### DIFF
--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -429,7 +429,7 @@ class StripeMethod(BasePaymentProvider):
         return kwargs
 
     def _init_api(self):
-        stripe.api_version = '2022-08-01'
+        stripe.api_version = '2022-11-15'
         stripe.set_app_info(
             "pretix",
             partner_id="pp_partner_FSaz4PpKIur7Ox",


### PR DESCRIPTION
With https://github.com/pretix/pretix/commit/8c8e8031fc39eff6dfcb201242ca3c65d7ee1bd1, which (`stripe v5`) has an expectation to use `2022-11-15`, the version Stripe plugin uses to communicate should be updated as well. 