### PR TITLE
Clean up localization or error messages in cart

### DIFF
--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -43,7 +43,9 @@ from django.db import DatabaseError, transaction
 from django.db.models import Count, Exists, IntegerField, OuterRef, Q, Value
 from django.dispatch import receiver
 from django.utils.timezone import make_aware, now
-from django.utils.translation import gettext as _, gettext_lazy, ngettext_lazy, pgettext_lazy
+from django.utils.translation import (
+    gettext as _, gettext_lazy, ngettext_lazy, pgettext_lazy,
+)
 from django_scopes import scopes_disabled
 
 from pretix.base.channels import get_all_sales_channels

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -74,10 +74,18 @@ from pretix.presale.signals import (
 
 
 class CartError(Exception):
-    def __init__(self, msg):
-        # force msg to string to make sure lazy-translation is done in current locale-context
-        # otherwise translation might happen in celery-context, which uses default-locale
-        super().__init__(str(msg))
+    def __init__(self, *args):
+        msg = args[0]
+        msgargs = args[1] if len(args) > 1 else None
+        self.args = args
+        if msgargs:
+            msg = _(msg) % msgargs
+        else:
+            # force msg to string to make sure lazy-translation is done in current locale-context
+            # otherwise translation might happen in celery-context, which uses default-locale
+            # also translate with _/gettext to keep it backwards compatible
+            msg = _(str(msg))
+        super().__init__(msg)
 
 
 error_messages = {

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -43,7 +43,7 @@ from django.db import DatabaseError, transaction
 from django.db.models import Count, Exists, IntegerField, OuterRef, Q, Value
 from django.dispatch import receiver
 from django.utils.timezone import make_aware, now
-from django.utils.translation import gettext as _, pgettext_lazy
+from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django_scopes import scopes_disabled
 
 from pretix.base.channels import get_all_sales_channels

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -60,9 +60,7 @@ from django_scopes import scopes_disabled
 from pretix.api.models import OAuthApplication
 from pretix.base.channels import get_all_sales_channels
 from pretix.base.email import get_email_context
-from pretix.base.i18n import (
-    get_language_without_region, language,
-)
+from pretix.base.i18n import get_language_without_region, language
 from pretix.base.models import (
     CartPosition, Device, Event, GiftCard, Item, ItemVariation, Membership,
     Order, OrderPayment, OrderPosition, Quota, Seat, SeatCategoryMapping, User,

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -134,7 +134,7 @@ error_messages = {
     ),
     'not_started': gettext_lazy('The booking period for this event has not yet started.'),
     'ended': gettext_lazy('The booking period has ended.'),
-    'voucher_min_usages': gettext_lazy(
+    'voucher_min_usages': ngettext_lazy(
         'The voucher code "%(voucher)s" can only be used if you select at least %(number)s matching products.',
         'The voucher code "%(voucher)s" can only be used if you select at least %(number)s matching products.',
         'number'

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -102,10 +102,18 @@ from pretix.helpers.periodic import minimum_interval
 
 
 class OrderError(Exception):
-    def __init__(self, msg):
-        # force msg to string to make sure lazy-translation is done in current locale-context
-        # otherwise translation might happen in celery-context, which uses default-locale
-        super().__init__(str(msg))
+    def __init__(self, *args):
+        msg = args[0]
+        msgargs = args[1] if len(args) > 1 else None
+        self.args = args
+        if msgargs:
+            msg = _(msg) % msgargs
+        else:
+            # force msg to string to make sure lazy-translation is done in current locale-context
+            # otherwise translation might happen in celery-context, which uses default-locale
+            # also translate with _/gettext to keep it backwards compatible
+            msg = _(str(msg))
+        super().__init__(msg)
 
 
 error_messages = {

--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -525,7 +525,7 @@ class CartAdd(EventViewMixin, CartActionMixin, AsyncAction, View):
                 return JsonResponse({
                     'redirect': self.get_error_url(),
                     'success': False,
-                    'message': _(error_messages['empty'])
+                    'message': str(error_messages['empty'])
                 })
             else:
                 return redirect(self.get_error_url())
@@ -597,8 +597,6 @@ class RedeemView(NoSearchIndexViewMixin, EventViewMixin, CartMixin, TemplateView
         return context
 
     def dispatch(self, request, *args, **kwargs):
-        from pretix.base.services.cart import error_messages
-
         err = None
         v = request.GET.get('voucher')
 
@@ -652,7 +650,7 @@ class RedeemView(NoSearchIndexViewMixin, EventViewMixin, CartMixin, TemplateView
             pass
 
         if err:
-            messages.error(request, _(err))
+            messages.error(request, str(err))
             return redirect_to_url(self.get_next_url() + "?voucher_invalid")
 
         return super().dispatch(request, *args, **kwargs)

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -1389,22 +1389,16 @@ class OrderChange(EventViewMixin, OrderDetailMixin, TemplateView):
                     selected[i, None] = val, price
 
         if sum(a[0] for a in selected.values()) > category['max_count']:
-            # TODO: Proper pluralization
             raise ValidationError(
-                _(error_messages['addon_max_count']),
-                'addon_max_count',
-                {
+                error_messages['addon_max_count'] % {
                     'base': str(form['pos'].item.name),
                     'max': category['max_count'],
                     'cat': str(category['category'].name),
                 }
             )
         elif sum(a[0] for a in selected.values()) < category['min_count']:
-            # TODO: Proper pluralization
             raise ValidationError(
-                _(error_messages['addon_min_count']),
-                'addon_min_count',
-                {
+                error_messages['addon_min_count'] % {
                     'base': str(form['pos'].item.name),
                     'min': category['min_count'],
                     'cat': str(category['category'].name),
@@ -1412,9 +1406,7 @@ class OrderChange(EventViewMixin, OrderDetailMixin, TemplateView):
             )
         elif any(sum(v[0] for k, v in selected.items() if k[0] == i) > 1 for i in category['items']) and not category['multi_allowed']:
             raise ValidationError(
-                _(error_messages['addon_no_multi']),
-                'addon_no_multi',
-                {
+                error_messages['addon_no_multi'] % {
                     'base': str(form['pos'].item.name),
                     'cat': str(category['category'].name),
                 }

--- a/src/tests/presale/test_cart.py
+++ b/src/tests/presale/test_cart.py
@@ -1529,7 +1529,7 @@ class CartTest(CartTestMixin, TestCase):
         response = self.client.get('/%s/%s/redeem' % (self.orga.slug, self.event.slug),
                                    {'voucher': v.code},
                                    follow=True)
-        assert error_messages['voucher_item_not_available'] in response.rendered_content
+        assert str(error_messages['voucher_item_not_available']) in response.rendered_content
 
     def test_voucher_price(self):
         with scopes_disabled():


### PR DESCRIPTION
Currently cart.py uses gettext to localize its error-messages on process-startup. This is not a problem as long as english is the default locale on startup as during code execution the error-messages get run through `gettext` again. If default locale is not english, this then creates static error messages in that locale for every language. This PR fixes #2519 

This PR actually fixes two things:

1. All pre-defined error messages in `services/cart.py` and `services/order.py` were translated during startup time, which is only a problem if you happen to have a default-locale other than `en` in your pretix.cfg. This PR now changes all pre-defined error message to use the lazy-versions of gettext.
2. These lazy-versions then introduce a different problem, when using pretix with celery (the usual dev-setup does not include celery, so not easy to catch at first): the lazy_string are handed to celery as is and then in celery are converted to proper strings, which causes the translation process to use the current language in celery (usually the default-locale) which very well might differ from the event’s locale. This does not happen on all error messages though as some error messages are converted to string before they are handed to celery by applying string-formatting – to be more precise, they are converted before they are even handed to `CartError`/`OrderError`. To make sure all error messages are converted to strings in the currently needed locale, `CartError` and `OrderError` force convert the `msg` to `str()`.

And last, but not least, this PR adds proper i18n pluralization to the error messages. :)