### PR TITLE
Cart: Add sneak-peek preview

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
@@ -13,7 +13,7 @@
 {% endblock %}
 {% block content %}
 <aside aria-label="{% trans "Your cart" %}">
-    <details class="panel panel-default cart" {% if "open_cart" in request.GET %}open{% endif %}>
+    <details class="panel panel-default cart{% if "open_cart" not in request.GET %} sneak-peek{% endif %}" {% if "open_cart" in request.GET %}open{% endif %}>
         <summary class="panel-heading">
             <h2 class="panel-title">
                 <span>
@@ -32,6 +32,11 @@
                 </span>
             </h2>
         </summary>
+        {% if "open_cart" not in request.GET %}
+        <p class="sneak-peek-trigger">
+            <button type="button" class="btn btn-default">{% trans "Show cart" %}</button>
+        </p>
+        {% endif %}
         <div>
             <div class="panel-body">
                 {% include "pretixpresale/event/fragment_cart.html" with cart=cart event=request.event %}

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
@@ -34,7 +34,7 @@
         </summary>
         {% if "open_cart" not in request.GET %}
         <p class="sneak-peek-trigger">
-            <button type="button" class="btn btn-default">{% trans "Show cart" %}</button>
+            <button type="button" class="btn btn-default">{% trans "Show full cart" %}</button>
         </p>
         {% endif %}
         <div>

--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -31,6 +31,10 @@ setup_collapsible_details = function (el) {
         e.preventDefault();
         return false;
     }).keyup(function (event) {
+        if ($details.hasClass('sneak-peek')) {
+            // if sneak-peek is active, needs to be handled differently
+            return true;
+        }
         if (32 == event.keyCode || (13 == event.keyCode && !isOpera)) {
             // Space or Enter is pressed — trigger the `click` event on the `summary` element
             // Opera already seems to trigger the `click` event when Enter is pressed

--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -7,6 +7,10 @@ setup_collapsible_details = function (el) {
             return true;
         }
         var $details = $(this).closest("details");
+        if ($details.hasClass('sneak-peek')) {
+            // if sneak-peek is active, needs to be handled differently
+            return true;
+        }
         var isOpen = $details.prop("open");
         var $detailsNotSummary = $details.children(':not(summary)');
         if ($detailsNotSummary.is(':animated')) {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -293,7 +293,8 @@ $(function () {
         var $elements = $("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)').attr('aria-hidden', 'true');
 
         var container = this;
-        $('summary, .sneak-peek-trigger button', container).one('click', function(e) {
+        var trigger = $('summary, .sneak-peek-trigger button', container);
+        function onclick(e) {
             e.preventDefault();
 
             container.addEventListener('transitionend', function() {
@@ -305,8 +306,10 @@ $(function () {
                 $(this).remove();
             });
             $elements.removeAttr('aria-hidden');
-            $('summary', container).focus();
-        });
+
+            trigger.off('click', onclick);
+        }
+        trigger.on('click', onclick);
     });
 
     // Copy answers

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -288,6 +288,27 @@ $(function () {
 
     $("#ajaxerr").on("click", ".ajaxerr-close", ajaxErrDialog.hide);
 
+    $('details.sneak-peek:not([open])').each(function() {
+        this.open = true;
+        var $elements = $("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)').attr('aria-hidden', 'true');
+
+        var container = this;
+        $('summary, .sneak-peek-trigger button', container).one('click', function(e) {
+            e.preventDefault();
+
+            container.addEventListener('transitionend', function() {
+                $(container).removeClass('sneak-peek');
+                container.style.removeProperty('height');
+            }, {once: true});
+            container.style.height = container.scrollHeight + 'px';
+            $('.sneak-peek-trigger', container).fadeOut(function() {
+                $(this).remove();
+            });
+            $elements.removeAttr('aria-hidden');
+            $('summary', container).focus();
+        });
+    });
+
     // Copy answers
     $(".js-copy-answers").click(function (e) {
         e.preventDefault();

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -398,6 +398,27 @@ details.details-open .panel-heading .collapse-indicator,
     transform: rotate(180deg);
 }
 
+details.sneak-peek {
+    position: relative;
+    height: 11em;
+    overflow: hidden;
+    transition: height .5s;
+}
+.sneak-peek-trigger {
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    width: 100%;
+    height: 8em;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(0deg, rgba(255,255,255,.9) 44%, rgba(255,255,255,0) 100%);
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 10;
+}
+
 form.download-btn-form {
     display: inline;
 }

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -409,10 +409,10 @@ details.sneak-peek {
     justify-content: center;
     align-content: center;
     width: 100%;
-    height: 8em;
+    height: 4.5em;
     margin: 0;
-    padding: 0;
-    background: linear-gradient(0deg, rgba(255,255,255,.9) 44%, rgba(255,255,255,0) 100%);
+    padding: 15px;
+    background: linear-gradient(0deg, rgba(248,248,248,.9) 44%, rgba(248,248,248,0) 100%);
     position: absolute;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
This PR adds an button „show cart“ and shows parts of the active cart during checkout. This should make it more obvious that the cart can be opened.

![Bildschirmfoto 2023-04-25 um 12 46 41](https://user-images.githubusercontent.com/276509/234254352-80c87828-be3a-4b5b-b479-cae81ae9ac14.png)
