### PR TITLE
Remove empty help-text for colorpickers with no-contrast

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -291,7 +291,7 @@ var form_handlers = function (el) {
                 maxTop: 200
             }
         }
-    }).on('changeColor create', function (e) {
+    }).not(".no-contrast").on('changeColor create', function (e) {
         var rgb = $(this).colorpicker('color').toRGB();
         var c = contrast([255,255,255], [rgb.r, rgb.g, rgb.b]);
         var mark = 'times';
@@ -302,21 +302,19 @@ var form_handlers = function (el) {
         if ($(this).val() === "") {
             $note.remove();
         }
-        if (!$(this).is(".no-contrast")) {
-            if (c > 7) {
-                $note.html("<span class='fa fa-fw fa-check-circle'></span>")
-                    .append(gettext('Your color has great contrast and is very easy to read!'));
-                $note.addClass("text-success").removeClass("text-warning").removeClass("text-danger");
-            } else if (c > 2.5) {
-                $note.html("<span class='fa fa-fw fa-info-circle'></span>")
-                    .append(gettext('Your color has decent contrast and is probably good-enough to read!'));
-                $note.removeClass("text-success").removeClass("text-warning").removeClass("text-danger");
-            } else {
-                $note.html("<span class='fa fa-fw fa-warning'></span>")
-                    .append(gettext('Your color has bad contrast for text on white background, please choose a darker ' +
-                        'shade.'));
-                $note.addClass("text-danger").removeClass("text-success").removeClass("text-warning");
-            }
+        if (c > 7) {
+            $note.html("<span class='fa fa-fw fa-check-circle'></span>")
+                .append(gettext('Your color has great contrast and is very easy to read!'));
+            $note.addClass("text-success").removeClass("text-warning").removeClass("text-danger");
+        } else if (c > 2.5) {
+            $note.html("<span class='fa fa-fw fa-info-circle'></span>")
+                .append(gettext('Your color has decent contrast and is probably good-enough to read!'));
+            $note.removeClass("text-success").removeClass("text-warning").removeClass("text-danger");
+        } else {
+            $note.html("<span class='fa fa-fw fa-warning'></span>")
+                .append(gettext('Your color has bad contrast for text on white background, please choose a darker ' +
+                    'shade.'));
+            $note.addClass("text-danger").removeClass("text-success").removeClass("text-warning");
         }
     });
 


### PR DESCRIPTION
When using a colorpicker without the contrast-check, an empty help-text element is created, which takes space and causes layout-shifts with white-space if previously the color was empty.