### PR TITLE
Changing orders: Default to not notifying the user

### DIFF
--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -270,7 +270,7 @@ class OtherOperationsForm(forms.Form):
     notify = forms.BooleanField(
         label=_('Notify user'),
         required=False,
-        initial=True,
+        initial=False,
         help_text=_(
             'Send an email to the customer notifying that their order has been changed.'
         )


### PR DESCRIPTION
A customer requested this and it's kinda a breaking change, but I'm inclined to agree it's a good change. It's so easy to accidentally keep this box checked if you really don't want to notify your customer.