### PR TITLE
[WIP] Presale: respect item.order_min when changing quantity (Z#23122112)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -193,7 +193,6 @@
                                             <div class="input-item-count-group">
                                                 <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
-                                                    {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                                     {% if var.initial %}value="{{ var.initial }}"{% endif %}
                                                     {% if item.free_price %}
                                                        data-checked-onchange="price-variation-{{form.pos.pk}}-{{ item.pk }}-{{ var.pk }}"
@@ -327,7 +326,6 @@
                                 <div class="input-item-count-group">
                                     <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
-                                        {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                         {% if item.free_price %}
                                            data-checked-onchange="price-item-{{ form.pos.pk }}-{{ item.pk }}"
                                         {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -193,6 +193,7 @@
                                             <div class="input-item-count-group">
                                                 <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                                    {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                                     {% if var.initial %}value="{{ var.initial }}"{% endif %}
                                                     {% if item.free_price %}
                                                        data-checked-onchange="price-variation-{{form.pos.pk}}-{{ item.pk }}-{{ var.pk }}"
@@ -326,6 +327,7 @@
                                 <div class="input-item-count-group">
                                     <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                        {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                         {% if item.free_price %}
                                            data-checked-onchange="price-item-{{ form.pos.pk }}-{{ item.pk }}"
                                         {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -21,7 +21,7 @@
     </div>
     <div role="rowgroup" class="firstchild-in-panel">
     {% for line in cart.positions %}
-        <div role="row" class="row cart-row {% if hide_prices %}hide-prices{% endif %} {% if download %}has-downloads{% endif %}{% if editable %}editable{% endif %}">
+        <div role="row" class="row cart-row {% if hide_prices %}hide-prices{% endif %} {% if download %}has-downloads{% endif %}{% if editable %}editable{% endif %}" data-item="{{ line.item.id }}" data-count="{{ line.count }}">
             <div role="cell" class="product">
                 <p>
                 {% if line.addon_to %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -201,7 +201,6 @@
                                                 <button type="button" data-step="-1" data-controls="variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
                                                     {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
-                                                       {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                                        {% if not ev.presale_is_running %}disabled{% endif %}
                                                         {% if item.free_price %}
                                                            data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -201,6 +201,7 @@
                                                 <button type="button" data-step="-1" data-controls="variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
                                                     {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                                       {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                                        {% if not ev.presale_is_running %}disabled{% endif %}
                                                         {% if item.free_price %}
                                                            data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
@@ -344,6 +345,7 @@
                                     <button type="button" data-step="-1" data-controls="item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
                                         {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                           {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                            {% if not ev.presale_is_running %}disabled{% endif %}
                                            {% if itemnum == 1 %}value="1"{% endif %}
                                             {% if item.free_price %}

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -257,6 +257,7 @@
                                                             <div class="input-item-count-group">
                                                                 <button type="button" data-step="-1" data-controls="variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                                                    {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                                                     max="{{ var.order_max }}"
                                                                     id="variation_{{ item.id }}_{{ var.id }}"
                                                                     name="variation_{{ item.id }}_{{ var.id }}"
@@ -400,6 +401,7 @@
                                                     <button type="button" data-step="-1" data-controls="item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                     <input type="number" class="form-control input-item-count"
                                                        placeholder="0" min="0"
+                                                       {% if item.min_per_order and item.min_per_order > 1 %}data-min="{{ item.min_per_order }}"{% endif %}
                                                        max="{{ item.order_max }}"
                                                        id="item_{{ item.id }}"
                                                        name="item_{{ item.id }}"

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -126,6 +126,13 @@ var form_handlers = function (el) {
         controls.value = currentValue <= itemOrderMin && step < 0 ? 0 : Math.max(itemOrderMin || controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
         controls.dispatchEvent(new Event("change"));
     });
+    el.find("input[data-min]").on("blur", function(e) {
+        var quantity = parseFloat(this.value);
+        var itemOrderMin = parseFloat(this.getAttribute("data-min"));
+        if (quantity && quantity < itemOrderMin) {
+            this.value = itemOrderMin;
+        }
+    });
 
     el.find("script[data-replace-with-qr]").each(function () {
         var $div = $("<div>");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -122,7 +122,8 @@ var form_handlers = function (el) {
         var step = parseFloat(this.getAttribute("data-step"));
         var controls = document.getElementById(this.getAttribute("data-controls"));
         var currentValue = parseFloat(controls.value);
-        controls.value = Math.max(controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
+        var itemOrderMin = parseFloat(controls.getAttribute("data-min"))
+        controls.value = currentValue <= itemOrderMin && step < 0 ? 0 : Math.max(itemOrderMin || controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
         controls.dispatchEvent(new Event("change"));
     });
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -130,6 +130,12 @@ var form_handlers = function (el) {
     }).on("change", function(e) {
         var quantity = parseFloat(this.value) || 0;
         var itemOrderMin = parseFloat(this.getAttribute("data-min")) || 0;
+        if (itemOrderMin) {
+            document.querySelectorAll(".cart-row[data-item='"+this.id.substring(5)+"']").forEach(function(row) {
+                itemOrderMin -= (parseFloat(row.getAttribute("data-count")) || 1)
+            });
+            if (itemOrderMin < 0) itemOrderMin = 0;
+        }
         if (quantity && quantity < itemOrderMin) {
             this.value = this.previousValue > quantity ? 0 : itemOrderMin;
         }

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -128,7 +128,7 @@ var form_handlers = function (el) {
     el.find("input[data-min]").each(function(i) {
         this.previousValue = parseFloat(this.value) || 0;
     }).on("change", function(e) {
-        var quantity = parseFloat(this.value) || 0;
+        var currentValue = parseFloat(this.value) || 0;
         var itemOrderMin = parseFloat(this.getAttribute("data-min")) || 0;
         if (itemOrderMin) {
             document.querySelectorAll(".cart-row[data-item='"+this.id.substring(5)+"']").forEach(function(row) {
@@ -136,10 +136,10 @@ var form_handlers = function (el) {
             });
             if (itemOrderMin < 0) itemOrderMin = 0;
         }
-        if (quantity && quantity < itemOrderMin) {
-            this.value = this.previousValue > quantity ? 0 : itemOrderMin;
+        if (currentValue && currentValue < itemOrderMin) {
+            this.value = this.previousValue > currentValue ? 0 : itemOrderMin;
         }
-        this.previousValue = quantity;
+        this.previousValue = currentValue;
     });
 
     el.find("script[data-replace-with-qr]").each(function () {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -139,7 +139,7 @@ var form_handlers = function (el) {
         if (currentValue && currentValue < itemOrderMin) {
             this.value = this.previousValue > currentValue ? 0 : itemOrderMin;
         }
-        this.previousValue = currentValue;
+        this.previousValue = this.value;
     });
 
     el.find("script[data-replace-with-qr]").each(function () {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -121,17 +121,19 @@ var form_handlers = function (el) {
         e.preventDefault();
         var step = parseFloat(this.getAttribute("data-step"));
         var controls = document.getElementById(this.getAttribute("data-controls"));
-        var currentValue = parseFloat(controls.value);
-        var itemOrderMin = parseFloat(controls.getAttribute("data-min"))
-        controls.value = currentValue <= itemOrderMin && step < 0 ? 0 : Math.max(itemOrderMin || controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
+        var currentValue = parseFloat(controls.value) || 0;
+        controls.value = Math.max(controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
         controls.dispatchEvent(new Event("change"));
     });
-    el.find("input[data-min]").on("blur", function(e) {
-        var quantity = parseFloat(this.value);
-        var itemOrderMin = parseFloat(this.getAttribute("data-min"));
+    el.find("input[data-min]").each(function(i) {
+        this.previousValue = parseFloat(this.value) || 0;
+    }).on("change", function(e) {
+        var quantity = parseFloat(this.value) || 0;
+        var itemOrderMin = parseFloat(this.getAttribute("data-min")) || 0;
         if (quantity && quantity < itemOrderMin) {
-            this.value = itemOrderMin;
+            this.value = this.previousValue > quantity ? 0 : itemOrderMin;
         }
+        this.previousValue = quantity;
     });
 
     el.find("script[data-replace-with-qr]").each(function () {


### PR DESCRIPTION
This PR adds support for item.order_min on spinner buttons. Furthermore it adds an onblur-handler that set the input to the order_min if not 0 – as this happens without any further warning, I am not sure whether that is a good idea, although IMHO it is not bad either. As it is a separate commit we can remove that behaviour easily from this PR.