### PR TITLE
Cart: make single-select checkbox look like a button (Z#23121616)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -177,7 +177,7 @@
                                 {% if var.cached_availability.0 == 100 or var.initial %}
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
                                         {% if c.max_count == 1 or not c.multi_allowed %}
-                                            <label class="item-checkbox-label btn btn-default">
+                                            <label class="btn btn-default btn-checkbox">
                                                 <input type="checkbox" value="1"
                                                         {% if var.initial %}checked="checked"{% endif %}
                                                         {% if item.free_price %}
@@ -306,7 +306,7 @@
                     {% if item.cached_availability.0 == 100 or item.initial %}
                         <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
                             {% if c.max_count == 1 or not c.multi_allowed %}
-                                <label class="item-checkbox-label btn btn-default">
+                                <label class="btn btn-default btn-checkbox">
                                     <input type="checkbox" value="1"
                                             {% if item.free_price %}
                                                data-checked-onchange="price-item-{{ form.pos.pk }}-{{ item.pk }}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -188,7 +188,7 @@
                                                         data-exclusive-prefix="cp_{{ form.pos.pk }}_variation_{{ item.id }}_"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                                {% trans "Select" %}
+                                                {% trans "Select" context "checkbox" %}
                                             </label>
                                         {% else %}
                                             <div class="input-item-count-group">
@@ -322,7 +322,7 @@
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                             {% if item.description %} aria-describedby="cp-{{ form.pos.pk }}-item-{{ item.id }}-description"{% endif %}>
                                             <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                            {% trans "Select" %}
+                                            {% trans "Select" context "checkbox" %}
                                 </label>
                             {% else %}
                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -177,7 +177,7 @@
                                 {% if var.cached_availability.0 == 100 or var.initial %}
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
                                         {% if c.max_count == 1 or not c.multi_allowed %}
-                                            <label class="item-checkbox-label">
+                                            <label class="item-checkbox-label btn btn-default">
                                                 <input type="checkbox" value="1"
                                                         {% if var.initial %}checked="checked"{% endif %}
                                                         {% if item.free_price %}
@@ -187,7 +187,7 @@
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         data-exclusive-prefix="cp_{{ form.pos.pk }}_variation_{{ item.id }}_"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
-                                                <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
+                                                {% trans "Select" %}
                                             </label>
                                         {% else %}
                                             <div class="input-item-count-group">
@@ -305,7 +305,7 @@
                     {% if item.cached_availability.0 == 100 or item.initial %}
                         <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
                             {% if c.max_count == 1 or not c.multi_allowed %}
-                                <label class="item-checkbox-label">
+                                <label class="item-checkbox-label btn btn-default">
                                     <input type="checkbox" value="1"
                                             {% if item.free_price %}
                                                data-checked-onchange="price-item-{{ form.pos.pk }}-{{ item.pk }}"
@@ -320,7 +320,7 @@
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                             {% if item.description %} aria-describedby="cp-{{ form.pos.pk }}-item-{{ item.id }}-description"{% endif %}>
-                                            <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
+                                            {% trans "Select" %}
                                 </label>
                             {% else %}
                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -187,6 +187,7 @@
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         data-exclusive-prefix="cp_{{ form.pos.pk }}_variation_{{ item.id }}_"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
+                                                <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" %}
                                             </label>
                                         {% else %}
@@ -320,6 +321,7 @@
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                             {% if item.description %} aria-describedby="cp-{{ form.pos.pk }}-item-{{ item.id }}-description"{% endif %}>
+                                            <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                             {% trans "Select" %}
                                 </label>
                             {% else %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -184,7 +184,7 @@
                                 {% elif var.cached_availability.0 == 100 %}
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
 										{% if var.order_max == 1 %}
-                                            <label class="item-checkbox-label btn btn-default">
+                                            <label class="btn btn-default btn-checkbox">
                                                 <input type="checkbox" value="1"
                                                     {% if item.free_price %}
                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
@@ -329,7 +329,7 @@
                     {% elif item.cached_availability.0 == 100 %}
                         <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
 							{% if item.order_max == 1 %}
-                                <label class="item-checkbox-label btn btn-default">
+                                <label class="btn btn-default btn-checkbox">
                                     <input type="checkbox" value="1" {% if itemnum == 1 %}checked{% endif %}
                                         {% if item.free_price %}
                                            data-checked-onchange="price-item-{{ item.pk }}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -195,7 +195,7 @@
                                                        aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
                                                        {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                                {% trans "Select" %}
+                                                {% trans "Select" context "checkbox" %}
                                             </label>
                                         {% else %}
                                             <div class="input-item-count-group">
@@ -339,7 +339,7 @@
                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
                                         <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                        {% trans "Select" %}
+                                        {% trans "Select" context "checkbox" %}
                                 </label>
                             {% else %}
                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -184,7 +184,7 @@
                                 {% elif var.cached_availability.0 == 100 %}
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
 										{% if var.order_max == 1 %}
-                                            <label class="item-checkbox-label">
+                                            <label class="item-checkbox-label btn btn-default">
                                                 <input type="checkbox" value="1"
                                                     {% if item.free_price %}
                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
@@ -194,7 +194,7 @@
                                                        name="variation_{{ item.id }}_{{ var.id }}"
                                                        aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
                                                        {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
-                                               <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
+                                               {% trans "Select" %}
                                             </label>
                                         {% else %}
                                             <div class="input-item-count-group">
@@ -328,7 +328,7 @@
                     {% elif item.cached_availability.0 == 100 %}
                         <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
 							{% if item.order_max == 1 %}
-                                <label class="item-checkbox-label">
+                                <label class="item-checkbox-label btn btn-default">
                                     <input type="checkbox" value="1" {% if itemnum == 1 %}checked{% endif %}
                                         {% if item.free_price %}
                                            data-checked-onchange="price-item-{{ item.pk }}"
@@ -337,7 +337,7 @@
                                            name="item_{{ item.id }}" id="item_{{ item.id }}"
                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
-                                           <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
+                                           {% trans "Select" %}
                                 </label>
                             {% else %}
                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -194,7 +194,8 @@
                                                        name="variation_{{ item.id }}_{{ var.id }}"
                                                        aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
                                                        {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
-                                               {% trans "Select" %}
+                                                <i class="fa fa-shopping-cart" aria-hidden="true"></i>
+                                                {% trans "Select" %}
                                             </label>
                                         {% else %}
                                             <div class="input-item-count-group">
@@ -337,7 +338,8 @@
                                            name="item_{{ item.id }}" id="item_{{ item.id }}"
                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
-                                           {% trans "Select" %}
+                                        <i class="fa fa-shopping-cart" aria-hidden="true"></i>
+                                        {% trans "Select" %}
                                 </label>
                             {% else %}
                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -243,7 +243,7 @@
                                                 <div class="col-md-2 col-sm-3 col-xs-6 availability-box available radio-box">
                                                     {% if max_times > 1 %}
                                                         {% if var.order_max == 1 %}
-                                                            <label class="item-checkbox-label btn btn-default">
+                                                            <label class="btn btn-default btn-checkbox">
                                                                 <input type="checkbox"
                                                                         value="1"
                                                                         id="variation_{{ item.id }}_{{ var.id }}"
@@ -386,7 +386,7 @@
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available radio-box">
                                         {% if max_times > 1 %}
                                             {% if item.order_max == 1 %}
-                                                <label class="item-checkbox-label btn btn-default">
+                                                <label class="btn btn-default btn-checkbox">
                                                     <input type="checkbox"
                                                            value="1"
                                                            id="item_{{ item.id }}"

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -243,7 +243,7 @@
                                                 <div class="col-md-2 col-sm-3 col-xs-6 availability-box available radio-box">
                                                     {% if max_times > 1 %}
                                                         {% if var.order_max == 1 %}
-                                                            <label class="item-checkbox-label">
+                                                            <label class="item-checkbox-label btn btn-default">
                                                                 <input type="checkbox"
                                                                         value="1"
                                                                         id="variation_{{ item.id }}_{{ var.id }}"
@@ -251,7 +251,7 @@
                                                                         {% if options == 1 %}checked{% endif %}
                                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
                                                                         {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
-                                                                <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
+                                                                {% trans "Select" %}
                                                             </label>
                                                         {% else %}
                                                             <div class="input-item-count-group">
@@ -385,7 +385,7 @@
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available radio-box">
                                         {% if max_times > 1 %}
                                             {% if item.order_max == 1 %}
-                                                <label class="item-checkbox-label">
+                                                <label class="item-checkbox-label btn btn-default">
                                                     <input type="checkbox"
                                                            value="1"
                                                            id="item_{{ item.id }}"
@@ -393,7 +393,7 @@
                                                            {% if options == 1 %}checked{% endif %}
                                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
-                                                    <i class="fa fa-cart-plus fa-lg" aria-hidden="true"></i>
+                                                    {% trans "Select" %}
                                                 </label>
                                             {% else %}
                                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -252,7 +252,7 @@
                                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
                                                                         {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
                                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                                                {% trans "Select" %}
+                                                                {% trans "Select" context "checkbox" %}
                                                             </label>
                                                         {% else %}
                                                             <div class="input-item-count-group">
@@ -395,7 +395,7 @@
                                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
                                                     <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                                    {% trans "Select" %}
+                                                    {% trans "Select" context "checkbox" %}
                                                 </label>
                                             {% else %}
                                                 <div class="input-item-count-group">

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -251,6 +251,7 @@
                                                                         {% if options == 1 %}checked{% endif %}
                                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
                                                                         {% if var.description %} aria-describedby="item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
+                                                                <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                                 {% trans "Select" %}
                                                             </label>
                                                         {% else %}
@@ -393,6 +394,7 @@
                                                            {% if options == 1 %}checked{% endif %}
                                                            aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
                                                            {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
+                                                    <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                     {% trans "Select" %}
                                                 </label>
                                             {% else %}

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -125,6 +125,12 @@ var form_handlers = function (el) {
         controls.value = Math.max(controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
         controls.dispatchEvent(new Event("change"));
     });
+    el.find(".item-checkbox-label input").on("change", function (e) {
+        $(this).closest(".item-checkbox-label")
+            .toggleClass("item-checkbox-label-checked", this.checked)
+            .find(".fa").toggleClass("fa-shopping-cart", !this.checked).toggleClass("fa-cart-arrow-down", this.checked);
+    });
+    el.find(".item-checkbox-label:has([checked]) .fa-shopping-cart").toggleClass("fa-shopping-cart fa-cart-arrow-down")
 
     el.find("script[data-replace-with-qr]").each(function () {
         var $div = $("<div>");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -125,12 +125,12 @@ var form_handlers = function (el) {
         controls.value = Math.max(controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
         controls.dispatchEvent(new Event("change"));
     });
-    el.find(".item-checkbox-label input").on("change", function (e) {
-        $(this).closest(".item-checkbox-label")
-            .toggleClass("item-checkbox-label-checked", this.checked)
+    el.find(".btn-checkbox input").on("change", function (e) {
+        $(this).closest(".btn-checkbox")
+            .toggleClass("btn-checkbox-checked", this.checked)
             .find(".fa").toggleClass("fa-shopping-cart", !this.checked).toggleClass("fa-cart-arrow-down", this.checked);
     });
-    el.find(".item-checkbox-label:has([checked]) .fa-shopping-cart").toggleClass("fa-shopping-cart fa-cart-arrow-down")
+    el.find(".btn-checkbox:has([checked]) .fa-shopping-cart").toggleClass("fa-shopping-cart fa-cart-arrow-down")
 
     el.find("script[data-replace-with-qr]").each(function () {
         var $div = $("<div>");

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -29,20 +29,6 @@
             color: $alert-warning-text;
         }
     }
-    .item-checkbox-label {
-        position: relative;
-        display: block;
-        padding-left: 24px;
-        padding-right: 24px;
-
-        input {
-            position: absolute;
-            left: 10px;
-        }
-        &.item-checkbox-label-checked {
-            background-color: $gray-lighter;
-        }
-    }
 
     .product-description.with-picture {
         margin-left: 70px;

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -31,7 +31,9 @@
     }
     .item-checkbox-label {
         display: block;
-        margin-top: .4em;
+    }
+    .item-checkbox-label:has(input:checked) {
+        background-color: $gray-lighter;
     }
 
     .product-description.with-picture {

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -30,10 +30,18 @@
         }
     }
     .item-checkbox-label {
+        position: relative;
         display: block;
-    }
-    .item-checkbox-label:has(input:checked) {
-        background-color: $gray-lighter;
+        padding-left: 24px;
+        padding-right: 24px;
+
+        input {
+            position: absolute;
+            left: 10px;
+        }
+        &.item-checkbox-label-checked {
+            background-color: $gray-lighter;
+        }
     }
 
     .product-description.with-picture {

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -7,6 +7,22 @@ a.btn, button.btn {
   white-space: normal;
 }
 
+.btn-checkbox {
+    position: relative;
+    display: block;
+    padding-left: 24px;
+    padding-right: 24px;
+    white-space: normal;
+
+    input {
+        position: absolute;
+        left: 10px;
+    }
+    &.btn-checkbox-checked {
+        background-color: $gray-lighter;
+    }
+}
+
 .panel-title .radio {
   margin-left: 20px;
 }


### PR DESCRIPTION
This PR explores the option to make the checkbox for items with a max-oder of 1 to look like a button. I like the idea, maybe something is missing? Add an icon? Or have it read „select one“?

Note: Firefox currently seems to not support the combination of `:has` and `:checked` – so atm only Safari/Chrome show the darkened background. For testing purposes this is okay. If we go with this design, then we might fallback on JS to handle this or ignore and wait for Firefox to catch up (as it is not that substantial).

![Bildschirmfoto 2023-05-24 um 15 36 12](https://github.com/pretix/pretix/assets/276509/517b8683-67bd-4be2-8c2d-c8ed6586d3d7)
![Bildschirmfoto 2023-05-24 um 15 36 47](https://github.com/pretix/pretix/assets/276509/b290539d-5419-4d24-af8d-961ab4f6fb8a)

Maybe with an icon? I like the one with an icon in front, but then we might remove the checkbox and use the icon to indicate state. E.g. an icon of a cart, then when checked, have a pointer pointing inside the cart? I fear using a checkmark on top of a cart might be misunderstood as in the item has already been added to the cart.

![Bildschirmfoto 2023-05-24 um 15 40 37](https://github.com/pretix/pretix/assets/276509/7e796628-ae0f-43b8-9069-c5087881741c)
![Bildschirmfoto 2023-05-24 um 15 39 00](https://github.com/pretix/pretix/assets/276509/a6ba9dcf-9a8a-4b47-8679-0182070eda95)

Just an icon:
![Bildschirmfoto 2023-05-24 um 15 46 11](https://github.com/pretix/pretix/assets/276509/6d6c0496-935a-48cb-bdcd-1710d464e80b)
![Bildschirmfoto 2023-05-24 um 15 46 32](https://github.com/pretix/pretix/assets/276509/ce565d78-8f9f-44c0-a577-7c6c6e40df88)

Also not sure about the wording, whether that needs to change, when the checkbox is checked. „Selected“? Hm, again could add more confusion than it helps.

UPDATE: After thinking about it some more, I think keeping the checkbox is helpful in understanding, what this input element is meant to do. I still like the icon and I think it improves communicating the action better than just „Select“. But checkbox and icon directly next to each other can look a bit crowded. So, how about aligning the checkbox left and centering the icon/text? I think combined with the icon-change from above (pointer-down when checked) that will work best. Updated this PR to the following label-layout:

![Bildschirmfoto 2023-06-01 um 08 35 45](https://github.com/pretix/pretix/assets/276509/72b98b67-fc4c-49f8-b3d1-987004956a39)
![Bildschirmfoto 2023-06-01 um 08 36 01](https://github.com/pretix/pretix/assets/276509/cd5029a0-9b0d-4446-92ce-928ba255a9d0)
