### PR TITLE
Add setting presale end show date

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -663,6 +663,7 @@ class EventSettingsSerializer(SettingsSerializer):
         'show_items_outside_presale_period',
         'display_net_prices',
         'presale_start_show_date',
+        'presale_end_show_date',
         'locales',
         'locale',
         'region',

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -782,6 +782,17 @@ DEFAULTS = {
             widget=forms.CheckboxInput,
         )
     },
+    'presale_end_show_date': {
+        'default': 'False',
+        'type': bool,
+        'form_class': forms.BooleanField,
+        'serializer_class': serializers.BooleanField,
+        'form_kwargs': dict(
+            label=_("Show end date"),
+            help_text=_("Show the presale end date during active presale."),
+            widget=forms.CheckboxInput,
+        )
+    },
     'tax_rate_default': {
         'default': None,
         'type': TaxRule

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -483,6 +483,7 @@ class EventSettingsForm(SettingsForm):
         'show_items_outside_presale_period',
         'display_net_prices',
         'presale_start_show_date',
+        'presale_end_show_date',
         'locales',
         'locale',
         'region',

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -222,6 +222,7 @@
                 <legend>{% trans "Timeline" %}</legend>
                 {% bootstrap_field form.presale_start layout="control" %}
                 {% bootstrap_field sform.presale_start_show_date layout="control" %}
+                {% bootstrap_field sform.presale_end_show_date layout="control" %}
                 {% bootstrap_field form.presale_end layout="control" %}
                 {% bootstrap_field sform.show_items_outside_presale_period layout="control" %}
                 {% bootstrap_field sform.last_order_modification_date layout="control" %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
@@ -21,7 +21,15 @@
             <div class="col-md-2 text-right flip">
                 {% if subev.presale_is_running and event.settings.event_list_availability %}
                     {% if subev.best_availability_state == 100 %}
-                        <span class="label label-success">{% trans "Book now" %}</span>
+                        {% if event.settings.presale_end_show_date %}
+                            <span class="label label-success">
+                                {% blocktrans trimmed with date=subev.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                    Book until {{ date }}
+                                {% endblocktrans %}
+                            </span>
+                        {% else %}
+                            <span class="label label-success">{% trans "Book now" %}</span>
+                        {% endif %}
                     {% elif event.settings.waiting_list_enabled and subev.best_availability_state >= 0 %}
                         <span class="label label-warning">{% trans "Waiting list" %}</span>
                     {% elif subev.best_availability_state == 20 %}
@@ -34,7 +42,15 @@
                         {% endif %}
                     {% endif %}
                 {% elif subev.presale_is_running %}
-                    <span class="label label-success">{% trans "Book now" %}</span>
+                    {% if event.settings.presale_end_show_date %}
+                        <span class="label label-success">
+                            {% blocktrans trimmed with date=subev.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                Book until {{ date }}
+                            {% endblocktrans %}
+                        </span>
+                    {% else %}
+                        <span class="label label-success">{% trans "Book now" %}</span>
+                    {% endif %}
                 {% elif subev.presale_has_ended %}
                     <span class="label label-danger">{% trans "Sale over" %}</span>
                 {% elif event.settings.presale_start_show_date %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -159,6 +159,20 @@
                     {% endblocktrans %}
                 {% endif %}
             </div>
+        {% else %}
+            {% if event.settings.presale_end_show_date %}
+                {% with date=ev.effective_presale_end|date:"SHORT_DATE_FORMAT" date_normalized=ev.effective_presale_end|date:"Y-m-d" %}
+                {% with time=ev.effective_presale_end|time:"TIME_FORMAT" time_24h=ev.effective_presale_end|time:"H:i" %}
+                    <div class="alert alert-info">
+                    <span data-time="{{ ev.effective_presale_end.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                        {% blocktrans trimmed with date="<time datetime='"|add:date_normalized|add:"'>"|add:date|add:"</time>"|safe time="<time datetime='"|add:time_24h|add:"'>"|add:time|add:"</time>"|safe %}
+                            The booking period for this event will end on {{ date }} at {{ time }}.
+                        {% endblocktrans %}
+                    </span>
+                    </div>
+                {% endwith %}
+                {% endwith %}
+            {% endif %}
         {% endif %}
         {% if not cart_namespace or subevent %}
             <div>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -68,7 +68,14 @@
                                             <span class="event-status">
                                                 {% if event.event.presale_is_running and show_avail %}
                                                     {% if event.event.best_availability_state == 100 %}
-                                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                                        {% if event.event.settings.presale_end_show_date %}
+                                                            <span class="fa fa-ticket"> </span>
+                                                            {% blocktrans trimmed with date=event.event.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                                            until {{ date }}
+                                                            {% endblocktrans %}
+                                                        {% else %}
+                                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                                        {% endif %}
                                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                                     {% elif event.event.best_availability_state == 20 %}
@@ -81,7 +88,14 @@
                                                         {% endif %}
                                                     {% endif %}
                                                 {% elif event.event.presale_is_running %}
-                                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                                    {% if event.event.settings.presale_end_show_date %}
+                                                        <span class="fa fa-ticket"> </span>
+                                                        {% blocktrans trimmed with date=event.event.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                                        until {{ date }}
+                                                        {% endblocktrans %}
+                                                    {% else %}
+                                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                                    {% endif %}
                                                 {% elif event.event.presale_has_ended %}
                                                     {% trans "Sale over" %}
                                                 {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
@@ -89,7 +89,14 @@
                         <span class="event-status">
                             {% if event.event.presale_is_running and show_avail %}
                                 {% if event.event.best_availability_state == 100 %}
-                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                        {% if event.event.settings.presale_end_show_date %}
+                                            <span class="fa fa-ticket"> </span>
+                                            {% blocktrans trimmed with date=event.event.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                            until {{ date }}
+                                            {% endblocktrans %}
+                                        {% else %}
+                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                        {% endif %}
                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                     <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                     {% elif event.event.best_availability_state == 20 %}
@@ -103,7 +110,14 @@
                                     {% endif %}
                                 {% endif %}
                             {% elif event.event.presale_is_running %}
-                                <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                {% if event.event.settings.presale_end_show_date %}
+                                    <span class="fa fa-ticket"> </span>
+                                    {% blocktrans trimmed with date=event.event.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                    until {{ date }}
+                                    {% endblocktrans %}
+                                {% else %}
+                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                {% endif %}
                                 {% elif event.event.presale_has_ended %}
                                 <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sale over" %}
                                 {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -53,7 +53,14 @@
                             <span class="event-status">
                                 {% if event.event.presale_is_running and show_avail %}
                                     {% if event.event.best_availability_state == 100 %}
-                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                        {% if event.event.settings.presale_end_show_date %}
+                                            <span class="fa fa-ticket"> </span>
+                                            {% blocktrans trimmed with date=event.event.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                            until {{ date }}
+                                            {% endblocktrans %}
+                                        {% else %}
+                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                        {% endif %}
                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                     {% elif event.event.best_availability_state == 20 %}
@@ -66,7 +73,14 @@
                                         {% endif %}
                                     {% endif %}
                                 {% elif event.event.presale_is_running %}
-                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                    {% if event.event.settings.presale_end_show_date %}
+                                        <span class="fa fa-ticket"> </span>
+                                        {% blocktrans trimmed with date=event.event.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                        until {{ date }}
+                                        {% endblocktrans %}
+                                    {% else %}
+                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                    {% endif %}
                                 {% elif event.event.presale_has_ended %}
                                     {% trans "Sale over" %}
                                 {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -81,7 +81,15 @@
                         <span class="label label-default">{% trans "Event series" %}</span>
                     {% elif e.presale_is_running and request.organizer.settings.event_list_availability %}
                         {% if e.best_availability_state == 100 %}
-                            <span class="label label-success">{% trans "Book now" %}</span>
+                            {% if e.settings.presale_end_show_date %}
+                                <span class="label label-success">
+                                {% blocktrans trimmed with date=e.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                    Book until {{ date }}
+                                {% endblocktrans %}
+                                </span>
+                            {% else %}
+                                <span class="label label-success">{% trans "Book now" %}</span>
+                            {% endif %}
                         {% elif e.settings.waiting_list_enabled and e.best_availability_state >= 0 %}
                             <span class="label label-warning">{% trans "Waiting list" %}</span>
                         {% elif e.best_availability_state == 20 %}
@@ -94,7 +102,15 @@
                             {% endif %}
                         {% endif %}
                     {% elif e.presale_is_running %}
-                        <span class="label label-success">{% trans "Book now" %}</span>
+                        {% if e.settings.presale_end_show_date %}
+                            <span class="label label-success">
+                            {% blocktrans trimmed with date=e.effective_presale_end|date:"SHORT_DATE_FORMAT" %}
+                                Book until {{ date }}
+                            {% endblocktrans %}
+                            </span>
+                        {% else %}
+                            <span class="label label-success">{% trans "Book now" %}</span>
+                        {% endif %}
                     {% elif e.presale_has_ended %}
                         <span class="label label-danger">{% trans "Sale over" %}</span>
                     {% elif e.settings.presale_start_show_date %}

--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -652,6 +652,7 @@ class WidgetAPIProductList(EventListMixin, View):
             'waiting_list_enabled': request.event.settings.waiting_list_enabled,
             'voucher_explanation_text': str(rich_text(request.event.settings.voucher_explanation_text, safelinks=False)),
             'error': None,
+            'info': None,
             'cart_exists': False
         }
 
@@ -680,6 +681,12 @@ class WidgetAPIProductList(EventListMixin, View):
                 }
             else:
                 data['error'] = gettext('The booking period for this event has not yet started.')
+        else:
+            if request.event.settings.presale_end_show_date:
+                data['info'] = gettext('The booking period for this event will end on %(date)s at %(time)s.') % {
+                    'date': date_format(ev.effective_presale_end.astimezone(request.event.timezone), "SHORT_DATE_FORMAT"),
+                    'time': date_format(ev.effective_presale_end.astimezone(request.event.timezone), "TIME_FORMAT"),
+                }
 
         self.voucher = None
         if 'voucher' in request.GET:

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -799,6 +799,8 @@ Vue.component('pretix-widget-event-form', {
 
         // Error message
         + '<div class="pretix-widget-error-message" v-if="$root.error">{{ $root.error }}</div>'
+        // Info message
+        + '<div class="pretix-widget-info-message" v-if="$root.info">{{ $root.info }}</div>'
 
         // Resume cart
         + '<div class="pretix-widget-info-message pretix-widget-clickable"'
@@ -1526,6 +1528,7 @@ var shared_root_methods = {
                 root.display_net_prices = data.display_net_prices;
                 root.voucher_explanation_text = data.voucher_explanation_text;
                 root.error = data.error;
+                root.info = data.info;
                 root.display_add_to_cart = data.display_add_to_cart;
                 root.waiting_list_enabled = data.waiting_list_enabled;
                 root.show_variations_expanded = data.show_variations_expanded || !!root.variation_filter;


### PR DESCRIPTION
This option is similar to `presale_start_show_date`. 

It enables the organizer to inform customers about the end of the presale period.