### PR TITLE
Fix: use format_lazy for formatted translation in settings

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2119,11 +2119,14 @@ Your {event} team"""))
             label=_('Attachment for new orders'),
             ext_whitelist=(".pdf",),
             max_size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT,
-            help_text=format_lazy(_('This file will be attached to the first email that we send for every new order. Therefore it will be '
-                        'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
-                        'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
-                        'it to send non-public information as this file might be sent before payment is confirmed or the order '
-                        'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.'),
+            help_text=format_lazy(
+                _(
+                    'This file will be attached to the first email that we send for every new order. Therefore it will be '
+                    'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
+                    'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
+                    'it to send non-public information as this file might be sent before payment is confirmed or the order '
+                    'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.'
+                ),
                 size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024),
             )
         ),

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -546,8 +546,8 @@ DEFAULTS = {
         'form_kwargs': dict(
             label=_("Ask for VAT ID"),
             help_text=format_lazy(
-                _("Only works if an invoice address is asked for. VAT ID is never required and only requested from "
-                  "business customers in the following countries: {countries}"),
+                "Only works if an invoice address is asked for. VAT ID is never required and only requested from "
+                "business customers in the following countries: {countries}",
                 countries=lazy(lambda *args: ', '.join(sorted(gettext(Country(cc).name) for cc in VAT_ID_COUNTRIES)), str)()
             ),
             widget=forms.CheckboxInput(attrs={'data-checkbox-dependency': '#id_invoice_address_asked'}),
@@ -1911,7 +1911,7 @@ DEFAULTS = {
         'form_kwargs': dict(
             label=_("Attach ticket files"),
             help_text=format_lazy(
-                _("Tickets will never be attached if they're larger than {size} to avoid email delivery problems."),
+                "Tickets will never be attached if they're larger than {size} to avoid email delivery problems.",
                 size='4 MB'
             ),
         )
@@ -2119,12 +2119,13 @@ Your {event} team"""))
             label=_('Attachment for new orders'),
             ext_whitelist=(".pdf",),
             max_size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT,
-            help_text=_('This file will be attached to the first email that we send for every new order. Therefore it will be '
-                        'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
-                        'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
-                        'it to send non-public information as this file might be sent before payment is confirmed or the order '
-                        'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.').format(
-                size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024),
+            help_text=format_lazy(
+                'This file will be attached to the first email that we send for every new order. Therefore it will be '
+                'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
+                'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
+                'it to send non-public information as this file might be sent before payment is confirmed or the order '
+                'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.',
+                size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024)
             )
         ),
         'serializer_class': UploadedFileField,

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -546,8 +546,8 @@ DEFAULTS = {
         'form_kwargs': dict(
             label=_("Ask for VAT ID"),
             help_text=format_lazy(
-                "Only works if an invoice address is asked for. VAT ID is never required and only requested from "
-                "business customers in the following countries: {countries}",
+                _("Only works if an invoice address is asked for. VAT ID is never required and only requested from "
+                  "business customers in the following countries: {countries}"),
                 countries=lazy(lambda *args: ', '.join(sorted(gettext(Country(cc).name) for cc in VAT_ID_COUNTRIES)), str)()
             ),
             widget=forms.CheckboxInput(attrs={'data-checkbox-dependency': '#id_invoice_address_asked'}),
@@ -1911,7 +1911,7 @@ DEFAULTS = {
         'form_kwargs': dict(
             label=_("Attach ticket files"),
             help_text=format_lazy(
-                "Tickets will never be attached if they're larger than {size} to avoid email delivery problems.",
+                _("Tickets will never be attached if they're larger than {size} to avoid email delivery problems."),
                 size='4 MB'
             ),
         )
@@ -2119,13 +2119,12 @@ Your {event} team"""))
             label=_('Attachment for new orders'),
             ext_whitelist=(".pdf",),
             max_size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT,
-            help_text=format_lazy(
-                'This file will be attached to the first email that we send for every new order. Therefore it will be '
-                'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
-                'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
-                'it to send non-public information as this file might be sent before payment is confirmed or the order '
-                'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.',
-                size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024)
+            help_text=_('This file will be attached to the first email that we send for every new order. Therefore it will be '
+                        'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
+                        'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
+                        'it to send non-public information as this file might be sent before payment is confirmed or the order '
+                        'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.').format(
+                size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024),
             )
         ),
         'serializer_class': UploadedFileField,

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2119,11 +2119,11 @@ Your {event} team"""))
             label=_('Attachment for new orders'),
             ext_whitelist=(".pdf",),
             max_size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT,
-            help_text=_('This file will be attached to the first email that we send for every new order. Therefore it will be '
+            help_text=format_lazy(_('This file will be attached to the first email that we send for every new order. Therefore it will be '
                         'combined with the "Placed order", "Free order", or "Received order" texts from above. It will be sent '
                         'to both order contacts and attendees. You can use this e.g. to send your terms of service. Do not use '
                         'it to send non-public information as this file might be sent before payment is confirmed or the order '
-                        'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.').format(
+                        'is approved. To avoid this vital email going to spam, you can only upload PDF files of up to {size} MB.'),
                 size=settings.FILE_UPLOAD_MAX_SIZE_EMAIL_AUTO_ATTACHMENT // (1024 * 1024),
             )
         ),

--- a/src/pretix/control/middleware.py
+++ b/src/pretix/control/middleware.py
@@ -41,7 +41,7 @@ from django.shortcuts import get_object_or_404, redirect, resolve_url
 from django.template.response import TemplateResponse
 from django.urls import get_script_prefix, resolve, reverse
 from django.utils.encoding import force_str
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django_scopes import scope
 
 from pretix.base.models import Event, Organizer

--- a/src/pretix/control/middleware.py
+++ b/src/pretix/control/middleware.py
@@ -41,7 +41,7 @@ from django.shortcuts import get_object_or_404, redirect, resolve_url
 from django.template.response import TemplateResponse
 from django.urls import get_script_prefix, resolve, reverse
 from django.utils.encoding import force_str
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from django_scopes import scope
 
 from pretix.base.models import Event, Organizer


### PR DESCRIPTION
When trying to access something in pretix-control, that the currently logged in user has no access-right to, the error message was not localised correctly.
In settings there were some formatted strings used incorrectly with translation – some where translated before being fed into format_lazy, one was using gettext_lazy, but directly using Python’s `.format`.