### PR TITLE
Add option to copy shop URL and generate QR code

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -16,6 +16,42 @@
             {% endif %}
         </small>
     </h1>
+    <div class="helper-space-below">
+        {% trans "Shop URL:" %}
+        <span id="shop_url" class="text-muted">{% abseventurl request.event "presale:event.index" %}</span>
+        <button type="button" class="btn btn-default btn-xs btn-clipboard" data-clipboard-target="#shop_url">
+            <i class="fa fa-clipboard" aria-hidden="true"></i>
+            <span class="sr-only">{% trans "Copy to clipboard" %}</span>
+        </button>
+        <div class="btn-group helper-display-inline-block">
+            <button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" title="{% trans "Create QR code" %}" aria-haspopup="true" aria-expanded="false">
+                <i class="fa fa-qrcode" aria-hidden="true"></i>
+            </button>
+            <ul class="dropdown-menu">
+                <li>
+                    <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="png" %}" target="_blank" download>
+                        {% blocktrans with filetype="PNG" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="svg" %}" target="_blank" download>
+                        {% blocktrans with filetype="SVG" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="jpeg" %}" target="_blank" download>
+                        {% blocktrans with filetype="JPG" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="gif" %}" target="_blank" download>
+                        {% blocktrans with filetype="GIF" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="clearfix"></div>
+    </div>
     {% if has_overpaid_orders %}
         <div class="alert alert-warning">
             {% blocktrans trimmed %}

--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -27,25 +27,25 @@
             <button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" title="{% trans "Create QR code" %}" aria-haspopup="true" aria-expanded="false">
                 <i class="fa fa-qrcode" aria-hidden="true"></i>
             </button>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu dropdown-menu-right">
                 <li>
                     <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="png" %}" target="_blank" download>
-                        {% blocktrans with filetype="PNG" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                        {% blocktrans with filetype="PNG" %}Download QR code as {{ filetype }} image{% endblocktrans %}
                     </a>
                 </li>
                 <li>
                     <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="svg" %}" target="_blank" download>
-                        {% blocktrans with filetype="SVG" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                        {% blocktrans with filetype="SVG" %}Download QR code as {{ filetype }} image{% endblocktrans %}
                     </a>
                 </li>
                 <li>
                     <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="jpeg" %}" target="_blank" download>
-                        {% blocktrans with filetype="JPG" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                        {% blocktrans with filetype="JPG" %}Download QR code as {{ filetype }} image{% endblocktrans %}
                     </a>
                 </li>
                 <li>
                     <a href="{% url "control:event.qrcode" event=request.event.slug organizer=request.organizer.slug filetype="gif" %}" target="_blank" download>
-                        {% blocktrans with filetype="GIF" %}Download QR-code as {{ filetype }} image{% endblocktrans %}
+                        {% blocktrans with filetype="GIF" %}Download QR code as {{ filetype }} image{% endblocktrans %}
                     </a>
                 </li>
             </ul>

--- a/src/pretix/control/templates/pretixcontrol/event/index.html
+++ b/src/pretix/control/templates/pretixcontrol/event/index.html
@@ -19,7 +19,7 @@
     <div class="helper-space-below">
         {% trans "Shop URL:" %}
         <span id="shop_url" class="text-muted">{% abseventurl request.event "presale:event.index" %}</span>
-        <button type="button" class="btn btn-default btn-xs btn-clipboard" data-clipboard-target="#shop_url">
+        <button type="button" class="btn btn-default btn-xs btn-clipboard js-only" data-clipboard-target="#shop_url">
             <i class="fa fa-clipboard" aria-hidden="true"></i>
             <span class="sr-only">{% trans "Copy to clipboard" %}</span>
         </button>

--- a/src/pretix/control/urls.py
+++ b/src/pretix/control/urls.py
@@ -231,6 +231,7 @@ urlpatterns = [
     re_path(r'^search/payments/$', search.PaymentSearch.as_view(), name='search.payments'),
     re_path(r'^event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/', include([
         re_path(r'^$', dashboards.event_index, name='event.index'),
+        re_path(r'^qrcode.(?P<filetype>(png|jpeg|gif|svg))$', event.EventQRCode.as_view(), name='event.qrcode'),
         re_path(r'^widgets.json$', dashboards.event_index_widgets_lazy, name='event.index.widgets'),
         re_path(r'^logs/embed$', dashboards.event_index_log_lazy, name='event.index.logs'),
         re_path(r'^live/$', event.EventLive.as_view(), name='event.live'),

--- a/src/pretix/control/views/event.py
+++ b/src/pretix/control/views/event.py
@@ -44,6 +44,7 @@ from urllib.parse import urlsplit
 
 import bleach
 import qrcode
+import qrcode.image.svg
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
@@ -88,7 +89,7 @@ from pretix.control.permissions import EventPermissionRequiredMixin
 from pretix.control.views.mailsetup import MailSettingsSetupView
 from pretix.control.views.user import RecentAuthenticationRequiredMixin
 from pretix.helpers.database import rolledback_transaction
-from pretix.multidomain.urlreverse import get_event_domain, build_absolute_uri
+from pretix.multidomain.urlreverse import build_absolute_uri, get_event_domain
 from pretix.plugins.stripe.payment import StripeSettingsHolder
 from pretix.presale.style import regenerate_css
 

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -139,11 +139,17 @@ p.bigger {
     font-size: 16px;
 }
 
+.helper-position-relative {
+    position: relative;
+}
 .helper-display-block {
     display: block !important;
 }
 .helper-display-inline {
     display: inline !important;
+}
+.helper-display-inline-block {
+    display: inline-block !important;
 }
 .helper-display-none-soft {
     display: none;

--- a/src/setup.py
+++ b/src/setup.py
@@ -218,6 +218,7 @@ setup(
         'python-u2flib-server==4.*',
         'pytz',
         'pyuca',
+        'qrcode==7.4.*',
         'redis==4.5.*,>=4.5.4',
         'reportlab==3.6.*',
         'requests==2.28.*',

--- a/src/tests/control/test_views.py
+++ b/src/tests/control/test_views.py
@@ -142,6 +142,10 @@ def logged_in_client(client, event):
     ('/control/events/add', 200),
 
     ('/control/event/{orga}/{event}/', 200),
+    ('/control/event/{orga}/{event}/qrcode.png', 200),
+    ('/control/event/{orga}/{event}/qrcode.jpeg', 200),
+    ('/control/event/{orga}/{event}/qrcode.svg', 200),
+    ('/control/event/{orga}/{event}/qrcode.gif', 200),
     ('/control/event/{orga}/{event}/live/', 200),
     ('/control/event/{orga}/{event}/dangerzone/', 200),
     ('/control/event/{orga}/{event}/cancel/', 200),


### PR DESCRIPTION
Non-technical users often struggle with finding the URL of their shop or generating a QR code for posters etc.

This adds a simple helper to make it easier:

![Screenshot 2023-04-05 at 15-55-26 Vouchermesse pretix eu](https://user-images.githubusercontent.com/64280/230102907-00209e13-1d04-4862-aaf7-a5591a19d233.png)

Of course, we could make this really complicated with options for the QR code colors and sizes but I think with this small effort we can already do a lot.