### PR TITLE
Presale: Improve visibiltity of edit links on order confirm/details page (Z#23108817)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -18,6 +18,9 @@
                 <h3 class="panel-title">
                     <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                     {% trans "Your cart" %}
+                    <a href="{% eventurl request.event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}" class="h6">
+                        <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Add or remove tickets" %}
+                    </a>
                 </h3>
                 <span class="panel-heading-flex-gap"></span>
                 <strong class="helper-display-block" id="cart-deadline-short" data-expires="{{ cart.first_expiry|date:"Y-m-d H:i:sO" }}">
@@ -27,30 +30,21 @@
                         {% trans "Cart expired" %}
                     {% endif %}
                 </strong>
-                <span class="helper-display-block cart-modify">
-                    <a href="{% eventurl request.event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}">
-                        <span class="fa fa-edit" aria-hidden="true"></span>
-                        {% trans "Add or remove tickets" %}
-                    </a>
-                </span>
             </div>
             <div class="panel-body">
                 {% include "pretixpresale/event/fragment_cart.html" with cart=cart event=request.event editable=False %}
             </div>
         </div>
         {% if payments %}
-            <div class="panel panel-primary">
+            <div class="panel panel-default">
                 <div class="panel-heading">
-                    {% if payment_provider.identifier != "free" %}
-                        <div class="pull-right flip">
-                            <a href="{% eventurl request.event "presale:event.checkout" step="payment" cart_namespace=cart_namespace|default_if_none:"" %}" aria-label="{% trans "Modify payment" %}">
-                                <span class="fa fa-edit" aria-hidden="true"></span>
-                                {% trans "Modify" %}
-                            </a>
-                        </div>
-                    {% endif %}
                     <h3 class="panel-title">
                         {% trans "Payment" %}
+                        {% if payment_provider.identifier != "free" %}
+                                <a href="{% eventurl request.event "presale:event.checkout" step="payment" cart_namespace=cart_namespace|default_if_none:"" %}" aria-label="{% trans "Modify payment" %}" class="h6">
+                                    <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Modify" %}
+                                </a>
+                        {% endif %}
                     </h3>
                 </div>
                 <ul class="list-group">
@@ -78,16 +72,13 @@
         <div class="row">
             {% if invoice_address_asked %}
                 <div class="col-md-6 col-xs-12">
-                    <div class="panel panel-primary panel-contact">
+                    <div class="panel panel-default panel-contact">
                         <div class="panel-heading">
-                            <div class="pull-right flip">
-                                <a href="{% eventurl request.event "presale:event.checkout" step="questions" cart_namespace=cart_namespace|default_if_none:"" %}?invoice=1" aria-label="{% trans "Modify invoice information" %}">
-                                    <span class="fa fa-edit" aria-hidden="true"></span>
-                                    {% trans "Modify" %}
-                                </a>
-                            </div>
                             <h3 class="panel-title">
                                 {% trans "Invoice information" %}
+                                <a href="{% eventurl request.event "presale:event.checkout" step="questions" cart_namespace=cart_namespace|default_if_none:"" %}?invoice=1" aria-label="{% trans "Modify invoice information" %}" class="h6">
+                                    <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Modify" %}
+                                </a>
                             </h3>
                         </div>
                         <div class="panel-body">
@@ -128,16 +119,13 @@
                 </div>
             {% endif %}
             <div class="{% if invoice_address_asked %}col-md-6{% endif %} col-xs-12">
-                <div class="panel panel-primary panel-contact">
+                <div class="panel panel-default panel-contact">
                     <div class="panel-heading">
-                        <div class="pull-right flip">
-                            <a href="{% eventurl request.event "presale:event.checkout" step="questions" cart_namespace=cart_namespace|default_if_none:"" %}" aria-label="{% trans "Modify contact information" %}">
-                                <span class="fa fa-edit" aria-hidden="true"></span>
-                                {% trans "Modify" %}
-                            </a>
-                        </div>
                         <h3 class="panel-title">
                             {% trans "Contact information" %}
+                            <a href="{% eventurl request.event "presale:event.checkout" step="questions" cart_namespace=cart_namespace|default_if_none:"" %}" aria-label="{% trans "Modify contact information" %}" class="h6">
+                                <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Modify" %}
+                            </a>
                         </h3>
                     </div>
                     <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -100,23 +100,25 @@
                 {% if last_payment %}
                     {{ last_payment_info }}
                     {% if can_pay %}
-                        <div class="text-right flip">
+                        <p>
+                            <a href="{% eventurl event "presale:event.order.pay.change" secret=order.secret order=order.code %}"
+                                    class="btn btn-primary">
+                                {% trans "Retry payment" %}
+                            </a>
                             <a href="{% eventurl event "presale:event.order.pay.change" secret=order.secret order=order.code %}"
                                     class="btn btn-default">
-                                {% trans "Re-try payment or choose another payment method" %}
+                                {% trans "Choose another payment method" %}
                             </a>
-                        </div>
+                        </p>
                     {% endif %}
                 {% else %}
                     {% if can_pay %}
-                        <div class="text-right flip">
+                        <p>
                             <a href="{% eventurl event "presale:event.order.pay.change" secret=order.secret order=order.code %}"
                                     class="btn btn-primary btn-lg">{% trans "Pay now" %}</a>
-                        </div>
+                        </p>
                     {% endif %}
                 {% endif %}
-
-                <div class="clearfix"></div>
             </div>
         </div>
     {% endif %}
@@ -226,6 +228,14 @@
                     </div>
                     <div class="clearfix"></div>
                 </div>
+            {% endif %}
+            {% if order.can_modify_answers %}
+                <p>
+                    <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change ordered items" %}" class="btn btn-primary">
+                        <span class="fa fa-edit" aria-hidden="true"></span>
+                        {% trans "Change details" %}
+                    </a>
+                </p>
             {% endif %}
         </div>
     </div>
@@ -341,6 +351,16 @@
                             <dd>{{ order.invoice_address.internal_reference }}</dd>
                         {% endif %}
                     </dl>
+                    {% if invoice_address_asked or request.event.settings.invoice_name_required %}
+                        {% if order.can_modify_answers %}
+                            <p>
+                                <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change your information" %}" class="btn btn-primary">
+                                    <span class="fa fa-edit" aria-hidden="true"></span>
+                                    {% trans "Change details" %}
+                                </a>
+                            </p>
+                        {% endif %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -191,7 +191,7 @@
         {% endif %}
     {% endif %}
     {% include "pretixpresale/event/fragment_downloads.html" with position_page=False %}
-    <div class="panel panel-primary cart">
+    <div class="panel panel-default cart">
         <div class="panel-heading">
             {% if order.can_modify_answers %}
                 <div class="pull-right flip">
@@ -284,7 +284,7 @@
             </div>
         {% endif %}
         <div class="col-xs-12 {% if invoices or can_generate_invoice %}col-md-6{% endif %}">
-            <div class="panel panel-primary">
+            <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if invoice_address_asked or request.event.settings.invoice_name_required %}
                         {% if order.can_modify_answers %}
@@ -347,7 +347,7 @@
         <div class="clearfix"></div>
     </div>
     {% if user_change_allowed or user_cancel_allowed %}
-        <div class="panel panel-primary panel-cancellation">
+        <div class="panel panel-default panel-cancellation">
             <div class="panel-heading">
                 <h3 class="panel-title">
                     {% trans "Change or cancel your order" context "action" %}

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -103,11 +103,7 @@
                         <p>
                             <a href="{% eventurl event "presale:event.order.pay.change" secret=order.secret order=order.code %}"
                                     class="btn btn-primary">
-                                {% trans "Retry payment" %}
-                            </a>
-                            <a href="{% eventurl event "presale:event.order.pay.change" secret=order.secret order=order.code %}"
-                                    class="btn btn-default">
-                                {% trans "Choose another payment method" %}
+                                {% trans "Re-try payment or choose another payment method" %}
                             </a>
                         </p>
                     {% endif %}
@@ -226,14 +222,6 @@
                     <div class="clearfix"></div>
                 </div>
             {% endif %}
-            {% if order.can_modify_answers %}
-                <p>
-                    <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change ordered items" %}" class="btn btn-primary">
-                        <span class="fa fa-edit" aria-hidden="true"></span>
-                        {% trans "Change details" %}
-                    </a>
-                </p>
-            {% endif %}
         </div>
     </div>
     {% eventsignal event "pretix.presale.signals.order_info" order=order request=request %}
@@ -345,16 +333,6 @@
                             <dd>{{ order.invoice_address.internal_reference }}</dd>
                         {% endif %}
                     </dl>
-                    {% if invoice_address_asked or request.event.settings.invoice_name_required %}
-                        {% if order.can_modify_answers %}
-                            <p>
-                                <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change your information" %}" class="btn btn-primary">
-                                    <span class="fa fa-edit" aria-hidden="true"></span>
-                                    {% trans "Change details" %}
-                                </a>
-                            </p>
-                        {% endif %}
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -195,16 +195,15 @@
     {% include "pretixpresale/event/fragment_downloads.html" with position_page=False %}
     <div class="panel panel-default cart">
         <div class="panel-heading">
-            {% if order.can_modify_answers %}
-                <div class="pull-right flip">
-                    <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change ordered items" %}">
-                        <span class="fa fa-edit" aria-hidden="true"></span>
-                        {% trans "Change details" %}
-                    </a>
-                </div>
-            {% endif %}
             <h3 class="panel-title">
                 {% trans "Ordered items" %}
+                {% if order.can_modify_answers %}
+                    &nbsp;
+                    <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change ordered items" %}" class="h6">
+                        <span class="fa fa-edit" aria-hidden="true"></span>
+                        <u>{% trans "Change details" %}</u>
+                    </a>
+                {% endif %}
             </h3>
         </div>
         <div class="panel-body">
@@ -296,18 +295,17 @@
         <div class="col-xs-12 {% if invoices or can_generate_invoice %}col-md-6{% endif %}">
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    {% if invoice_address_asked or request.event.settings.invoice_name_required %}
-                        {% if order.can_modify_answers %}
-                            <div class="pull-right flip">
-                                <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change your information" %}">
-                                    <span class="fa fa-edit" aria-hidden="true"></span>
-                                    {% trans "Change details" %}
-                                </a>
-                            </div>
-                        {% endif %}
-                    {% endif %}
                     <h3 class="panel-title">
                         {% trans "Your information" %}
+                        {% if invoice_address_asked or request.event.settings.invoice_name_required %}
+                            {% if order.can_modify_answers %}
+                                &nbsp;
+                                <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change your information" %}" class="h6">
+                                    <span class="fa fa-edit" aria-hidden="true"></span>
+                                    <u>{% trans "Change details" %}</u>
+                                </a>
+                            {% endif %}
+                        {% endif %}
                     </h3>
                 </div>
                 <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -198,10 +198,8 @@
             <h3 class="panel-title">
                 {% trans "Ordered items" %}
                 {% if order.can_modify_answers %}
-                    &nbsp;
                     <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change ordered items" %}" class="h6">
-                        <span class="fa fa-edit" aria-hidden="true"></span>
-                        <u>{% trans "Change details" %}</u>
+                        <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Change details" %}
                     </a>
                 {% endif %}
             </h3>
@@ -299,10 +297,8 @@
                         {% trans "Your information" %}
                         {% if invoice_address_asked or request.event.settings.invoice_name_required %}
                             {% if order.can_modify_answers %}
-                                &nbsp;
                                 <a href="{% eventurl event "presale:event.order.modify" secret=order.secret order=order.code %}" aria-label="{% trans "Change your information" %}" class="h6">
-                                    <span class="fa fa-edit" aria-hidden="true"></span>
-                                    <u>{% trans "Change details" %}</u>
+                                    <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Change details" %}
                                 </a>
                             {% endif %}
                         {% endif %}

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -140,6 +140,7 @@ article.item-with-variations .product-row:last-child:after {
     display: none;
 }
 
+.panel-body > *:last-child,
 .panel-body address:last-child {
     margin-bottom: 0;
 }

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -367,6 +367,14 @@ body.loading .container {
     background-color: darken($btn-primary-bg, 10%);
 }
 
+.panel-title a.h6 {
+    text-decoration: underline;
+    margin-left: .5em;
+}
+.panel-title a.h6 .fa {
+    margin-left: .25em;
+    margin-right: .25em;
+}
 
 details {
     list-style: none;


### PR DESCRIPTION
This PR tries to improve about the discoverability of an order’s edit links. Currently they are only on the right side of the panel’s head, styled as text (no underline, no button). This PR moves those links to the left and underlines them. Furthermore it removes panel-primary purple in favor of panel-default grey panel-headers, so the newly added buttons „pop“ more.

For this PR, all plugins that listen to signals `order_info_top` and `order_info` as well as `checkout_confirm_page_content` have been checked. Only pretix-shipping needed adjustments.