### PR TITLE
Add lifetime spending to customer details

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -25,7 +25,6 @@
                     <form action="" method="post" class="row">
                         {% csrf_token %}
                         <dl class="dl-horizontal col-lg-6 col-sm-12">
-                            <div>
                                 <dt>{% trans "Customer ID" %}</dt>
                                 <dd>#{{ customer.identifier }}</dd>
                                 {% if customer.provider %}
@@ -72,24 +71,21 @@
                                 <dt>{% trans "Notes" %}</dt>
                                 <dd>{{ customer.notes|linebreaks }}</dd>
                             {% endif %}
-                            </div>
                         </dl>
+                        {% if lifetime_spending %}
                         <dl class="col-lg-6 col-sm-12 text-right">
-                            <div>
-                            {% if lifetime_spending %}
-                                <dt class="text-muted"
-                                    data-toggle="tooltip"
-                                    title="{% trans "This includes all paid orders by this customer across all your events." %}">
-                                    {% trans "Lifetime spending" %}
-                                </dt>
-                                <dd class="text-success helper-font-size-24">
-                                    {% for s in lifetime_spending %}
-                                            {{ s.spending|money:s.currency }} <br>
-                                    {% endfor %}
-                                </dd>
-                            {% endif %}
-                            </div>
+                            <dt class="text-muted"
+                                data-toggle="tooltip"
+                                title="{% trans "This includes all paid orders by this customer across all your events." %}">
+                                {% trans "Lifetime spending" %}
+                            </dt>
+                            <dd class="text-success helper-font-size-24">
+                                {% for s in lifetime_spending %}
+                                        {{ s.spending|money:s.currency }} <br>
+                                {% endfor %}
+                            </dd>
                         </dl>
+                        {% endif %}
                     </form>
                     <div class="text-right">
                         <a href="{% url "control:organizer.customer.edit" organizer=request.organizer.slug customer=customer.identifier %}"

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -22,10 +22,10 @@
                     </h3>
                 </div>
                 <div class="panel-body">
-                <div class="row">
-                    <form action="" method="post" class="col-lg-8 col-md-6 col-sm-12">
+                    <form action="" method="post" class="row">
                         {% csrf_token %}
                         <dl class="dl-horizontal">
+                        <div class="col-lg-6 col-sm-12">
                             <dt>{% trans "Customer ID" %}</dt>
                             <dd>#{{ customer.identifier }}</dd>
                             {% if customer.provider %}
@@ -72,22 +72,23 @@
                             <dt>{% trans "Notes" %}</dt>
                             <dd>{{ customer.notes|linebreaks }}</dd>
                         {% endif %}
+                        </div>
+                        <div class="col-lg-6 col-sm-12 text-right">
+                        {% if lifetime_spending %}
+                            <dt class="text-muted text-right"
+                                data-toggle="tooltip"
+                                title="{% trans "This includes all paid orders by this customer across all your events." %}">
+                                {% trans "Lifetime spending" %}
+                            </dt>
+                            <dd class="text-success h3">
+                                {% for s in lifetime_spending %}
+                                        {{ s.spending|money:s.currency }}
+                                {% endfor %}
+                            </dd>
+                        {% endif %}
+                        </div>
                         </dl>
                     </form>
-                    {% if lifetime_spending %}
-                        <div class="text-right col-lg-4 col-md-6 col-sm-12"
-                                data-toggle="tooltip"
-                                title="{% trans "This includes all paid orders by this customer across all your events." %}"
-                        >
-                            <p class="text-muted">{% trans "Lifetime spending" %}</p>
-                                <h3 class="text-success">
-                                    {% for s in lifetime_spending %}
-                                            {{ s.spending|money:s.currency }}
-                                    {% endfor %}
-                                </h3>
-                        </div>
-                    {% endif %}
-                </div>
                     <div class="text-right">
                         <a href="{% url "control:organizer.customer.edit" organizer=request.organizer.slug customer=customer.identifier %}"
                                 class="btn btn-default">

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -72,20 +72,22 @@
                                 <dd>{{ customer.notes|linebreaks }}</dd>
                             {% endif %}
                         </dl>
-                        {% if lifetime_spending %}
                         <dl class="col-lg-6 col-sm-12 text-right">
                             <dt class="text-muted"
                                 data-toggle="tooltip"
                                 title="{% trans "This includes all paid orders by this customer across all your events." %}">
                                 {% trans "Lifetime spending" %}
                             </dt>
+                        {% if lifetime_spending %}
                             <dd class="text-success helper-font-size-24">
                                 {% for s in lifetime_spending %}
                                         {{ s.spending|money:s.currency }} <br>
                                 {% endfor %}
                             </dd>
-                        </dl>
+                        {% else %}
+                            <dd class="helper-font-size-24">–</dd>
                         {% endif %}
+                        </dl>
                     </form>
                     <div class="text-right">
                         <a href="{% url "control:organizer.customer.edit" organizer=request.organizer.slug customer=customer.identifier %}"

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -71,6 +71,10 @@
                             <dt>{% trans "Notes" %}</dt>
                             <dd>{{ customer.notes|linebreaks }}</dd>
                         {% endif %}
+                        <dt>{% trans "Lifetime spending" %}</dt>
+                        {% for currency, total in lifetime_spending.items %}
+                            <dd>{{ total|money:currency }}</dd>
+                        {% endfor %}
                         </dl>
                     </form>
                     <div class="text-right">

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -72,8 +72,8 @@
                             <dd>{{ customer.notes|linebreaks }}</dd>
                         {% endif %}
                         <dt>{% trans "Lifetime spending" %}</dt>
-                        {% for currency, total in lifetime_spending.items %}
-                            <dd>{{ total|money:currency }}</dd>
+                        {% for s in lifetime_spending %}
+                            <dd>{{ s.spending|money:s.currency }}</dd>
                         {% endfor %}
                         </dl>
                     </form>

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -79,7 +79,7 @@
                                 {% trans "Lifetime spending" %}
                             </dt>
                         {% if lifetime_spending %}
-                            <dd class="text-success helper-font-size-24">
+                            <dd class="text-success text-h3">
                                 {% for s in lifetime_spending %}
                                         {{ s.spending|money:s.currency }} <br>
                                 {% endfor %}

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -79,13 +79,15 @@
                                 {% trans "Lifetime spending" %}
                             </dt>
                         {% if lifetime_spending %}
-                            <dd class="text-success text-h3">
-                                {% for s in lifetime_spending %}
-                                        {{ s.spending|money:s.currency }} <br>
-                                {% endfor %}
-                            </dd>
+                            {% for s in lifetime_spending %}
+                                {% if s.spending >= 0 %}
+                                    <dd class="text-success text-h3">{{ s.spending|money:s.currency }}</dd>
+                                {% elif s.spending < 0 %}
+                                    <dd class="text-error text-h3">{{ s.spending|money:s.currency }}</dd>
+                                {% endif %}
+                            {% endfor %}
                         {% else %}
-                            <dd class="helper-font-size-24">–</dd>
+                            <dd class="text-muted text-h3">{{ 0|floatformat:2 }}</dd>
                         {% endif %}
                         </dl>
                     </form>

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -22,7 +22,8 @@
                     </h3>
                 </div>
                 <div class="panel-body">
-                    <form action="" method="post">
+                <div class="row">
+                    <form action="" method="post" class="col-lg-8 col-md-6 col-sm-12">
                         {% csrf_token %}
                         <dl class="dl-horizontal">
                             <dt>{% trans "Customer ID" %}</dt>
@@ -71,12 +72,22 @@
                             <dt>{% trans "Notes" %}</dt>
                             <dd>{{ customer.notes|linebreaks }}</dd>
                         {% endif %}
-                        <dt>{% trans "Lifetime spending" %}</dt>
-                        {% for s in lifetime_spending %}
-                            <dd>{{ s.spending|money:s.currency }}</dd>
-                        {% endfor %}
                         </dl>
                     </form>
+                    {% if lifetime_spending %}
+                        <div class="text-right col-lg-4 col-md-6 col-sm-12"
+                                data-toggle="tooltip"
+                                title="{% trans "This includes all paid orders by this customer across all your events." %}"
+                        >
+                            <p class="text-muted">{% trans "Lifetime spending" %}</p>
+                                <h3 class="text-success">
+                                    {% for s in lifetime_spending %}
+                                            {{ s.spending|money:s.currency }}
+                                    {% endfor %}
+                                </h3>
+                        </div>
+                    {% endif %}
+                </div>
                     <div class="text-right">
                         <a href="{% url "control:organizer.customer.edit" organizer=request.organizer.slug customer=customer.identifier %}"
                                 class="btn btn-default">

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -24,69 +24,71 @@
                 <div class="panel-body">
                     <form action="" method="post" class="row">
                         {% csrf_token %}
-                        <dl class="dl-horizontal">
-                        <div class="col-lg-6 col-sm-12">
-                            <dt>{% trans "Customer ID" %}</dt>
-                            <dd>#{{ customer.identifier }}</dd>
-                            {% if customer.provider %}
-                                <dt>{% trans "SSO provider" %}</dt>
-                                <dd>{{ customer.provider.name }}</dd>
-                            {% endif %}
-                            {% if customer.external_identifier %}
-                                <dt>{% trans "External identifier" %}</dt>
-                                <dd>{{ customer.external_identifier }}</dd>
-                            {% endif %}
-                            <dt>{% trans "Status" %}</dt>
-                            <dd>
-                                {% if not customer.is_active %}
-                                    {% trans "disabled" %}
-                                {% elif not customer.is_verified %}
-                                    {% trans "not yet activated" %}
-                                {% else %}
-                                    {% trans "active" %}
+                        <dl class="dl-horizontal col-lg-6 col-sm-12">
+                            <div>
+                                <dt>{% trans "Customer ID" %}</dt>
+                                <dd>#{{ customer.identifier }}</dd>
+                                {% if customer.provider %}
+                                    <dt>{% trans "SSO provider" %}</dt>
+                                    <dd>{{ customer.provider.name }}</dd>
                                 {% endif %}
-                            </dd>
-                            <dt>{% trans "E-mail" %}</dt>
-                            <dd>
-                                {{ customer.email|default_if_none:"" }}
-                                {% if customer.email and not customer.provider %}
-                                    <button type="submit" name="action" value="pwreset" class="btn btn-xs btn-default">
-                                    {% trans "Send password reset link" %}
-                                    </button>
+                                {% if customer.external_identifier %}
+                                    <dt>{% trans "External identifier" %}</dt>
+                                    <dd>{{ customer.external_identifier }}</dd>
                                 {% endif %}
-                            </dd>
-                            <dt>{% trans "Name" %}</dt>
-                            <dd>{{ customer.name }}</dd>
-                        {% if customer.phone %}
-                            <dt>{% trans "Phone" %}</dt>
-                            <dd>{{ customer.phone }}</dd>
-                        {% endif %}
-                            <dt>{% trans "Locale" %}</dt>
-                            <dd>{{ display_locale }}</dd>
-                            <dt>{% trans "Registration date" %}</dt>
-                            <dd>{{ customer.date_joined|date:"SHORT_DATETIME_FORMAT" }}</dd>
-                            <dt>{% trans "Last login" %}</dt>
-                            <dd>{% if customer.last_login %}{{ customer.last_login|date:"SHORT_DATETIME_FORMAT" }}{% else %}
-                                –{% endif %}</dd>
-                        {% if customer.notes %}
-                            <dt>{% trans "Notes" %}</dt>
-                            <dd>{{ customer.notes|linebreaks }}</dd>
-                        {% endif %}
-                        </div>
-                        <div class="col-lg-6 col-sm-12 text-right">
-                        {% if lifetime_spending %}
-                            <dt class="text-muted pull-right"
-                                data-toggle="tooltip"
-                                title="{% trans "This includes all paid orders by this customer across all your events." %}">
-                                {% trans "Lifetime spending" %}
-                            </dt>
-                            <dd class="text-success h3">
-                                {% for s in lifetime_spending %}
-                                        {{ s.spending|money:s.currency }}
-                                {% endfor %}
-                            </dd>
-                        {% endif %}
-                        </div>
+                                <dt>{% trans "Status" %}</dt>
+                                <dd>
+                                    {% if not customer.is_active %}
+                                        {% trans "disabled" %}
+                                    {% elif not customer.is_verified %}
+                                        {% trans "not yet activated" %}
+                                    {% else %}
+                                        {% trans "active" %}
+                                    {% endif %}
+                                </dd>
+                                <dt>{% trans "E-mail" %}</dt>
+                                <dd>
+                                    {{ customer.email|default_if_none:"" }}
+                                    {% if customer.email and not customer.provider %}
+                                        <button type="submit" name="action" value="pwreset" class="btn btn-xs btn-default">
+                                        {% trans "Send password reset link" %}
+                                        </button>
+                                    {% endif %}
+                                </dd>
+                                <dt>{% trans "Name" %}</dt>
+                                <dd>{{ customer.name }}</dd>
+                            {% if customer.phone %}
+                                <dt>{% trans "Phone" %}</dt>
+                                <dd>{{ customer.phone }}</dd>
+                            {% endif %}
+                                <dt>{% trans "Locale" %}</dt>
+                                <dd>{{ display_locale }}</dd>
+                                <dt>{% trans "Registration date" %}</dt>
+                                <dd>{{ customer.date_joined|date:"SHORT_DATETIME_FORMAT" }}</dd>
+                                <dt>{% trans "Last login" %}</dt>
+                                <dd>{% if customer.last_login %}{{ customer.last_login|date:"SHORT_DATETIME_FORMAT" }}{% else %}
+                                    –{% endif %}</dd>
+                            {% if customer.notes %}
+                                <dt>{% trans "Notes" %}</dt>
+                                <dd>{{ customer.notes|linebreaks }}</dd>
+                            {% endif %}
+                            </div>
+                        </dl>
+                        <dl class="col-lg-6 col-sm-12 text-right">
+                            <div>
+                            {% if lifetime_spending %}
+                                <dt class="text-muted"
+                                    data-toggle="tooltip"
+                                    title="{% trans "This includes all paid orders by this customer across all your events." %}">
+                                    {% trans "Lifetime spending" %}
+                                </dt>
+                                <dd class="text-success helper-font-size-24">
+                                    {% for s in lifetime_spending %}
+                                            {{ s.spending|money:s.currency }} <br>
+                                    {% endfor %}
+                                </dd>
+                            {% endif %}
+                            </div>
                         </dl>
                     </form>
                     <div class="text-right">

--- a/src/pretix/control/templates/pretixcontrol/organizers/customer.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/customer.html
@@ -75,7 +75,7 @@
                         </div>
                         <div class="col-lg-6 col-sm-12 text-right">
                         {% if lifetime_spending %}
-                            <dt class="text-muted text-right"
+                            <dt class="text-muted pull-right"
                                 data-toggle="tooltip"
                                 title="{% trans "This includes all paid orders by this customer across all your events." %}">
                                 {% trans "Lifetime spending" %}

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -2313,7 +2313,7 @@ class CustomerDetailView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMi
 
         ctx["lifetime_spending"] = (
             self.get_queryset()
-            .filter(status__in=[Order.STATUS_PAID, Order.STATUS_PENDING])
+            .filter(status=Order.STATUS_PAID)
             .values(currency=F("event__currency"))
             .order_by("currency")
             .annotate(spending=Sum("total"))

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -2296,6 +2296,7 @@ class CustomerDetailView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMi
             )
         }
 
+        spending = {}
         scs = get_all_sales_channels()
         for o in ctx['orders']:
             if o.pk not in annotated:
@@ -2310,6 +2311,15 @@ class CustomerDetailView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMi
             o.computed_payment_refund_sum = annotated.get(o.pk)['computed_payment_refund_sum']
             o.icnt = annotated.get(o.pk)['icnt']
             o.sales_channel_obj = scs[o.sales_channel]
+            currency = o.event.currency
+            if currency in spending:
+                total = spending[currency]
+                total += o.total
+                spending[currency] = total
+            else:
+                spending[currency] = o.total
+
+        ctx['lifetime_spending'] = spending
 
         return ctx
 

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -45,8 +45,8 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.files import File
 from django.db import connections, transaction
 from django.db.models import (
-    Count, Exists, IntegerField, Max, Min, OuterRef, Prefetch, ProtectedError,
-    Q, Subquery, Sum, F,
+    Count, Exists, F, IntegerField, Max, Min, OuterRef, Prefetch,
+    ProtectedError, Q, Subquery, Sum,
 )
 from django.db.models.functions import Coalesce, Greatest
 from django.forms import DecimalField

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -160,6 +160,9 @@ p.bigger {
 .helper-space-below {
     margin-bottom: 10px;
 }
+.helper-font-size-24 {
+    font-size: 24px;
+}
 
 .section-moved {
     margin: 20px 0;

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -160,9 +160,12 @@ p.bigger {
 .helper-space-below {
     margin-bottom: 10px;
 }
-.helper-font-size-24 {
-    font-size: 24px;
-}
+.text-h1 { font-size: $font-size-h1; }
+.text-h2 { font-size: $font-size-h2; }
+.text-h3 { font-size: $font-size-h3; }
+.text-h4 { font-size: $font-size-h4; }
+.text-h5 { font-size: $font-size-h5; }
+.text-h6 { font-size: $font-size-h6; }
 
 .section-moved {
     margin: 20px 0;


### PR DESCRIPTION
Add an entry for lifetime spending in a customer account's details section, so organizers can easily see how much a customer has spent on all of their events. It gets split for currency, as money exchange courses are not set in stone.