### PR TITLE
Widget: fix default-open variations being hidden (Z#23118652)

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -482,33 +482,27 @@ Vue.component('item', {
             expanded: this.$root.show_variations_expanded
         };
     },
-    watch: {
-        expanded: function (newValue) {
-            var v = this.$refs.variations;
-            if (newValue) {
-                v.hidden = false;
-            } else {
-                // Vue.nextTick does not work here
-                window.setTimeout(function () {
-                    v.style.maxHeight = 0;
-                }, 50);
-            }
-            v.style.maxHeight = v.scrollHeight + 'px';
-        }
-    },
     mounted: function () {
         if (this.$refs.variations) {
-            this.$refs.variations.hidden = !this.expanded;
             if (!this.expanded) {
-                this.$refs.variations.style.maxHeight = '0px';
+                var $this = this;
+                this.$refs.variations.hidden = true;
+                this.$refs.variations.addEventListener('transitionend', function (event) {
+                    if (event.target == this) {
+                        this.hidden = !$this.expanded;
+                        this.style.maxHeight = 'none';
+                    }
+                });
+                this.$watch('expanded', function (newValue) {
+                    var v = this.$refs.variations;
+                    v.hidden = false;
+                    v.style.maxHeight = (newValue ? 0 : v.scrollHeight) + 'px';
+                    // Vue.nextTick does not work here
+                    window.setTimeout(function () {
+                        v.style.maxHeight = (!newValue ? 0 : v.scrollHeight) + 'px';
+                    }, 50);
+                })
             }
-            this.$refs.variations.addEventListener('transitionend', function (event) {
-                if (this.style.maxHeight && this.style.maxHeight != '0px') {
-                    this.style.maxHeight = 'none';
-                } else {
-                    this.hidden = true;
-                }
-            });
         }
     },
     methods: {


### PR DESCRIPTION
My latest changes regarding A11y for widget opening variations failed badly when variations were to be displayed open by default. The actual problem was, that I did not take into account that `transitionend` bubbles – and Firefox has a transition on input-focus-outline. So as soon as one focuses an input, a transition starts to fade-in the focus-outline and at the end of that short transition, the whole variations would be removed.

This PR fixes the bubbling issue and also changes the behaviour in that, if the variations are shown by default, none of the watchers are installed as variations that are open-by-default can not be closed. Furthermore the code is less complicated by always removing maxHeight when transition is done and always setting initial maxHeight before a transition is started.
