### PR TITLE
PDF: replace deprecated PdfMerger with PdfWriter

### DIFF
--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -51,7 +51,7 @@ from django.db.models import Case, Exists, OuterRef, Q, Subquery, When
 from django.db.models.functions import Cast, Coalesce
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _, gettext_lazy, pgettext_lazy
-from pypdf import PdfMerger, PdfReader, PdfWriter, Transformation
+from pypdf import PdfReader, PdfWriter, Transformation
 from pypdf.generic import RectangleObject
 from reportlab.lib import pagesizes
 from reportlab.lib.units import mm
@@ -196,7 +196,7 @@ def render_pdf(event, positions, opt):
         raise ExportError(_("None of the selected products is configured to print badges."))
 
     # render each badge on its own page first
-    merger = PdfMerger()
+    merger = PdfWriter()
     merger.add_metadata({
         '/Title': 'Badges',
         '/Creator': 'pretix',

--- a/src/pretix/plugins/ticketoutputpdf/exporters.py
+++ b/src/pretix/plugins/ticketoutputpdf/exporters.py
@@ -43,7 +43,7 @@ from django.db.models import Case, OuterRef, Q, Subquery, When
 from django.db.models.functions import Cast, Coalesce
 from django.utils.timezone import now
 from django.utils.translation import gettext as _, gettext_lazy, pgettext_lazy
-from pypdf import PdfMerger
+from pypdf import PdfWriter
 
 from pretix.base.exporter import BaseExporter
 from pretix.base.i18n import language
@@ -117,7 +117,7 @@ class AllTicketsPDF(BaseExporter):
         return d
 
     def render(self, form_data):
-        merger = PdfMerger()
+        merger = PdfWriter()
         qs = OrderPosition.objects.filter(
             order__event__in=self.events
         ).prefetch_related(

--- a/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
+++ b/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
@@ -44,7 +44,7 @@ from django.http import HttpRequest
 from django.template.loader import get_template
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from pypdf import PdfMerger
+from pypdf import PdfWriter
 
 from pretix.base.i18n import language
 from pretix.base.models import Order, OrderPosition
@@ -113,7 +113,7 @@ class PdfTicketOutput(BaseTicketOutput):
         return renderer.render_background(buffer, _('Ticket'))
 
     def generate_order(self, order: Order):
-        merger = PdfMerger()
+        merger = PdfWriter()
         with language(order.locale, self.event.settings.region):
             for op in order.positions_with_tickets:
                 layout = override_layout.send_chained(


### PR DESCRIPTION
PdfMerger is marked as deprecated in pypdf 5.0.0. This PR replaces PdfMerger with PdfWriter as suggested in the [docs](https://pypdf.readthedocs.io/en/latest/user/merging-pdfs.html)