### PR TITLE
banktransfer: show swiss QR bill code for non-CH IBANs, too

### DIFF
--- a/src/pretix/plugins/banktransfer/payment.py
+++ b/src/pretix/plugins/banktransfer/payment.py
@@ -479,7 +479,7 @@ class BankTransfer(BasePaymentProvider):
         return t
 
     def swiss_qrbill(self, payment):
-        if not self.settings.get('bank_details_sepa_iban') or not self.settings.get('bank_details_sepa_iban')[:2] in ('CH', 'LI'):
+        if not self.settings.get('bank_details_sepa_iban'):
             return
         if self.event.currency not in ('EUR', 'CHF'):
             return


### PR DESCRIPTION
I have bought tickets to two events that use pretix recently, and both times I could not do the bank transfer with my online banking app, because the swiss QR bill code was not displayed.

The current check does not make sense: A swiss QR bill code should be presented to guests with a swiss bank account, not just for events that have a swiss bank account.