### PR TITLE
implement customer_accounts_required setting

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -147,6 +147,16 @@ DEFAULTS = {
                         "advanced features like memberships.")
         )
     },
+    'customer_accounts_required': {
+        'default': 'False',
+        'type': bool,
+        'form_class': forms.BooleanField,
+        'serializer_class': serializers.BooleanField,
+        'form_kwargs': dict(
+            label=_("Require a customer account to use this shop"),
+            help_text=_("If enabled, all requests are redirected to the login form.")
+        )
+    },
     'customer_accounts_native': {
         'default': 'True',
         'type': bool,

--- a/src/pretix/control/forms/organizer.py
+++ b/src/pretix/control/forms/organizer.py
@@ -358,6 +358,7 @@ class OrganizerSettingsForm(SettingsForm):
     auto_fields = [
         'allowed_restricted_plugins',
         'customer_accounts',
+        'customer_accounts_required',
         'customer_accounts_native',
         'customer_accounts_link_by_email',
         'invoice_regenerate_allowed',

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -131,6 +131,7 @@
                     <fieldset>
                         <legend>{% trans "Customer accounts" %}</legend>
                         {% bootstrap_field sform.customer_accounts layout="control" %}
+                        {% bootstrap_field sform.customer_accounts_required layout="control" %}
                         {% bootstrap_field sform.customer_accounts_native layout="control" %}
                         {% bootstrap_field sform.customer_accounts_link_by_email layout="control" %}
                         {% bootstrap_field sform.name_scheme layout="control" %}


### PR DESCRIPTION
Currently, when customers are not logged in, they can still see events, for example on which date(s) the event is scheduled.

When the customer_accounts_required setting is enabled, customers always need to login to view any page of this shop.

This is useful for shops with closed user groups and prevents confusion: We have had a customer not understand how to order, because the “add to cart” button was missing when the customer is not logged in. With this setting, we enforce a login, and hence a functional event view.