### PR TITLE
Add checkin requires attention to advanced order search

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -573,6 +573,7 @@ class EventOrderExpertFilterForm(EventOrderFilterForm):
         required=False,
         widget=FilterNullBooleanSelect,
         label=_('Requires special attention'),
+        help_text=_('Only matches orders with the attention checkbox set directly for the order, not based on the product.'),
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -569,6 +569,11 @@ class EventOrderExpertFilterForm(EventOrderFilterForm):
         label=_('Sales channel'),
         required=False,
     )
+    checkin_attention = forms.NullBooleanField(
+        required=False,
+        widget=FilterNullBooleanSelect,
+        label=_('Requires special attention'),
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -689,6 +694,8 @@ class EventOrderExpertFilterForm(EventOrderFilterForm):
             qs = qs.filter(total=fdata.get('total'))
         if fdata.get('email_known_to_work') is not None:
             qs = qs.filter(email_known_to_work=fdata.get('email_known_to_work'))
+        if fdata.get('checkin_attention') is not None:
+            qs = qs.filter(checkin_attention=fdata.get('checkin_attention'))
         if fdata.get('locale'):
             qs = qs.filter(locale=fdata.get('locale'))
         if fdata.get('payment_sum_min') is not None:


### PR DESCRIPTION
_Checkin requires attention_ is a flag that can be set on orders, but couldn't be searched/filtered for in the advanced order search.