### PR TITLE
Docs: Add comment to webhook API

### DIFF
--- a/doc/api/resources/webhooks.rst
+++ b/doc/api/resources/webhooks.rst
@@ -101,7 +101,7 @@ Endpoints
             "all_events": false,
             "limit_events": ["democon"],
             "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-            "comment": null,
+            "comment": null
           }
         ]
       }
@@ -139,7 +139,7 @@ Endpoints
         "all_events": false,
         "limit_events": ["democon"],
         "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-        "comment": null,
+        "comment": null
       }
 
    :param organizer: The ``slug`` field of the organizer to fetch
@@ -167,7 +167,7 @@ Endpoints
         "all_events": false,
         "limit_events": ["democon"],
         "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-        "comment": null,
+        "comment": null
       }
 
    **Example response**:
@@ -185,7 +185,7 @@ Endpoints
         "all_events": false,
         "limit_events": ["democon"],
         "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-        "comment": null,
+        "comment": null
       }
 
    :param organizer: The ``slug`` field of the organizer to create a webhook for
@@ -231,7 +231,7 @@ Endpoints
         "all_events": false,
         "limit_events": ["democon"],
         "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-        "comment": null,
+        "comment": null
       }
 
    :param organizer: The ``slug`` field of the organizer to modify

--- a/doc/api/resources/webhooks.rst
+++ b/doc/api/resources/webhooks.rst
@@ -167,7 +167,7 @@ Endpoints
         "all_events": false,
         "limit_events": ["democon"],
         "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-        "comment": null
+        "comment": "Called for changes"
       }
 
    **Example response**:
@@ -185,7 +185,7 @@ Endpoints
         "all_events": false,
         "limit_events": ["democon"],
         "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
-        "comment": null
+        "comment": "Called for changes"
       }
 
    :param organizer: The ``slug`` field of the organizer to create a webhook for

--- a/doc/api/resources/webhooks.rst
+++ b/doc/api/resources/webhooks.rst
@@ -26,6 +26,7 @@ limit_events                          list of strings            If ``all_events
 action_types                          list of strings            A list of action type filters that limit the
                                                                  notifications sent to this webhook. See below for
                                                                  valid values
+comment                               string                     Internal comment on this webhook, default ``null``
 ===================================== ========================== =======================================================
 
 The following values for ``action_types`` are valid with pretix core:
@@ -99,7 +100,8 @@ Endpoints
             "target_url": "https://httpstat.us/200",
             "all_events": false,
             "limit_events": ["democon"],
-            "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"]
+            "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
+            "comment": null,
           }
         ]
       }
@@ -136,7 +138,8 @@ Endpoints
         "target_url": "https://httpstat.us/200",
         "all_events": false,
         "limit_events": ["democon"],
-        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"]
+        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
+        "comment": null,
       }
 
    :param organizer: The ``slug`` field of the organizer to fetch
@@ -163,7 +166,8 @@ Endpoints
         "target_url": "https://httpstat.us/200",
         "all_events": false,
         "limit_events": ["democon"],
-        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"]
+        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
+        "comment": null,
       }
 
    **Example response**:
@@ -180,7 +184,8 @@ Endpoints
         "target_url": "https://httpstat.us/200",
         "all_events": false,
         "limit_events": ["democon"],
-        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"]
+        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
+        "comment": null,
       }
 
    :param organizer: The ``slug`` field of the organizer to create a webhook for
@@ -225,7 +230,8 @@ Endpoints
         "target_url": "https://httpstat.us/200",
         "all_events": false,
         "limit_events": ["democon"],
-        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"]
+        "action_types": ["pretix.event.order.modified", "pretix.event.order.changed.*"],
+        "comment": null,
       }
 
    :param organizer: The ``slug`` field of the organizer to modify


### PR DESCRIPTION
Extend the API documentation with info and examples for the new webhooks comment field