### PR TITLE
urlize event location (and linebreaksbr in email)

### DIFF
--- a/src/pretix/base/templates/pretixbase/email/order_details.html
+++ b/src/pretix/base/templates/pretixbase/email/order_details.html
@@ -113,7 +113,7 @@
                                         {% endif %}
                                         {% if groupkey.2.location %}
                                             <br>
-                                            {{ groupkey.2.location|oneline }}
+                                            {{ groupkey.2.location|urlize|linebreaksbr }}
                                         {% endif %}
                                     {% endif %}
                                     {% if groupkey.3 %} {# attendee name #}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -83,9 +83,9 @@
                         <dt class="sr-only">{% trans "Location:" %}</dt>
                         <dd>
                             <div class="collapse-lines" data-expand-text="{% trans "Show full location" %}" aria-hidden="true">
-                                <span class="content text-muted" id="full-location-{{ line.pk }}">{{ line.subevent.location|linebreaksbr }}</span>
+                                <span class="content text-muted" id="full-location-{{ line.pk }}">{{ line.subevent.location|urlize|linebreaksbr }}</span>
                             </div>
-                            <div class="sr-only">{{ line.subevent.location|linebreaksbr }}</div>
+                            <div class="sr-only">{{ line.subevent.location|urlize|linebreaksbr }}</div>
                         </dd>
                     </div>
                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -166,7 +166,7 @@
                     <div class="info-row">
                         <span class="fa fa-map-marker fa-fw" aria-hidden="true" title="{% trans "Where does the event happen?" %}"></span>
                         <p><span class="sr-only">{% trans "Where does the event happen?" %}</span>
-                            {{ ev.location|linebreaksbr }}
+                            {{ ev.location|urlize|linebreaksbr }}
                         </p>
                     </div>
                 {% endif %}


### PR DESCRIPTION
This makes URLs in event locations a little more convenient, for example when saying “at <eventlocation>.ch”, or when linking to a detailed description for where the entrance is.