### PR TITLE
Cart: disable/enable add-to-cart button even with seating active

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -421,7 +421,7 @@ $(function () {
                 }
             });
         }
-        if (!is_enabled) {
+        if (!is_enabled && (!$(".has-seating").length || $("#seating-dummy-item-count").length)) {
             $("#btn-add-to-cart").prop("disabled", !is_enabled).popover({
                 'content': function () { return gettext("Please enter a quantity for one of the ticket types.") },
                 'placement': 'top',

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -421,7 +421,7 @@ $(function () {
                 }
             });
         }
-        if (!is_enabled && !$(".has-seating").length) {
+        if (!is_enabled) {
             $("#btn-add-to-cart").prop("disabled", !is_enabled).popover({
                 'content': function () { return gettext("Please enter a quantity for one of the ticket types.") },
                 'placement': 'top',


### PR DESCRIPTION
Latest pretix-seating (see internal merge request) improves its own disable/enable add-to-cart button by adding a hidden dummy-input element, which is tracked automagically by the existing disable/enable add-to-cart button algorithm. This PR just removes the if-condition to not disable add-to-cart button when seating is active.