### PR TITLE
fix: Treat events with empty `date_to` as happening now / in the future

### DIFF
--- a/doc/api/resources/events.rst
+++ b/doc/api/resources/events.rst
@@ -141,7 +141,7 @@ Endpoints
    :query has_subevents: If set to ``true``/``false``, only events with a matching value of ``has_subevents`` are returned.
    :query is_future: If set to ``true`` (``false``), only events that happen currently or in the future are (not) returned. Event series are never (always) returned.
    :query is_past: If set to ``true`` (``false``), only events that are over are (not) returned. Event series are never (always) returned.
-   :query ends_after: If set to a date and time, only events that happen during of after the given time are returned. Event series are never returned.
+   :query ends_after: If set to a date and time, only events that happen during or after the given time are returned. Event series are never returned.
    :query string ordering: Manually set the ordering of results. Valid fields to be used are ``date_from`` and
                            ``slug``. Keep in mind that ``date_from`` of event series does not really tell you anything.
                            Default: ``slug``.

--- a/src/pretix/api/views/event.py
+++ b/src/pretix/api/views/event.py
@@ -80,7 +80,7 @@ with scopes_disabled():
             expr = (
                 Q(has_subevents=False) &
                 Q(
-                    Q(Q(date_to__isnull=True) & Q(date_from__gte=value))
+                    Q(Q(date_to__isnull=True))
                     | Q(Q(date_to__isnull=False) & Q(date_to__gte=value))
                 )
             )

--- a/src/tests/api/test_events.py
+++ b/src/tests/api/test_events.py
@@ -178,9 +178,16 @@ def test_event_list(token_client, organizer, event):
     assert resp.status_code == 200
     assert [TEST_EVENT_RES] == resp.data['results']
 
+    assert event.date_to is None
     resp = token_client.get('/api/v1/organizers/{}/events/?ends_after=2017-12-27T10:01:00Z'.format(organizer.slug))
     assert resp.status_code == 200
-    assert [] == resp.data['results']
+    assert [TEST_EVENT_RES] == resp.data['results']
+
+    assert event.date_to is None
+    resp = token_client.get('/api/v1/organizers/{}/events/?ends_after=2017-12-30T10:01:00Z'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert [TEST_EVENT_RES] == resp.data['results']
+
     resp = token_client.get('/api/v1/organizers/{}/events/?ends_after=2017-12-27T09:59:59Z'.format(organizer.slug))
     assert resp.status_code == 200
     assert [TEST_EVENT_RES] == resp.data['results']


### PR DESCRIPTION
This PR changes the behaviour of the event list regarding events that have no end datetime set. The current state probably doesn't cover all codepaths that need to be changed, but I wanted to open this PR as early as possible to find out how events with no end date should be treated.

## Current Behaviour

For events with an empty end time, the start time is often (always?) used instead. This leads to some (in my opinion) unintuitive behaviours. One example (and the reason why I found this) is initializing a new check-in device after the event start day:

1. Create an event with the start time set to a few days ago and no end time set
2. Create a new check-in device with (only) access to this event
3. Initialize the pretixSCAN app
4. An empty event list is shown on the device

The pretixSCAN app uses the event list endpoint to query possible events, which no longer returns the event because the start date is in the past

## Proposed Behaviour

This PR would change the behaviour in this endpoint to treat an empty end date as always in the future. This way the event is still shown in the pretixSCAN app.

**Note:** This can lead to a long event list via the api if an organizer has a lot of events in the past without a end date set.

## Questions

This PR was initially created to fix the bug I encountered. However I'm not sure whether this is the perfect fix. The questions for me are

1. What does an empty end date symbolise? That the event has no end or that the end is the same as the start?
2. Should this be a heuristic instead, meaning an empty `date_to` is equal to `date_from + X` with X being a few days?

**Note:** pretixSCAN [already has a workaround](https://github.com/pretix/pretixscan-ios/commit/d2dbcddbe78674c708c10bdf36b81d8b5e079f0b) that queries older events. This could be extended to be a few days instead to fix this issue for some occasions. However IMHO this is not the proper way, as this is always a workaround that won't work for a lot of people