### PR TITLE
Editor: fix sample text when key missing

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/editor.js
+++ b/src/pretix/static/pretixcontrol/js/ui/editor.js
@@ -256,7 +256,7 @@ var editor = {
             } else if (d.content === "other_i18n") {
                 o.text_i18n = d.text_i18n
                 o.setText(d.text_i18n[Object.keys(d.text_i18n)[0]]);
-            } else {
+            } else if (d.content) {
                 o.setText(editor._get_text_sample(d.content));
             }
             if (d.locale) {


### PR DESCRIPTION
There seems to be a way to create a PDF-Layout with an element having no content-attribute. This PR currently changes the editor to not fail, but ignore such elements. This creates an element, that once selected in the editor has no option in the „Content“-dropdown selected. And once one selects e.g. „Other“ the text (Sample text?) gets replaced with an empty string. Do we want this or should we instead do `if (!d.content) d.content = "other";`.