### PR TITLE
Event index: Increase white-space for products and headlines

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -16,7 +16,7 @@
             <span role="columnheader" aria-sort="none">{% trans "Price total" %}</span>
         </div>
     </div>
-    <div role="rowgroup">
+    <div role="rowgroup" class="firstchild-in-panel">
     {% for line in cart.positions %}
         <div role="row" class="row cart-row {% if download %}has-downloads{% endif %}{% if editable %}editable{% endif %}">
             <div role="cell" class="product">

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -1,6 +1,6 @@
 .cart-row {
     /* Cart grid */
-    padding: 10px 0;
+    padding: 0.75*$line-height-computed 0;
 
     .product>*:last-child {
         margin-bottom: 0;

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -100,6 +100,9 @@
     }
 }
 
+.cart .firstchild-in-panel .cart-row:first-child {
+    padding-top: 0;
+}
 .cart [role=rowgroup]:last-child {
     border-top: 1px solid $table-border-color;
 }

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -146,7 +146,7 @@ article.item-with-variations .product-row:last-child:after {
 }
 
 .product-row {
-    padding: 10px 0;
+    padding: 0.75*$line-height-computed 0;
 
     .count form {
         display: inline;

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -96,9 +96,9 @@
     }
 
     &.headline, &.simple {
-        border-top: 2px solid transparent;
+        border-top: 1px solid transparent;
         &::before {
-            border-top: 2px solid $table-border-color;
+            border-top: 1px solid $table-border-color;
         }
     }
 }
@@ -110,14 +110,14 @@ article.item-with-variations {
 
 article.item-with-variations:last-child, .product-row:last-child {
     position: relative;
-    border-bottom: 2px solid transparent;
+    border-bottom: 1px solid transparent;
     &::after {
         position: absolute;
         bottom: 0;
         left: 15px;
         width: calc(100% - 30px);
         content: '';
-        border-bottom: 2px solid $table-border-color;
+        border-bottom: 1px solid $table-border-color;
     }
 }
 article.item-with-variations .product-row:last-child:after {

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -1,5 +1,12 @@
 @import "../../pretixbase/scss/_contrast.scss";
 
+h1, .h1,
+h2, .h2,
+h3, .h3 {
+  margin-top: 2.25 * $line-height-computed;
+  margin-bottom: 0.75 * $line-height-computed;
+}
+
 .page-header {
   position: relative;
   padding-bottom: 9px;

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -351,8 +351,8 @@ body.loading .container {
 
 .panel-title a[data-toggle="collapse"], details .panel-title {
     display: flex;
-    padding: 10px 15px;
-    margin: -10px -15px;
+    padding: 0.75*$line-height-computed;
+    margin: -0.75*$line-height-computed;
     align-items: center;
     justify-content: space-between;
     outline: 0;


### PR DESCRIPTION
This PR tries to improve the visual appearance by increasing the white-space around products and headlines. It furthermore harmonizes line-width between products to 1px as used in other places for lines. Furthermore it fixes a minor padding-top issue with cart where the first item of the cart is too far away from the top/panel-title.