### PR TITLE
Checkout: remove Indonesia from zipcode-validation

### DIFF
--- a/src/pretix/base/addressvalidation.py
+++ b/src/pretix/base/addressvalidation.py
@@ -42,7 +42,6 @@ from localflavor.fr.forms import FRZipCodeField
 from localflavor.gb.forms import GBPostcodeField
 from localflavor.gr.forms import GRPostalCodeField
 from localflavor.hr.forms import HRPostalCodeField
-from localflavor.id_.forms import IDPostCodeField
 from localflavor.ie.forms import EircodeField
 from localflavor.il.forms import ILPostalCodeField
 from localflavor.in_.forms import INZipCodeField
@@ -167,7 +166,6 @@ _zip_code_fields = {
     'GB': GBPostcodeField,
     'GR': GRPostalCodeField,
     'HR': HRPostalCodeField,
-    'ID': IDPostCodeField,
     'IE': EircodeField,
     'IL': ILPostalCodeField,
     'IN': INZipCodeField,

--- a/src/pretix/base/addressvalidation.py
+++ b/src/pretix/base/addressvalidation.py
@@ -80,8 +80,8 @@ COUNTRIES_WITH_STREET_ZIPCODE_AND_CITY_REQUIRED = {
     # We don't presume this for countries we don't have knowledge about, there are countries in the
     # world e.g. without zipcodes
     'AR', 'AT', 'AU', 'BE', 'BR', 'CA', 'CH', 'CN', 'CU', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR',
-    'GB', 'GR', 'HR', 'ID', 'IE', 'IL', 'IN', 'IR', 'IS', 'IT', 'JP', 'LT', 'LV', 'MA', 'MT', 'MX',
-    'NL', 'NO', 'NZ', 'PK', 'PL', 'PT', 'RO', 'RU', 'SE', 'SG', 'SI', 'SK', 'TR', 'UA', 'US', 'ZA',
+    'GB', 'GR', 'HR', 'IE', 'IL', 'IN', 'IR', 'IS', 'IT', 'JP', 'LT', 'LV', 'MA', 'MT', 'MX', 'NL',
+    'NO', 'NZ', 'PK', 'PL', 'PT', 'RO', 'RU', 'SE', 'SG', 'SI', 'SK', 'TR', 'UA', 'US', 'ZA',
 }
 
 


### PR DESCRIPTION
Indonesia uses a 4 digit zip-code with an additional province-select in localflavor. Pretix currently does not support province, so a common fallback seems to be a 5 digit zip-code, which fails in localflavor. This PR removes Indonesia from zipcode-validation through localflavor.

Should I add a custom validator that at least does a basic „is 5 digits“ validation?