### PR TITLE
Widget: fix centering for close-svg

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -708,8 +708,13 @@
     font-family: sans-serif;
     text-decoration: none;
     padding: 4px 0;
-    display: block;
+    display: inline-block;
     line-height: 16px;
+  }
+
+  .pretix-widget-frame-close svg {
+    display: inline-block;
+    border: none;
   }
 
   .pretix-widget-frame-inner iframe {


### PR DESCRIPTION
On some customer sites, svg gets a style `display: block` which is not the default and breaks the close-icons centering. This PR fixes this.