### PR TITLE
API: Fix crash when creating addons with order change endpoint

### DIFF
--- a/src/pretix/api/serializers/orderchange.py
+++ b/src/pretix/api/serializers/orderchange.py
@@ -70,6 +70,8 @@ class OrderPositionCreateForExistingOrderSerializer(OrderPositionCreateSerialize
 
     def validate(self, data):
         data = super().validate(data)
+        if 'order' in self.context:
+            data['order'] = self.context['order']
         if data.get('addon_to'):
             try:
                 data['addon_to'] = data['order'].positions.get(positionid=data['addon_to'])


### PR DESCRIPTION
Pretix crashes whenever the `addon_to` parameter is set for an item in `create_positions`.

See the regression test I've added. Without this change, the test fails with:

```
self = OrderPositionCreateForExistingOrderSerializer(context={'order': <Order: DUMMY-FOO>, 'request': <rest_framework.request..._from = DateTimeField(allow_null=True, required=False)
    valid_until = DateTimeField(allow_null=True, required=False)
data = OrderedDict([('item', <Item: WS1>), ('addon_to', 1)])

    def validate(self, data):
        data = super().validate(data)
        if data.get('addon_to'):
            try:
>               data['addon_to'] = data['order'].positions.get(positionid=data['addon_to'])
E               KeyError: 'order'

pretix/api/serializers/orderchange.py:75: KeyError
```