### PR TITLE
Fix #1251 -- Event list/calendar: Show "event almost sold out" state

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -36,7 +36,7 @@ import logging
 import os
 import string
 import uuid
-from collections import OrderedDict, Counter, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 from datetime import datetime, time, timedelta
 from operator import attrgetter
 from urllib.parse import urljoin

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -350,10 +350,10 @@ class EventMixin:
         Returns ``True`` if the availability of tickets in this event is lower than the percentage
         given in setting ``low_availability_percentage``.
         """
+        if not self.settings.low_availability_percentage:
+            return False
         ba = self.best_availability
         if ba[1] is None or not ba[2]:
-            return False
-        if not self.settings.low_availability_percentage:
             return False
 
         percentage = ba[1] / ba[2]

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -356,7 +356,7 @@ class EventMixin:
         if ba[1] is None or not ba[2]:
             return False
 
-        percentage = ba[1] / ba[2]
+        percentage = ba[1] / ba[2] * 100
         return percentage < self.settings.low_availability_percentage
 
     @cached_property

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1308,6 +1308,24 @@ DEFAULTS = {
                         "the email. Does not affect orders performed through other sales channels."),
         )
     },
+    'low_availability_percentage': {
+        'default': None,
+        'type': int,
+        'serializer_class': serializers.IntegerField,
+        'form_class': forms.IntegerField,
+        'serializer_kwargs': dict(
+            min_value=0,
+            max_value=100,
+        ),
+        'form_kwargs': dict(
+            label=_('Low availability threshold'),
+            help_text=_('If the availability of tickets falls below this percentage, the event (or a date, if it is an '
+                        'event series) will be highlighted to have low availability in the event list.'),
+            min_value=0,
+            max_value=100,
+            required=False
+        )
+    },
     'event_list_availability': {
         'default': 'True',
         'type': bool,

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1320,7 +1320,8 @@ DEFAULTS = {
         'form_kwargs': dict(
             label=_('Low availability threshold'),
             help_text=_('If the availability of tickets falls below this percentage, the event (or a date, if it is an '
-                        'event series) will be highlighted to have low availability in the event list.'),
+                        'event series) will be highlighted to have low availability in the event list or calendar. If '
+                        'you keep this option empty, low availability will not be shown publicly.'),
             min_value=0,
             max_value=100,
             required=False

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -507,6 +507,7 @@ class EventSettingsForm(SettingsForm):
         'meta_noindex',
         'redirect_to_checkout_directly',
         'frontpage_subevent_ordering',
+        'low_availability_percentage',
         'event_list_type',
         'event_list_available_only',
         'frontpage_text',

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -314,7 +314,8 @@
                 {% if sform.event_list_available_only %}
                     {% bootstrap_field sform.event_list_available_only layout="control" %}
                 {% endif %}
-                
+                {% bootstrap_field sform.low_availability_percentage layout="control" %}
+
                 {% url "control:organizer.edit" organizer=request.organizer.slug as org_url %}
                 {% propagated request.event org_url "meta_noindex" %}
                     {% bootstrap_field sform.meta_noindex layout="control" %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
@@ -21,7 +21,11 @@
             <div class="col-md-2 text-right flip">
                 {% if subev.presale_is_running and event.settings.event_list_availability %}
                     {% if subev.best_availability_state == 100 %}
-                        <span class="label label-success">{% trans "Book now" %}</span>
+                        {% if subev.best_availability_is_low %}
+                            <span class="label label-success">{% trans "Few tickets left" %}</span>
+                        {% else %}
+                            <span class="label label-success">{% trans "Book now" %}</span>
+                        {% endif %}
                     {% elif event.settings.waiting_list_enabled and subev.best_availability_state >= 0 %}
                         <span class="label label-warning">{% trans "Waiting list" %}</span>
                     {% elif subev.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
@@ -22,14 +22,14 @@
                 {% if subev.presale_is_running and event.settings.event_list_availability %}
                     {% if subev.best_availability_state == 100 %}
                         {% if subev.best_availability_is_low %}
-                            <span class="label label-success">{% trans "Few tickets left" %}</span>
+                            <span class="label label-success-warning">{% trans "Few tickets left" %}</span>
                         {% else %}
                             <span class="label label-success">{% trans "Book now" %}</span>
                         {% endif %}
                     {% elif event.settings.waiting_list_enabled and subev.best_availability_state >= 0 %}
                         <span class="label label-warning">{% trans "Waiting list" %}</span>
                     {% elif subev.best_availability_state == 20 %}
-                        <span class="label label-warning">{% trans "Reserved" %}</span>
+                        <span class="label label-danger">{% trans "Reserved" %}</span>
                     {% elif subev.best_availability_state < 20 %}
                         {% if subev.has_paid_item %}
                             <span class="label label-danger">{% trans "Sold out" %}</span>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -27,7 +27,7 @@
                                     <li><a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
     {% if event.event.presale_is_running and show_avail %}
         {% if event.event.best_availability_state == 100 %}
-            available
+            available {% if event.event.best_availability_is_low %} low {% endif %}
         {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
             waitinglist
         {% elif event.event.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -68,7 +68,11 @@
                                             <span class="event-status">
                                                 {% if event.event.presale_is_running and show_avail %}
                                                     {% if event.event.best_availability_state == 100 %}
-                                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                                        {% if event.event.best_availability_is_low %}
+                                                            <span class="fa fa-exclamation-circle" aria-hidden="true"></span> {% trans "Few tickets left" %}
+                                                        {% else %}
+                                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                                        {% endif %}
                                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                                     {% elif event.event.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
@@ -89,12 +89,16 @@
                         <span class="event-status">
                             {% if event.event.presale_is_running and show_avail %}
                                 {% if event.event.best_availability_state == 100 %}
-                                    <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
-                                    {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
+                                    {% if event.event.best_availability_is_low %}
+                                        <span class="fa fa-exclamation-circle" aria-hidden="true"></span> {% trans "Few tickets left" %}
+                                    {% else %}
+                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                    {% endif %}
+                                {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                     <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
-                                    {% elif event.event.best_availability_state == 20 %}
+                                {% elif event.event.best_availability_state == 20 %}
                                     <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Reserved" %}
-                                    {% elif event.event.best_availability_state < 20 %}
+                                {% elif event.event.best_availability_state < 20 %}
                                     {% if event.event.has_paid_item %}
                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sold out" %}
                                     {% else %}
@@ -104,9 +108,9 @@
                                 {% endif %}
                             {% elif event.event.presale_is_running %}
                                 <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
-                                {% elif event.event.presale_has_ended %}
+                            {% elif event.event.presale_has_ended %}
                                 <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Sale over" %}
-                                {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}
+                            {% elif event.event.settings.presale_start_show_date and event.event.presale_start %}
                                 <span class="fa fa-ticket" aria-hidden="true"></span>
                                 {% blocktrans with start_date=event.event.presale_start|date:"SHORT_DATE_FORMAT" %}
                                     from {{ start_date }}

--- a/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
@@ -40,7 +40,7 @@
                 <a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
     {% if event.event.presale_is_running and show_avail %}
         {% if event.event.best_availability_state == 100 %}
-            available
+            available {% if event.event.best_availability_is_low %} low {% endif %}
         {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
             waitinglist
         {% elif event.event.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -53,7 +53,11 @@
                             <span class="event-status">
                                 {% if event.event.presale_is_running and show_avail %}
                                     {% if event.event.best_availability_state == 100 %}
-                                        <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                        {% if event.event.best_availability_is_low %}
+                                            <span class="fa fa-exclamation-circle" aria-hidden="true"></span> {% trans "Few tickets left" %}
+                                        {% else %}
+                                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Book now" %}
+                                        {% endif %}
                                     {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
                                         <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Waiting list" %}
                                     {% elif event.event.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -12,7 +12,7 @@
                     <li><a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
     {% if event.event.presale_is_running and show_avail %}
         {% if event.event.best_availability_state == 100 %}
-            available
+            available {% if event.event.best_availability_is_low %} low {% endif %}
         {% elif event.event.settings.waiting_list_enabled and event.event.best_availability_state >= 0 %}
             waitinglist
         {% elif event.event.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -81,7 +81,11 @@
                         <span class="label label-default">{% trans "Event series" %}</span>
                     {% elif e.presale_is_running and request.organizer.settings.event_list_availability %}
                         {% if e.best_availability_state == 100 %}
-                            <span class="label label-success">{% trans "Book now" %}</span>
+                            {% if e.best_availability_is_low %}
+                                <span class="label label-success">{% trans "Few tickets left" %}</span>
+                            {% else %}
+                                <span class="label label-success">{% trans "Book now" %}</span>
+                            {% endif %}
                         {% elif e.settings.waiting_list_enabled and e.best_availability_state >= 0 %}
                             <span class="label label-warning">{% trans "Waiting list" %}</span>
                         {% elif e.best_availability_state == 20 %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -82,14 +82,14 @@
                     {% elif e.presale_is_running and request.organizer.settings.event_list_availability %}
                         {% if e.best_availability_state == 100 %}
                             {% if e.best_availability_is_low %}
-                                <span class="label label-success">{% trans "Few tickets left" %}</span>
+                                <span class="label label-success-warning">{% trans "Few tickets left" %}</span>
                             {% else %}
                                 <span class="label label-success">{% trans "Book now" %}</span>
                             {% endif %}
                         {% elif e.settings.waiting_list_enabled and e.best_availability_state >= 0 %}
                             <span class="label label-warning">{% trans "Waiting list" %}</span>
                         {% elif e.best_availability_state == 20 %}
-                            <span class="label label-warning">{% trans "Reserved" %}</span>
+                            <span class="label label-danger">{% trans "Reserved" %}</span>
                         {% elif e.best_availability_state < 20 %}
                             {% if e.has_paid_item %}
                                 <span class="label label-danger">{% trans "Sold out" %}</span>

--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -371,7 +371,7 @@ class WidgetAPIProductList(EventListMixin, View):
                 if ev.best_availability_is_low:
                     availability['color'] = 'green'
                     availability['text'] = gettext('Few tickets left')
-                    availability['reason'] = 'ok'
+                    availability['reason'] = 'low'
                 else:
                     availability['color'] = 'green'
                     availability['text'] = gettext('Book now')
@@ -381,7 +381,7 @@ class WidgetAPIProductList(EventListMixin, View):
                 availability['text'] = gettext('Waiting list')
                 availability['reason'] = 'waitinglist'
             elif ev.best_availability_state == Quota.AVAILABILITY_RESERVED:
-                availability['color'] = 'orange'
+                availability['color'] = 'red'
                 availability['text'] = gettext('Reserved')
                 availability['reason'] = 'reserved'
             elif ev.best_availability_state is not None and ev.best_availability_state < Quota.AVAILABILITY_RESERVED:

--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -368,9 +368,14 @@ class WidgetAPIProductList(EventListMixin, View):
         availability = {}
         if ev.presale_is_running and event.settings.event_list_availability:
             if ev.best_availability_state == Quota.AVAILABILITY_OK:
-                availability['color'] = 'green'
-                availability['text'] = gettext('Book now')
-                availability['reason'] = 'ok'
+                if ev.best_availability_is_low:
+                    availability['color'] = 'green'
+                    availability['text'] = gettext('Few tickets left')
+                    availability['reason'] = 'ok'
+                else:
+                    availability['color'] = 'green'
+                    availability['text'] = gettext('Book now')
+                    availability['reason'] = 'ok'
             elif event.settings.waiting_list_enabled and (ev.best_availability_state is not None and ev.best_availability_state >= 0):
                 availability['color'] = 'orange'
                 availability['text'] = gettext('Waiting list')

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -79,14 +79,15 @@
     }
 
     &.waitinglist {
-      background: lighten($brand-warning, 43%);
+      background: lighten($brand-warning, 41%);
       border-color: lighten($brand-warning, 30%);
-      border-left-color: lighten($brand-warning, 30%);
-      color: darken($brand-warning, 5%);
+      border-left-color: lighten($brand-warning, 12%);
+      color: #963;
 
       &:hover {
-        background: lighten($brand-warning, 45%);
-        border-color: lighten($brand-warning, 25%);
+        background: lighten($brand-warning, 43%);
+        border-color: $brand-warning;
+      }
       }
     }
 

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -58,7 +58,7 @@
       }
     }
 
-    &.available, {
+    &.available {
       background: lighten($brand-success, 48%);
       border-color: lighten($brand-success, 30%);
       border-left-color: $brand-success;
@@ -87,7 +87,6 @@
       &:hover {
         background: lighten($brand-warning, 43%);
         border-color: $brand-warning;
-      }
       }
     }
 

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -64,9 +64,29 @@
       border-left-color: $brand-success;
       color: darken($brand-success, 12%);
 
+      &.low {
+        border-left-color: $brand-warning;
+      }
+
       &:hover {
         background: lighten($brand-success, 50%);
         border-color: $brand-success;
+
+        &.low {
+          border-left-color: $brand-warning;
+        }
+      }
+    }
+
+    &.waitinglist {
+      background: lighten($brand-warning, 43%);
+      border-color: lighten($brand-warning, 30%);
+      border-left-color: lighten($brand-warning, 30%);
+      color: darken($brand-warning, 5%);
+
+      &:hover {
+        background: lighten($brand-warning, 45%);
+        border-color: lighten($brand-warning, 25%);
       }
     }
 
@@ -81,7 +101,6 @@
         border-color: lighten($brand-danger, 25%);
       }
     }
-
 
     &.available > *:first-child,
     &.continued > *:first-child,

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -65,7 +65,7 @@
       color: darken($brand-success, 12%);
 
       &.low {
-        border-left-color: $brand-warning;
+        border-left-color: lighten($brand-warning, 12%);
       }
 
       &:hover {

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -133,7 +133,7 @@ footer {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     color: white;
-    content: $fa-var-exclamation-circle;
+    content: $fa-var-exclamation;
     background: $label-warning-bg;
 
     display: block;

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -129,6 +129,9 @@ footer {
   position: relative;
   &::before {
     font-family: FontAwesome;
+    text-rendering: auto;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
     color: white;
     content: $fa-var-exclamation-circle;
     background: $label-warning-bg;

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -121,3 +121,30 @@ footer {
     padding-bottom: 0;
   }
 }
+
+.label-success-warning {
+  @include label-variant($label-success-bg);
+
+  padding-left: 2.5em;
+  position: relative;
+  &::before {
+    font-family: FontAwesome;
+    color: white;
+    content: $fa-var-exclamation-circle;
+    background: $label-warning-bg;
+
+    display: block;
+
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 2em;
+
+    padding-top: .5em;
+    text-align: center;
+
+    border-top-left-radius: .25em;
+    border-bottom-left-radius: .25em;
+  }
+}

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -495,6 +495,12 @@
   .pretix-widget-event-availability-red.pretix-widget-event-calendar-event {
     background-color: $brand-danger;
   }
+  .pretix-widget-event-availability-low .pretix-widget-event-list-entry-availability span {
+    border-left: 10px solid $brand-warning;
+  }
+  .pretix-widget-event-availability-low.pretix-widget-event-calendar-event {
+    border-right: 10px solid $brand-warning;
+  }
 
   .pretix-widget-event-calendar {
     padding-top: 10px;


### PR DESCRIPTION
This introduces a new setting as well as a new state in the event list and calendar. If set the new setting to "20", the event calendar will now mark all tickets with less than 20% available spots as "Few tickets left".

![2023-01-26-234606_1381x459_scrot](https://user-images.githubusercontent.com/64280/214967831-64043104-a54f-43f6-802a-2fd3f355b23e.png)

This is a little complex to implement as we need to deal with all possible combinations of overlapping quotas, etc.
The `best_availability_state` function is entirely rewritten for this purpose. In the end, performance should be approximately the same as before.

Design-wise, I think there are two main open questions:

- Should this new state be green or yellow? I kept it green for now since we use yellow for "waiting list", "reserved", and "not yet for sale" currently. So yellow currently means "not able to book", and making this new state yellow could be confusing. On the other hand, making the new state yellow will make it more visible, and is also consistent with the traffic light analogy used on many other sites.
- If the setting is enabled, should we also show something on the event detail page? Should it be a "low on tickets" above the list of events, or should we show a similar yellow indicator for every low-inventory item? That would be more useful but also "leak" more info.
- Is the wording good like this? We tend to avoid "ticket" in this place, but in this case I think it makes sense (since the feature can be disabled) and I did not want something longer.

We should also add more edge cases with weird quotas to the tests, I guess.