### PR TITLE
Use local name in control variation list heading

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/variations.js
+++ b/src/pretix/static/pretixcontrol/js/ui/variations.js
@@ -6,7 +6,18 @@ $(function () {
     }
 
     function update_variation_summary($el) {
-        var var_name = $el.find("input[name*=-value_]").filter(function () {return !!this.value}).first().val();
+        var var_names = Object.fromEntries(
+          $el
+            .find("input[name*=-value_]")
+            .filter(function () {
+              return !!this.value;
+            })
+            .map(function () {
+              return [[this.getAttribute("lang"), this.value]];
+            })
+            .get()
+        );
+        var var_name = i18nToString(var_names);
         var price = $el.find("input[name*=-default_price]").val();
         if (price) {
             var currency = $el.find("[name*=-default_price] + .input-group-addon").text();


### PR DESCRIPTION
Currently the first translation of the variation is shown as the variation name in the variation list. This commits changes this to prefer the variation name in the language that the control interface is set to.