### PR TITLE
Disable email rules if event is not live

### DIFF
--- a/src/pretix/plugins/sendmail/signals.py
+++ b/src/pretix/plugins/sendmail/signals.py
@@ -161,12 +161,14 @@ def sendmail_run_rules(sender, **kwargs):
         mails.filter(
             state=ScheduledMail.STATE_SCHEDULED,
             computed_datetime__lte=timezone.now() - datetime.timedelta(days=2),
+            event__live=True,
         ).update(
             state=ScheduledMail.STATE_MISSED
         )
         for m_id in mails.filter(
             state__in=(ScheduledMail.STATE_SCHEDULED, ScheduledMail.STATE_FAILED),
             rule__enabled=True,
+            event__live=True,
             computed_datetime__gte=timezone.now() - datetime.timedelta(days=2),
             computed_datetime__lte=timezone.now(),
         ).values_list('pk', flat=True):

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html
@@ -4,6 +4,11 @@
 {% block title %}{% trans "Create Email Rule" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Create Email Rule" %}</h1>
+    {% if not request.event.live %}
+        <div class="alert alert-warning">
+            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+        </div>
+    {% endif %}
     {% block inner %}
         <form class="form-horizontal" method="post" action="" enctype="multipart/form-data">
             {% csrf_token %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html
@@ -9,6 +9,11 @@
             This page shows when your rule is planned to be sent.
         {% endblocktrans %}
     </p>
+    {% if not request.event.live %}
+        <div class="alert alert-warning">
+            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+        </div>
+    {% endif %}
     <dl class="dl-horizontal">
         <dt>{% trans "Email subject" %}</dt>
         <dd>{{ rule.subject }}</dd>

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html
@@ -10,6 +10,11 @@
             your event.
         {% endblocktrans %}
     </p>
+    {% if not request.event.live %}
+        <div class="alert alert-warning">
+            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+        </div>
+    {% endif %}
 
     {% if rules %}
         <p>

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html
@@ -5,6 +5,11 @@
 {% block title %}{% trans "Update Email Rule" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Update Email Rule" %}</h1>
+    {% if not request.event.live %}
+        <div class="alert alert-warning">
+            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+        </div>
+    {% endif %}
     {% block inner %}
         <form class="form-horizontal" method="post" action="" enctype="multipart/form-data">
             {% csrf_token %}

--- a/src/tests/plugins/sendmail/conftest.py
+++ b/src/tests/plugins/sendmail/conftest.py
@@ -33,7 +33,7 @@ def event():
     o = Organizer.objects.create(name='Dummy', slug='dummy')
     event = Event.objects.create(
         organizer=o, name='Dummy', slug='dummy',
-        date_from=now(),
+        date_from=now(), live=True,
         plugins='pretix.plugins.sendmail,tests.testdummy',
     )
     return event

--- a/src/tests/plugins/sendmail/test_rules.py
+++ b/src/tests/plugins/sendmail/test_rules.py
@@ -370,6 +370,20 @@ def test_sendmail_rule_only_send_once(event, order):
 
 @pytest.mark.django_db
 @scopes_disabled()
+def test_sendmail_rule_only_live(event, order):
+    djmail.outbox = []
+    event.live = False
+    event.save()
+
+    event.sendmail_rules.create(send_date=dt_now - datetime.timedelta(hours=1), include_pending=True,
+                                subject='meow', template='meow meow meow')
+
+    sendmail_run_rules(None)
+    assert len(djmail.outbox) == 0
+
+
+@pytest.mark.django_db
+@scopes_disabled()
 def test_sendmail_rule_disabled(event, order):
     djmail.outbox = []
     event.sendmail_rules.create(send_date=dt_now - datetime.timedelta(hours=1), include_pending=True,


### PR DESCRIPTION
This is a breaking change, but I think it's worth it. It mainly prevents rules to execute immediately after cloning an event, which is a common pain point.