### PR TITLE
API: add log_action/webhook for confirmed payments

### DIFF
--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -665,8 +665,8 @@ class OrderViewSet(viewsets.ModelViewSet):
             if payment and payment.state == OrderPayment.PAYMENT_STATE_CONFIRMED:
                 order.log_action(
                     'pretix.event.order.payment.confirmed', {
-                        'local_id': self.local_id,
-                        'provider': self.provider,
+                        'local_id': payment.local_id,
+                        'provider': payment.provider,
                     },
                     user=request.user if request.user.is_authenticated else None,
                     auth=request.auth,

--- a/src/tests/api/test_order_create.py
+++ b/src/tests/api/test_order_create.py
@@ -1807,7 +1807,7 @@ def test_order_create_free(token_client, organizer, event, item, quota, question
     assert p.provider == "free"
     assert p.amount == o.total
     assert p.state == "confirmed"
-    assert o.all_logentries().count() == 2
+    assert o.all_logentries().count() == 3
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR adds an order.log_action and thus a webhook-call for confirmed payments created through the order-create-API.