### PR TITLE
Add system question order to device event settings api endpoint

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -863,6 +863,7 @@ class DeviceEventSettingsSerializer(EventSettingsSerializer):
         'invoice_address_from_tax_id',
         'invoice_address_from_vat_id',
         'name_scheme',
+        'system_question_order',
     ]
 
     def __init__(self, *args, **kwargs):

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -212,6 +212,8 @@ DEFAULTS = {
     'system_question_order': {
         'default': {},
         'type': dict,
+        'serializer_class': serializers.DictField,
+        'serializer_kwargs': lambda: dict(read_only=True, allow_empty=True),
     },
     'attendee_names_asked': {
         'default': 'True',


### PR DESCRIPTION
With this PR, pretixPOS and others that ask the customer for answers to questions can now get the order of the system questions too. This allows correct sorting of them, like configured and displayed on `/control/event/<organizer>/<event>/questions/`

Fixes Z#23118233