### PR TITLE
Product list: add border to disabled spinner buttons

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -69,6 +69,10 @@ a.btn, button.btn {
   -webkit-appearance: none;
   margin: 0;
 }
+.input-item-count-dec[disabled],
+.input-item-count-inc[disabled] {
+  box-shadow: 0px 0px 0px 1px #cccccc inset;
+}
 .input-item-count-dec {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -70,8 +70,12 @@ a.btn, button.btn {
   margin: 0;
 }
 .input-item-count-dec[disabled],
-.input-item-count-inc[disabled] {
+.input-item-count-inc[disabled],
+.input-item-count-dec[disabled]:hover,
+.input-item-count-inc[disabled]:hover {
   box-shadow: 0px 0px 0px 1px #cccccc inset;
+  background: #eee;
+  opacity: 1;
 }
 .input-item-count-dec {
   border-top-right-radius: 0;


### PR DESCRIPTION
When the quantity is disabled, the spinner buttons are disabled as well. Current design for disabled buttons removes border, which in case of the spinner buttons’ design as a union with the input does not look good. This PR adds the usual border (technical a box-shadow) to disabled spinner buttons.

Normal
![Bildschirmfoto 2023-05-26 um 13 28 04](https://github.com/pretix/pretix/assets/276509/b90f4bf7-de87-42f3-8f90-64d88679cb71)

Normal disabled button with added border (current status of this PR)
![Bildschirmfoto 2023-05-26 um 13 27 35](https://github.com/pretix/pretix/assets/276509/e8e5f033-eb27-46b8-a5bd-4412b12e75e4)

With background-color slightly darkened (actual background of input element, but disabled buttons have a slight opacity):
![Bildschirmfoto 2023-05-26 um 13 27 52](https://github.com/pretix/pretix/assets/276509/eeebc14b-c8da-4ec6-a93b-9fcb7ebb2f9c)

With background-color darkened to same bg as input (ie. no additional no opacity on button) – this is my favourite:
![Bildschirmfoto 2023-05-26 um 13 31 58](https://github.com/pretix/pretix/assets/276509/40ecc252-246f-41b2-b4c7-7de151e0af3a)
