### PR TITLE
sendmail/orders: supply event_or_subevent, add event_date_from

### DIFF
--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -505,6 +505,17 @@ def base_placeholders(sender, **kwargs):
             lambda event: str(event.location or ''),
         ),
         SimpleFunctionalMailTextPlaceholder(
+            'event_date_from', ['event_or_subevent'],
+            lambda event_or_subevent: str(date_format(
+                event_or_subevent.date_from,
+                'SHORT_DATETIME_FORMAT'
+            )),
+            lambda event: str(date_format(
+                event.date_from,
+                'SHORT_DATETIME_FORMAT'
+            )),
+        ),
+        SimpleFunctionalMailTextPlaceholder(
             'event_admission_time', ['event_or_subevent'],
             lambda event_or_subevent:
                 date_format(event_or_subevent.date_admission.astimezone(event_or_subevent.timezone), 'TIME_FORMAT')

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -2052,7 +2052,11 @@ class OrderSendMail(EventPermissionRequiredMixin, OrderViewMixin, FormView):
         )
         self.preview_output = {}
         with language(order.locale, self.request.event.settings.region):
-            email_context = get_email_context(event=order.event, order=order)
+            email_context = get_email_context(
+                event=order.event,
+                order=order,
+                event_or_subevent=order.subevent or order.event,
+            )
         email_template = LazyI18nString(form.cleaned_data['message'])
         email_subject = format_map(str(form.cleaned_data['subject']), email_context)
         email_content = render_mail(email_template, email_context)

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -243,7 +243,7 @@ class BaseSenderView(EventPermissionRequiredMixin, FormView):
 class OrderSendView(BaseSenderView):
     form_class = forms.OrderMailForm
     form_fragment_name = "pretixplugins/sendmail/send_form_fragment_orders.html"
-    context_parameters = ['event', 'order', 'position_or_address']
+    context_parameters = ['event', 'order', 'position_or_address', 'event_or_subevent']
     task = send_mails_to_orders
 
     ACTION_TYPE = 'pretix.plugins.sendmail.sent'


### PR DESCRIPTION
This allows sending emails to customers to remind them of the specific date of the time slot (subevent) they booked, which is very useful when using pretix to schedule appointments.