### PR TITLE
Shop header: Fix logo link outline to contain image (Z#23115320)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -66,7 +66,7 @@
     </div>
 {% endblock %}
 {% block page %}
-    <div class="page-header {% if event_logo and event_logo_image_large %}logo-large{% endif %}">
+    <div class="page-header{% if event_logo %} pager-header-with-logo{% endif %}{% if event_logo and event_logo_image_large %} logo-large{% endif %}">
         <div class="{% if not event_logo or not event_logo_image_large %}pull-left flip{% endif %}">
             {% if event_logo and event_logo_image_large %}
                 <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}"

--- a/src/pretix/presale/templates/pretixpresale/organizers/base.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/base.html
@@ -37,7 +37,7 @@
     {% endif %}
 {% endblock %}
 {% block page %}
-    <div class="page-header {% if organizer_logo and organizer.settings.organizer_logo_image_large %}logo-large{% endif %}">
+    <div class="page-header{% if organizer_logo %} pager-header-with-logo{% endif %}{% if organizer_logo and organizer.settings.organizer_logo_image_large %} logo-large{% endif %}">
         <div class="{% if not organizer_logo or not organizer.settings.organizer_logo_image_large %}pull-left flip{% endif %}">
             {% if organizer_logo and organizer.settings.organizer_logo_image_large %}
                 <a href="{% eventurl organizer "presale:organizer.index" %}" title="{{ organizer.name }}">

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -5,9 +5,6 @@
   padding-bottom: 9px;
   margin-top: 20px;
 
-  a {
-    display: inline-block;
-  }
   h1 {
     margin: 0;
   }
@@ -21,6 +18,9 @@
     max-width: 100%;
     height: auto;
   }
+}
+.pager-header-with-logo a {
+  display: inline-block;
 }
 
 .main-box {

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -5,6 +5,9 @@
   padding-bottom: 9px;
   margin-top: 20px;
 
+  a {
+    display: inline-block;
+  }
   h1 {
     margin: 0;
   }


### PR DESCRIPTION
Currently when navigating with tab or after a click on the logo-link, the focus-outline is just one line-height high due to being `display: inline`. THis PR fixes the outline to contain the logo image but at the same time keeping text-only logo/page-header to stay on the same line by using `display: inline-block` instead of `display: block`, which would cause the text-only logo to break the line before displaying the date.

There is one edge-case where the layout then differs from the current behaviour: when there is not header-image, but the event’s title is used and the title is veeeeery long and has a line break in itself, then the following date will be on a new line.

Old behaviour:

![Bildschirm­foto 2023-01-25 um 15 19 20](https://user-images.githubusercontent.com/276509/214587670-edebc814-ac06-4daa-9b55-ed48cd5b316f.png)

New behaviour:
![Bildschirm­foto 2023-01-25 um 15 19 05](https://user-images.githubusercontent.com/276509/214587713-4e8ac056-fab0-4b02-965b-e5eb9f7e2d81.png)

On „normal“ length event titles it looks the same as before.
![Bildschirm­foto 2023-01-25 um 15 20 40](https://user-images.githubusercontent.com/276509/214587876-68fc2adf-00ef-48e2-9bd5-16f8f05e9fca.png)


Another approach might be to use the „new“ `:has` selector to only target `.page-header a:has(img)`. That way we always have the same look as before, but older browser (is in current Firefox!?) with no support for `:has` will still show the focus-outline too small. Not sure what is the best tradeoff here.