### PR TITLE
Add webhooks for changes to items

### DIFF
--- a/doc/api/resources/webhooks.rst
+++ b/doc/api/resources/webhooks.rst
@@ -56,6 +56,7 @@ The following values for ``action_types`` are valid with pretix core:
     * ``pretix.subevent.added``
     * ``pretix.subevent.changed``
     * ``pretix.subevent.deleted``
+    * ``pretix.event.item.*``
     * ``pretix.event.live.activated``
     * ``pretix.event.live.deactivated``
     * ``pretix.event.testmode.activated``

--- a/src/pretix/control/templates/pretixcontrol/organizers/webhook_logs.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/webhook_logs.html
@@ -90,7 +90,7 @@
             </div>
         </details>
     {% empty %}
-        <div class="alert-info">{% trans "This webhook did not receive any events in the last 30 days." %}</div>
+        <div class="alert alert-info">{% trans "This webhook did not receive any events in the last 30 days." %}</div>
     {% endfor %}
     {% include "pretixcontrol/pagination.html" %}
 {% endblock %}


### PR DESCRIPTION
I decided for one grouped webhook category instead of 12 single ones since we might add more of them at any time and users still likely would want to receive the hooks in that case.