### PR TITLE
PDF-Editor: fix empty background / reduce precision of page width and height (Z#23112472)

### DIFF
--- a/src/pretix/control/views/pdf.py
+++ b/src/pretix/control/views/pdf.py
@@ -156,8 +156,8 @@ class BaseEditorView(EventPermissionRequiredMixin, TemplateView):
             p = PdfWriter()
             try:
                 p.add_blank_page(
-                    width=float(request.POST.get('width')) * mm,
-                    height=float(request.POST.get('height')) * mm,
+                    width=Decimal('%.5f' % (float(request.POST.get('width')) * mm)),
+                    height=Decimal('%.5f' % (float(request.POST.get('height')) * mm)),
                 )
             except ValueError:
                 return JsonResponse({


### PR DESCRIPTION
When creating an empty background pdf, passing floats can result in high precision numbers, which cause an error in Adobe Acrobat. This PR reduces precision to 5.