### PR TITLE
Bank transfer: Do not use <pre> for bank details in emails

### DIFF
--- a/src/pretix/plugins/banktransfer/payment.py
+++ b/src/pretix/plugins/banktransfer/payment.py
@@ -457,21 +457,20 @@ class BankTransfer(BasePaymentProvider):
         t = gettext("Please transfer the full amount to the following bank account:")
         t += "\n\n"
 
-        bankdetails = []
+        md_nl2br = "  \n"
         if self.settings.get('bank_details_type') == 'sepa':
-            bankdetails += [
-                "**", _("Reference"), ":** ", self._code(order), "  \n",
-                "**", _("Amount"), ":** ", money_filter(payment.amount, self.event.currency), "  \n",
-                "**", _("Account holder"), ":** ", self.settings.get('bank_details_sepa_name'), "  \n",
-                "**", _("IBAN"), ":** ", ibanformat(self.settings.get('bank_details_sepa_iban')), "  \n",
-                "**", _("BIC"), ":** ", self.settings.get('bank_details_sepa_bic'), "  \n",
-                "**", _("Bank"), ":** ", self.settings.get('bank_details_sepa_bank'),
-            ]
-        if bankdetails and self.settings.get('bank_details', as_type=LazyI18nString):
-            bankdetails.append("  \n")
-        bankdetails.append(self.settings.get('bank_details', as_type=LazyI18nString))
-
-        t += ''.join(str(i) for i in bankdetails)
+            bankdetails = (
+                (_("Reference"), self._code(order)),
+                (_("Amount"), money_filter(payment.amount, self.event.currency)),
+                (_("Account holder"), self.settings.get('bank_details_sepa_name')),
+                (_("IBAN"), ibanformat(self.settings.get('bank_details_sepa_iban'))),
+                (_("BIC"), self.settings.get('bank_details_sepa_bic')),
+                (_("Bank"), self.settings.get('bank_details_sepa_bank')),
+            )
+            t += md_nl2br.join([f"**{k}:** {v}" for k, v in bankdetails])
+            if self.settings.get('bank_details', as_type=LazyI18nString):
+                t += md_nl2br
+        t += str(self.settings.get('bank_details', as_type=LazyI18nString))
         return t
 
     def swiss_qrbill(self, payment):

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/email/order_pending.txt
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/email/order_pending.txt
@@ -1,7 +1,0 @@
-{% load i18n %}{% load l10n %}{% load money %}{% blocktrans with bank=details|safe total=amount|money:event.currency %}
-Please transfer the full amount to the following bank account.
-
-    Reference: {{ code }}
-    Amount: {{ total }}
-{{ bank }}
-{% endblocktrans %}


### PR DESCRIPTION
The main reason for using ``<pre>`` here previously was that we did not have a good way to do force new lines otherwise, but I fixed that in 3df64a46e.