### PR TITLE
PProv: Implement detection of wallets such as Google Pay and Apple Pay

### DIFF
--- a/doc/development/api/payment.rst
+++ b/doc/development/api/payment.rst
@@ -70,6 +70,8 @@ The provider class
 
    .. autoattribute:: settings_form_fields
 
+   .. autoattribute:: walletqueries
+
    .. automethod:: settings_form_clean
 
    .. automethod:: settings_content_render

--- a/src/pretix/base/middleware.py
+++ b/src/pretix/base/middleware.py
@@ -249,7 +249,7 @@ class SecurityMiddleware(MiddlewareMixin):
 
         h = {
             'default-src': ["{static}"],
-            'script-src': ['{static}', 'https://checkout.stripe.com', 'https://js.stripe.com'],
+            'script-src': ['{static}', 'https://checkout.stripe.com', 'https://js.stripe.com', 'https://pay.google.com'],
             'object-src': ["'none'"],
             'frame-src': ['{static}', 'https://checkout.stripe.com', 'https://js.stripe.com'],
             'style-src': ["{static}", "{media}"],

--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -449,10 +449,13 @@ class BasePaymentProvider:
     @property
     def walletqueries(self):
         """
+        .. warning:: This property is considered **experimental**. It might change or get removed at any time without
+                     prior notice.
+
         A list of wallet payment methods that should be dynamically joined to the public name of the payment method,
         if they are available to the user.
         The detection is made on a best effort basis with no guarantees of correctness and actual availability.
-        Wallets that pretix can check for are exposed through pretix.base.payment.WalletQueries.
+        Wallets that pretix can check for are exposed through ``pretix.base.payment.WalletQueries``.
         """
         return []
 

--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -78,6 +78,16 @@ from pretix.presale.views.cart import cart_session, get_or_create_cart_id
 logger = logging.getLogger(__name__)
 
 
+class WalletQueries:
+    APPLEPAY = 'applepay'
+    GOOGLEPAY = 'googlepay'
+
+    WALLETS = (
+        (APPLEPAY, pgettext_lazy('payment', 'Apple Pay')),
+        (GOOGLEPAY, pgettext_lazy('payment', 'Google Pay')),
+    )
+
+
 class PaymentProviderForm(Form):
     def clean(self):
         cleaned_data = super().clean()
@@ -435,6 +445,16 @@ class BasePaymentProvider:
         d['_restricted_countries']._as_type = list
         d['_restrict_to_sales_channels']._as_type = list
         return d
+
+    @property
+    def walletqueries(self):
+        """
+        A list of wallet payment methods that should be dynamically joined to the public name of the payment method,
+        if they are available to the user.
+        The detection is made on a best effort basis with no guarantees of correctness and actual availability.
+        Wallets that pretix can check for are exposed through pretix.base.payment.WalletQueries.
+        """
+        return []
 
     def settings_form_clean(self, cleaned_data):
         """

--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -59,7 +59,7 @@ from pretix import __version__
 from pretix.base.decimal import round_decimal
 from pretix.base.forms import SecretKeySettingsField
 from pretix.base.models import Event, OrderPayment, OrderRefund, Quota
-from pretix.base.payment import BasePaymentProvider, PaymentException
+from pretix.base.payment import BasePaymentProvider, PaymentException, WalletQueries
 from pretix.base.plugins import get_all_plugins
 from pretix.base.services.mail import SendMailException
 from pretix.base.settings import SettingsSandbox
@@ -746,6 +746,11 @@ class StripeCC(StripeMethod):
     verbose_name = _('Credit card via Stripe')
     public_name = _('Credit card')
     method = 'cc'
+
+    @property
+    def walletqueries(self):
+        # ToDo: Check against Stripe API, if ApplePay and GooglePay are even activated/available
+        return [WalletQueries.APPLEPAY, WalletQueries.GOOGLEPAY]
 
     def payment_form_render(self, request, total) -> str:
         account = get_stripe_account_key(self)

--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -59,7 +59,9 @@ from pretix import __version__
 from pretix.base.decimal import round_decimal
 from pretix.base.forms import SecretKeySettingsField
 from pretix.base.models import Event, OrderPayment, OrderRefund, Quota
-from pretix.base.payment import BasePaymentProvider, PaymentException, WalletQueries
+from pretix.base.payment import (
+    BasePaymentProvider, PaymentException, WalletQueries,
+)
 from pretix.base.plugins import get_all_plugins
 from pretix.base.services.mail import SendMailException
 from pretix.base.settings import SettingsSandbox
@@ -750,6 +752,8 @@ class StripeCC(StripeMethod):
     @property
     def walletqueries(self):
         # ToDo: Check against Stripe API, if ApplePay and GooglePay are even activated/available
+        # This is probably only really feasable once the Payment Methods Configuration API is out of beta
+        # https://stripe.com/docs/connect/payment-method-configurations
         return [WalletQueries.APPLEPAY, WalletQueries.GOOGLEPAY]
 
     def payment_form_render(self, request, total) -> str:

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
@@ -3,6 +3,10 @@
 {% load money %}
 {% load bootstrap3 %}
 {% load rich_text %}
+{% block custom_header %}
+    {{ block.super }}
+    {% include "pretixpresale/event/fragment_walletdetection_head.html" %}
+{% endblock %}
 {% block inner %}
     {% if current_payments %}
         <p>{% trans "You already selected the following payment methods:" %}</p>
@@ -71,7 +75,8 @@
                                            {% if selected == p.provider.identifier %}checked="checked"{% endif %}
                                            id="input_payment_{{ p.provider.identifier }}"
                                            aria-describedby="payment_{{ p.provider.identifier }}"
-                                           data-toggle="radiocollapse" data-target="#payment_{{ p.provider.identifier }}"/>
+                                           data-toggle="radiocollapse" data-target="#payment_{{ p.provider.identifier }}"
+                                           data-wallets="{{ p.provider.walletqueries|join:"|" }}" />
                                     <label for="input_payment_{{ p.provider.identifier }}"><strong>{{ p.provider.public_name }}</strong></label>
                                 </p>
                             </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_walletdetection_head.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_walletdetection_head.html
@@ -1,0 +1,6 @@
+{% load static %}
+{% load compress %}
+
+{% compress js %}
+    <script type="text/javascript" src="{% static "pretixpresale/js/walletdetection.js" %}"></script>
+{% endcompress %}

--- a/src/pretix/presale/templates/pretixpresale/event/order_pay_change.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order_pay_change.html
@@ -3,6 +3,10 @@
 {% load eventurl %}
 {% load money %}
 {% block title %}{% trans "Change payment method" %}{% endblock %}
+{% block custom_header %}
+    {{ block.super }}
+    {% include "pretixpresale/event/fragment_walletdetection_head.html" %}
+{% endblock %}
 {% block content %}
     <h2>
         {% blocktrans trimmed with code=order.code %}
@@ -29,7 +33,8 @@
                                 <input type="radio" name="payment" value="{{ p.provider.identifier }}"
                                         data-parent="#payment_accordion"
                                         {% if selected == p.provider.identifier %}checked="checked"{% endif %}
-                                        data-toggle="radiocollapse" data-target="#payment_{{ p.provider.identifier }}" />
+                                        data-toggle="radiocollapse" data-target="#payment_{{ p.provider.identifier }}"
+                                        data-wallets="{{ p.provider.walletqueries|join:"|" }}"/>
                                 <strong>{{ p.provider.public_name }}</strong>
                             </label>
                         </h4>

--- a/src/pretix/static/pretixpresale/js/walletdetection.js
+++ b/src/pretix/static/pretixpresale/js/walletdetection.js
@@ -1,0 +1,120 @@
+'use strict';
+
+var walletdetection = {
+    applepay: function () {
+        // This is a weak check for Apple Pay -  in order to do a proper check, we would need to also call
+        // canMakePaymentsWithActiveCard(merchantIdentifier)
+
+        return !!(window.ApplePaySession && window.ApplePaySession.canMakePayments());
+    },
+    googlepay: function () {
+        // Checking for Google Pay is a little bit more involved, since it requires including the Google Pay JS SDK, and
+        // providing a lot of information.
+        // So for the time being, we only check if Google Pay is available in TEST-mode, which should hopefully give us a
+        // good enough idea if Google Pay could be present on this device; even though there are still a lot of other
+        // factors that could inhibit Google Pay from actually being offered to the customer.
+
+        const baseRequest = {
+            apiVersion: 2,
+            apiVersionMinor: 0
+        };
+        const tokenizationSpecification = {
+            type: 'PAYMENT_GATEWAY',
+            parameters: {
+                'gateway': 'example',
+                'gatewayMerchantId': 'exampleGatewayMerchantId'
+            }
+        };
+        const allowedCardNetworks = ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"];
+        const allowedCardAuthMethods = ["PAN_ONLY", "CRYPTOGRAM_3DS"];
+        const baseCardPaymentMethod = {
+            type: 'CARD',
+            parameters: {
+                allowedAuthMethods: allowedCardAuthMethods,
+                allowedCardNetworks: allowedCardNetworks
+            }
+        };
+        const cardPaymentMethod = Object.assign(
+            {tokenizationSpecification: tokenizationSpecification},
+            baseCardPaymentMethod
+        );
+
+        return $.ajax({
+            url: 'https://pay.google.com/gp/p/js/pay.js',
+            dataType: 'script',
+            success: function () {
+                const paymentsClient = new google.payments.api.PaymentsClient({environment: 'TEST'});
+                const isReadyToPayRequest = Object.assign({}, baseRequest);
+                isReadyToPayRequest.allowedPaymentMethods = [baseCardPaymentMethod];
+
+                paymentsClient.isReadyToPay(isReadyToPayRequest)
+                    .then(function (response) {
+                        if (response.result) {
+                            return true;
+                        }
+                    })
+                    .catch(function (err) {
+                        return false;
+                    });
+            },
+        });
+    },
+    name_map: {
+        applepay: gettext('Apple Pay'),
+        googlepay: gettext('Google Pay'),
+    }
+}
+
+$(function () {
+    let requestedWallets = Array();
+    let paymentMethods = $('[data-wallets][data-wallets!=""]');
+
+    paymentMethods.each(function () {
+        let $s = $(this);
+        requestedWallets = requestedWallets.concat($s.data("wallets").split("|"));
+    })
+
+    // Filtering out any doubles
+    requestedWallets = new Set(requestedWallets);
+
+    // Perform the actual check *only* on the requested wallets, if they are supported by the browser
+    let availableWallets = Array();
+    requestedWallets.forEach(function (it) {
+        if (walletdetection[it]()) {
+            availableWallets.push(it);
+        }
+    });
+
+    paymentMethods.each(function () {
+        let $s = $(this);
+        let wallets = Array();
+
+        // Run the translation on the available wallet strings before pushing them out.
+        $s.data("wallets").split("|").forEach(function (it) {
+            if (availableWallets.includes(it)) {
+                wallets.push(gettext(walletdetection.name_map[it]));
+            }
+        })
+
+        // In case there is no wallets available, we do not want to flicker the screen
+        if (wallets.length === 0) {
+            return;
+        }
+
+        // The first selector is used on the regular payment-step of the checkout flow
+        // The second selector is used for the payment method change view.
+        // In the long run, the layout of both pages should be adjusted to be one.
+        let textselector = $s.next('label').find('strong');
+        let textselector2 = $s.next("strong");
+        textselector.fadeOut(300, function () {
+            wallets.unshift(textselector.text());
+            textselector.text(wallets.join(", "));
+            textselector.fadeIn(300);
+        });
+        textselector2.fadeOut(300, function () {
+            wallets.unshift(textselector2.text());
+            textselector2.text(wallets.join(", "));
+            textselector2.fadeIn(300);
+        });
+    });
+});

--- a/src/pretix/static/pretixpresale/js/walletdetection.js
+++ b/src/pretix/static/pretixpresale/js/walletdetection.js
@@ -1,62 +1,37 @@
 'use strict';
 
 var walletdetection = {
-    applepay: function () {
+    applepay: async function () {
         // This is a weak check for Apple Pay -  in order to do a proper check, we would need to also call
         // canMakePaymentsWithActiveCard(merchantIdentifier)
 
         return !!(window.ApplePaySession && window.ApplePaySession.canMakePayments());
     },
-    googlepay: function () {
+    googlepay: async function () {
         // Checking for Google Pay is a little bit more involved, since it requires including the Google Pay JS SDK, and
         // providing a lot of information.
         // So for the time being, we only check if Google Pay is available in TEST-mode, which should hopefully give us a
         // good enough idea if Google Pay could be present on this device; even though there are still a lot of other
         // factors that could inhibit Google Pay from actually being offered to the customer.
 
-        const baseRequest = {
-            apiVersion: 2,
-            apiVersionMinor: 0
-        };
-        const tokenizationSpecification = {
-            type: 'PAYMENT_GATEWAY',
-            parameters: {
-                'gateway': 'example',
-                'gatewayMerchantId': 'exampleGatewayMerchantId'
-            }
-        };
-        const allowedCardNetworks = ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"];
-        const allowedCardAuthMethods = ["PAN_ONLY", "CRYPTOGRAM_3DS"];
-        const baseCardPaymentMethod = {
-            type: 'CARD',
-            parameters: {
-                allowedAuthMethods: allowedCardAuthMethods,
-                allowedCardNetworks: allowedCardNetworks
-            }
-        };
-        const cardPaymentMethod = Object.assign(
-            {tokenizationSpecification: tokenizationSpecification},
-            baseCardPaymentMethod
-        );
-
         return $.ajax({
             url: 'https://pay.google.com/gp/p/js/pay.js',
             dataType: 'script',
-            success: function () {
-                const paymentsClient = new google.payments.api.PaymentsClient({environment: 'TEST'});
-                const isReadyToPayRequest = Object.assign({}, baseRequest);
-                isReadyToPayRequest.allowedPaymentMethods = [baseCardPaymentMethod];
-
-                paymentsClient.isReadyToPay(isReadyToPayRequest)
-                    .then(function (response) {
-                        if (response.result) {
-                            return true;
-                        }
-                    })
-                    .catch(function (err) {
-                        return false;
-                    });
-            },
+        }).then(function() {
+            const paymentsClient = new google.payments.api.PaymentsClient({environment: 'TEST'});
+            return paymentsClient.isReadyToPay({
+                apiVersion: 2,
+                apiVersionMinor: 0,
+                allowedPaymentMethods: [{
+                    type: 'CARD',
+                    parameters: {
+                        allowedAuthMethods: ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+                        allowedCardNetworks: ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"]
+                    }
+                }],
+            })
+        }).then(function (response) {
+            return !!response.result;
         });
     },
     name_map: {
@@ -66,55 +41,31 @@ var walletdetection = {
 }
 
 $(function () {
-    let requestedWallets = Array();
-    let paymentMethods = $('[data-wallets][data-wallets!=""]');
-
-    paymentMethods.each(function () {
-        let $s = $(this);
-        requestedWallets = requestedWallets.concat($s.data("wallets").split("|"));
-    })
-
-    // Filtering out any doubles
-    requestedWallets = new Set(requestedWallets);
-
-    // Perform the actual check *only* on the requested wallets, if they are supported by the browser
-    let availableWallets = Array();
-    requestedWallets.forEach(function (it) {
-        if (walletdetection[it]()) {
-            availableWallets.push(it);
-        }
-    });
-
-    paymentMethods.each(function () {
-        let $s = $(this);
-        let wallets = Array();
-
-        // Run the translation on the available wallet strings before pushing them out.
-        $s.data("wallets").split("|").forEach(function (it) {
-            if (availableWallets.includes(it)) {
-                wallets.push(gettext(walletdetection.name_map[it]));
-            }
+    const wallets = $('[data-wallets]')
+        .map(function(index, pm) {
+            return pm.getAttribute("data-wallets").split("|");
         })
-
-        // In case there is no wallets available, we do not want to flicker the screen
-        if (wallets.length === 0) {
-            return;
-        }
-
-        // The first selector is used on the regular payment-step of the checkout flow
-        // The second selector is used for the payment method change view.
-        // In the long run, the layout of both pages should be adjusted to be one.
-        let textselector = $s.next('label').find('strong');
-        let textselector2 = $s.next("strong");
-        textselector.fadeOut(300, function () {
-            wallets.unshift(textselector.text());
-            textselector.text(wallets.join(", "));
-            textselector.fadeIn(300);
+        .get()
+        .flat()
+        .filter(function(item, pos, self) {
+            // filter out empty or duplicate values
+            return item && self.indexOf(item) == pos;
         });
-        textselector2.fadeOut(300, function () {
-            wallets.unshift(textselector2.text());
-            textselector2.text(wallets.join(", "));
-            textselector2.fadeIn(300);
-        });
+
+    wallets.forEach(function(wallet) {
+        const labels = $('[data-wallets*='+wallet+'] + label strong, [data-wallets*='+wallet+'] + strong')
+            .append('<span class="wallet wallet-loading"> <i aria-hidden="true" class="fa fa-cog fa-spin"></i></span>')
+        walletdetection[wallet]()
+            .then(function(result) {
+                const spans = labels.find(".wallet-loading:nth-of-type(1)");
+                if (result) {
+                    spans.removeClass('wallet-loading').hide().text(', ' + walletdetection.name_map[wallet]).fadeIn(300);
+                } else {
+                    spans.remove();
+                }
+            })
+            .catch(function(result) {
+                labels.find(".wallet-loading:nth-of-type(1)").remove();
+            })
     });
 });

--- a/src/pretix/static/pretixpresale/scss/_checkout.scss
+++ b/src/pretix/static/pretixpresale/scss/_checkout.scss
@@ -179,3 +179,7 @@
     flex: 1;
   }
 }
+
+.wallet-loading + .wallet-loading {
+  display: none;
+}


### PR DESCRIPTION
Until now, we have never actively advertised card tokenization wallet-payment methods such as Apple or Google Pay in the payment provider selection screen.

This is based on the fact, that there are a lot of factors involved in deciding if the wallet payment method is actually offered to the customer: browser, browser settings (incognito/regular), cards added to the wallet, payment-gateway support, merchant enrollment, etc.

So we ended up only displaying "Credit Card" on the selection screen and leaving it up to the payment provider to render one or more wallet payment buttons if they deemed it appropriate.

Understandably, some event organizers do not like this, since their customers do not realize that Apple Pay/Google Pay is just a glorified credit card transaction and wouldn't think of clicking on the Credit Card payment option.

This PR is an attempt at remedying this situation.

- A payment provider can now optionally declare a list of `walletqueries`. These are added to the payment method selection accordions on the checkout and order change pages.
- It is the job of the payment provider to only request those wallets, which - to it's best knowledge - are available to the user. So if payment provider knows that a certain wallet is not available to the merchant (Example for Stripe: disabled in the Stripe Dashboard), it should not query for that wallet.
- Client-side, a JS will aggregate the requested wallets and then attempt a best-effort check of the availability of said wallets.
- If the requested wallet is available, the JS will (similar to PayPal2) add the name of the wallet to the public_name of the payment method.

The biggest caveat of this solution is that it cannot be 100% precise:
- For Apple Pay, we only call `canMakePayments()`. In order to get a more precise result, we would need to call `canMakePaymentsWithActiveCard(merchantIdentifier)`. But since in 99% of all cases, we do not have the `merchantIdentifier`, this is impossible.
- For Google Pay, we only check the availability using `test` parameters. As with Apple Pay, one would need the real/live gateway type, merchantId and gatewayMerchantId. In addition, a proper PaymentRequest would need to be constructed, passing the desired card networks, amount, etc. - something we do not have most of the time. By checking against the test-gateway, we only check if the device is capable of doing a Google Pay transaction in theory, which hopefully is enough.
- In order to check for Google Pay availability, we need to include the Google Pay JS-SDK.

In theory, we could provide facilities for payment providers to expose their merchantIdentifiers and query with them - but seeing how none of our currently implemented payment providers allow for this, I think we can skip over this.

I do not know how precise this detection is (especially for Google Pay) - so I think we should merge it but perhaps declare it as experimental?