### PR TITLE
add rudimentary img support in email messages

### DIFF
--- a/doc/user/markdown.rst
+++ b/doc/user/markdown.rst
@@ -145,7 +145,7 @@ to get a better plain text representation of your text. Note however, that for
 security reasons you can only use the following HTML elements::
 
     a, abbr, acronym, b, br, code, div, em, h1, h2,
-    h3, h4, h5, h6, hr, i, li, ol, p, pre, span, strong,
+    h3, h4, h5, h6, hr, i, img, li, ol, p, pre, span, strong,
     table, tbody, td, thead, tr, ul
 
 Additionally, only the following attributes are allowed on them::
@@ -156,6 +156,7 @@ Additionally, only the following attributes are allowed on them::
     <table width="…">
     <td width="…" align="…">
     <div class="…">
+    <img src="…" alt="…" width="…" height="…">
     <p class="…">
     <span class="…">
 

--- a/src/pretix/base/templatetags/rich_text.py
+++ b/src/pretix/base/templatetags/rich_text.py
@@ -85,6 +85,7 @@ ALLOWED_TAGS = ALLOWED_TAGS_SNIPPET + [
     'h4',
     'h5',
     'h6',
+    'img',
     'pre',
     # Update doc/user/markdown.rst if you change this!
 ]
@@ -96,6 +97,7 @@ ALLOWED_ATTRIBUTES = {
     'table': ['width'],
     'td': ['width', 'align'],
     'div': ['class'],
+    'img': ['src', 'alt', 'width', 'height'],
     'p': ['class'],
     'span': ['class', 'title'],
     'ol': ['start'],


### PR DESCRIPTION
As I proposed in https://github.com/pretix/pretix/discussions/3416, I was looking for a way to include an image when sending mails to my attendees. Specifically the image was a pickup map on where a boat would pick them up. 

By modifying the files changed, I was able to get Pretix to send out mails with images. 