### PR TITLE
Scheduled exports: Set owner to cc instead of to if there is an explicit recipient

### DIFF
--- a/src/pretix/base/services/export.py
+++ b/src/pretix/base/services/export.py
@@ -228,10 +228,20 @@ def _run_scheduled_export(schedule, context: Union[Event, Organizer], exporter, 
         else:
             schedule.error_counter = 0
             schedule.save(update_fields=['error_counter'])
+            to = [r for r in schedule.mail_additional_recipients.split(",") if r]
+            cc = [r for r in schedule.mail_additional_recipients_cc.split(",") if r]
+            bcc = [r for r in schedule.mail_additional_recipients_bcc.split(",") if r]
+            if to:
+                # If there is an explicit To, the owner is Cc. Otherwise, the owner is To. Yes, this is
+                # purely cosmetical and has policital reasons.
+                cc.append(schedule.owner.email)
+            else:
+                to.append(schedule.owner.email)
+
             mail(
-                email=[schedule.owner.email] + [r for r in schedule.mail_additional_recipients.split(",") if r],
-                cc=[r for r in schedule.mail_additional_recipients_cc.split(",") if r],
-                bcc=[r for r in schedule.mail_additional_recipients_bcc.split(",") if r],
+                email=to,
+                cc=cc,
+                bcc=bcc,
                 subject=schedule.mail_subject,
                 template=LazyI18nString(schedule.mail_template),
                 context=get_email_context(event=context) if isinstance(context, Event) else {},

--- a/src/tests/base/test_export.py
+++ b/src/tests/base/test_export.py
@@ -182,8 +182,8 @@ def test_event_ok(event, user, team):
     assert len(djmail.outbox) == 1
     assert djmail.outbox[0].subject == "Report 1"
     assert "Here is the report." in djmail.outbox[0].body
-    assert djmail.outbox[0].to == [user.email, "boss@example.org", "boss@example.net"]
-    assert djmail.outbox[0].cc == ["assistant@example.net"]
+    assert djmail.outbox[0].to == ["boss@example.org", "boss@example.net"]
+    assert djmail.outbox[0].cc == ["assistant@example.net", user.email]
     assert djmail.outbox[0].bcc == ["archive@example.net"]
     assert len(djmail.outbox[0].attachments) == 1
     assert djmail.outbox[0].attachments[0][0] == "dummy_orders.xlsx"
@@ -355,8 +355,8 @@ def test_organizer_ok(event, user, team):
     assert len(djmail.outbox) == 1
     assert djmail.outbox[0].subject == "Report 1"
     assert "Here is the report." in djmail.outbox[0].body
-    assert djmail.outbox[0].to == [user.email, "boss@example.org", "boss@example.net"]
-    assert djmail.outbox[0].cc == ["assistant@example.net"]
+    assert djmail.outbox[0].to == ["boss@example.org", "boss@example.net"]
+    assert djmail.outbox[0].cc == ["assistant@example.net", user.email]
     assert djmail.outbox[0].bcc == ["archive@example.net"]
     assert len(djmail.outbox[0].attachments) == 1
     assert djmail.outbox[0].attachments[0][0] == "dummy_events.csv"


### PR DESCRIPTION
The customer who sponsored the scheduled export feature, requested this change to make sure only the boss is highlighted in the "To" field of the report.