### PR TITLE
PPv2: Simulate cart_payments in XHR-calls; only look at multi_use-payments for remaining value calculation

### DIFF
--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -163,14 +163,13 @@ class XHRView(View):
 
             total_remaining = cart_total
             for p in multi_use_cart_payments:
-                if p['provider'] != 'paypal':
-                    if p.get('min_value') and total_remaining < Decimal(p['min_value']):
-                        continue
+                if p.get('min_value') and total_remaining < Decimal(p['min_value']):
+                    continue
 
-                    to_pay = total_remaining
-                    if p.get('max_value') and to_pay > Decimal(p['max_value']):
-                        to_pay = min(to_pay, Decimal(p['max_value']))
-                    total_remaining -= to_pay
+                to_pay = total_remaining
+                if p.get('max_value') and to_pay > Decimal(p['max_value']):
+                    to_pay = min(to_pay, Decimal(p['max_value']))
+                total_remaining -= to_pay
 
             cart_total = total_remaining
 

--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -153,8 +153,8 @@ class XHRView(View):
             simulated_payments = multi_use_cart_payments + [{
                 'provider': 'paypal',
                 'multi_use_supported': False,
-                'min_value': prov.settings._total_min,
-                'max_value': prov.settings._total_max,
+                'min_value': None,
+                'max_value': None,
                 'info_data': {},
             }]
 


### PR DESCRIPTION
c.f. Z#23113247