### PR TITLE
Widget: fix close-icon position

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -723,6 +723,7 @@
     text-decoration: none;
     padding: 4px 0;
     display: block;
+    line-height: 16px;
   }
 
   .pretix-widget-frame-inner iframe {


### PR DESCRIPTION
This PR fixes the position of the widget-close-icon (X) being offset when fontsize or lineheight in the embedding webpage is differing from the browser default. This PR uses a fixed line-height of 16px instead of 1em as the SVG-icon is 16px fixed height. Closes #2531 