### PR TITLE
PPv2: Improve visibility of last step in paying orders

### DIFF
--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -31,7 +31,7 @@ from django.contrib import messages
 from django.http import HttpRequest
 from django.template.loader import get_template
 from django.templatetags.static import static
-from django.urls import reverse, resolve
+from django.urls import resolve, reverse
 from django.utils.crypto import get_random_string
 from django.utils.safestring import mark_safe
 from django.utils.timezone import now

--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -31,7 +31,7 @@ from django.contrib import messages
 from django.http import HttpRequest
 from django.template.loader import get_template
 from django.templatetags.static import static
-from django.urls import reverse
+from django.urls import reverse, resolve
 from django.utils.crypto import get_random_string
 from django.utils.safestring import mark_safe
 from django.utils.timezone import now
@@ -583,7 +583,13 @@ class PaypalMethod(BasePaymentProvider):
         on the 'confirm order' page.
         """
         template = get_template('pretixplugins/paypal2/checkout_payment_confirm.html')
-        ctx = {'request': request, 'event': self.event, 'settings': self.settings, 'method': self.method}
+        ctx = {
+            'request': request,
+            'url': resolve(request.path_info),
+            'event': self.event,
+            'settings': self.settings,
+            'method': self.method
+        }
         return template.render(ctx)
 
     def execute_payment(self, request: HttpRequest, payment: OrderPayment):

--- a/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_confirm.html
+++ b/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_confirm.html
@@ -1,29 +1,29 @@
 {% load i18n %}
 
-<p>
-    {% if method == "wallet" %}
-        {% if url.url_name == "event.order.pay.confirm" %}
-            <div class="text-center" aria-hidden="true">
-                <span class="fa fa-info-circle fa-4x text-primary"></span>
-            </div>
-            <h2 class="text-center">
-                {% trans "Almost done…" %}
-            </h2>
-            <h4 class="text-center">
-                {% trans 'Please click on the "Pay now" button below to confirm your payment.' %}
-            </h4>
-            <h4 class="text-center text-muted">
-                {% trans "We will then charge your PayPal account and finalize the order." %}
-            </h4>
-        {% else %}
-            {% blocktrans trimmed %}
-                The total amount listed above will be withdrawn from your PayPal account after the
-                confirmation of your purchase.
-            {% endblocktrans %}
-        {% endif %}
+{% if method == "wallet" %}
+    {% if url.url_name == "event.order.pay.confirm" %}
+        <div class="text-center" aria-hidden="true">
+            <span class="fa fa-info-circle fa-4x text-primary"></span>
+        </div>
+        <h2 class="text-center">
+            {% trans "Almost done …" %}
+        </h2>
+        <p class="h4 text-center">
+            {% trans 'Please click on the "Pay now" button below to confirm your payment.' %}
+        </p>
+        <p class="h4 text-center text-muted">
+            {% trans "We will then charge your PayPal account and finalize the order." %}
+        </p>
     {% else %}
+        {% blocktrans trimmed %}
+            The total amount listed above will be withdrawn from your PayPal account after the
+            confirmation of your purchase.
+        {% endblocktrans %}
+    {% endif %}
+{% else %}
+    <p>
         {% blocktrans trimmed %}
             After placing your order, you will be able to select your desired payment method, including PayPal.
         {% endblocktrans %}
-    {% endif %}
-</p>
+    </p>
+{% endif %}

--- a/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_confirm.html
+++ b/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_confirm.html
@@ -2,16 +2,24 @@
 
 <p>
     {% if method == "wallet" %}
-        {% blocktrans trimmed %}
-            The total amount listed above will be withdrawn from your PayPal account after the
-            confirmation of your purchase.
-        {% endblocktrans %}
         {% if url.url_name == "event.order.pay.confirm" %}
-            <div class='alert alert-info'>
-                {% blocktrans trimmed %}
-                    Please click on the "Pay now"-button below to confirm your payment and finalize your order.
-                {% endblocktrans %}
+            <div class="text-center" aria-hidden="true">
+                <span class="fa fa-info-circle fa-4x text-primary"></span>
             </div>
+            <h2 class="text-center">
+                {% trans "Almost done…" %}
+            </h2>
+            <h4 class="text-center">
+                {% trans 'Please click on the "Pay now" button below to confirm your payment.' %}
+            </h4>
+            <h4 class="text-center text-muted">
+                {% trans "We will then charge your PayPal account and finalize the order." %}
+            </h4>
+        {% else %}
+            {% blocktrans trimmed %}
+                The total amount listed above will be withdrawn from your PayPal account after the
+                confirmation of your purchase.
+            {% endblocktrans %}
         {% endif %}
     {% else %}
         {% blocktrans trimmed %}

--- a/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_confirm.html
+++ b/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_confirm.html
@@ -6,6 +6,13 @@
             The total amount listed above will be withdrawn from your PayPal account after the
             confirmation of your purchase.
         {% endblocktrans %}
+        {% if url.url_name == "event.order.pay.confirm" %}
+            <div class='alert alert-info'>
+                {% blocktrans trimmed %}
+                    Please click on the "Pay now"-button below to confirm your payment and finalize your order.
+                {% endblocktrans %}
+            </div>
+        {% endif %}
     {% else %}
         {% blocktrans trimmed %}
             After placing your order, you will be able to select your desired payment method, including PayPal.


### PR DESCRIPTION
When paying an **existing** order with PayPal, it is not obvious that you have to click one more time after you signed in with PayPal. This tries to make it more obvious

![2023-01-20T17:34:57+01:00](https://user-images.githubusercontent.com/64280/213753388-08fec34f-4640-4bf1-ac19-b4d839a1570b.png)
