### PR TITLE
Badges: reduce memory usage when placing multiple per page (Z#23125583)

### DIFF
--- a/src/pretix/base/exporter.py
+++ b/src/pretix/base/exporter.py
@@ -140,7 +140,7 @@ class BaseExporter:
         """
         return {}
 
-    def render(self, form_data: dict) -> Tuple[str, str, bytes]:
+    def render(self, form_data: dict) -> Tuple[str, str, Optional[bytes]]:
         """
         Render the exported file and return a tuple consisting of a filename, a file type
         and file content.

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1034,9 +1034,11 @@ class Renderer:
             output = PdfWriter()
 
             for i, page in enumerate(new_pdf.pages):
-                bg_page = copy.copy(self.bg_pdf.pages[i])
+                bg_page = self.bg_pdf.pages[i]
                 bg_rotation = bg_page.get('/Rotate')
                 if bg_rotation:
+                    # as we mess with the page, copy it first
+                    bg_page = copy.copy(bg_page)
                     # /Rotate is clockwise, transformation.rotate is counter-clockwise
                     t = Transformation().rotate(bg_rotation)
                     w = float(page.mediabox.getWidth())

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1033,11 +1033,9 @@ class Renderer:
             output = PdfWriter()
 
             for i, page in enumerate(new_pdf.pages):
-                bg_page = self.bg_pdf.pages[i]
+                bg_page = copy.deepcopy(self.bg_pdf.pages[i])
                 bg_rotation = bg_page.get('/Rotate')
                 if bg_rotation:
-                    # as we mess with the page, copy it first
-                    bg_page = copy.copy(bg_page)
                     # /Rotate is clockwise, transformation.rotate is counter-clockwise
                     t = Transformation().rotate(bg_rotation)
                     w = float(page.mediabox.getWidth())
@@ -1094,11 +1092,9 @@ def merge_background(fg_pdf, bg_pdf, compress):
     else:
         output = PdfWriter()
         for i, page in enumerate(fg_pdf.pages):
-            bg_page = bg_pdf.pages[i]
+            bg_page = copy.deepcopy(bg_pdf.pages[i])
             bg_rotation = bg_page.get('/Rotate')
             if bg_rotation:
-                # as we change that page, better copy the page to not mess up the original?
-                # bg_page = copy.copy(bg_page)
                 # /Rotate is clockwise, transformation.rotate is counter-clockwise
                 t = Transformation().rotate(bg_rotation)
                 w = float(page.mediabox.getWidth())

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -61,7 +61,8 @@ from django.utils.html import conditional_escape
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _, pgettext
 from i18nfield.strings import LazyI18nString
-from pypdf import PdfReader
+from pypdf import PdfReader, PdfWriter, Transformation
+from pypdf.generic import RectangleObject
 from reportlab.graphics import renderPDF
 from reportlab.graphics.barcode.qr import QrCodeWidget
 from reportlab.graphics.shapes import Drawing
@@ -1027,8 +1028,6 @@ class Renderer:
                 with open(os.path.join(d, 'out.pdf'), 'rb') as f:
                     return BytesIO(f.read())
         else:
-            from pypdf import PdfReader, PdfWriter, Transformation
-            from pypdf.generic import RectangleObject
             buffer.seek(0)
             new_pdf = PdfReader(buffer)
             output = PdfWriter()
@@ -1072,6 +1071,7 @@ class Renderer:
             outbuffer.seek(0)
             return outbuffer
 
+
 def merge_background(fg_pdf, bg_pdf, compress):
     if settings.PDFTK:
         with tempfile.TemporaryDirectory() as d:
@@ -1092,14 +1092,13 @@ def merge_background(fg_pdf, bg_pdf, compress):
             p = subprocess.run(pdftk_cmd, check=True, capture_output=True)
             return BytesIO(p.stdout)
     else:
-        from pypdf import PdfWriter
         output = PdfWriter()
         for i, page in enumerate(fg_pdf.pages):
             bg_page = bg_pdf.pages[i]
             bg_rotation = bg_page.get('/Rotate')
             if bg_rotation:
                 # as we change that page, better copy the page to not mess up the original?
-                #bg_page = copy.copy(bg_page)
+                # bg_page = copy.copy(bg_page)
                 # /Rotate is clockwise, transformation.rotate is counter-clockwise
                 t = Transformation().rotate(bg_rotation)
                 w = float(page.mediabox.getWidth())
@@ -1127,6 +1126,7 @@ def merge_background(fg_pdf, bg_pdf, compress):
         output.write(outbuffer)
         outbuffer.seek(0)
         return outbuffer
+
 
 @deconstructible
 class PdfLayoutValidator:

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1079,15 +1079,17 @@ def merge_background(fg_pdf, bg_pdf, compress):
             bg_filename = os.path.join(d, 'bg.pdf')
             fg_pdf.write(fg_filename)
             bg_pdf.write(bg_filename)
-            p = subprocess.run([
+            pdftk_cmd = [
                 settings.PDFTK,
                 fg_filename,
                 'multibackground',
                 bg_filename,
                 'output',
-                '-',
-                'compress' if compress else ''
-            ], check=True, capture_output=True)
+                '-'
+            ]
+            if compress:
+                pdftk_cmd.append('compress')
+            p = subprocess.run(pdftk_cmd, check=True, capture_output=True)
             return BytesIO(p.stdout)
     else:
         output = PdfWriter()

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1092,6 +1092,7 @@ def merge_background(fg_pdf, bg_pdf, compress):
             p = subprocess.run(pdftk_cmd, check=True, capture_output=True)
             return BytesIO(p.stdout)
     else:
+        from pypdf import PdfWriter
         output = PdfWriter()
         for i, page in enumerate(fg_pdf.pages):
             bg_page = bg_pdf.pages[i]

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1070,7 +1070,7 @@ class Renderer:
             return outbuffer
 
 
-def merge_background(fg_pdf, bg_pdf, compress):
+def merge_background(fg_pdf, bg_pdf, out_file, compress):
     if settings.PDFTK:
         with tempfile.TemporaryDirectory() as d:
             fg_filename = os.path.join(d, 'fg.pdf')
@@ -1083,12 +1083,11 @@ def merge_background(fg_pdf, bg_pdf, compress):
                 'multibackground',
                 bg_filename,
                 'output',
-                '-'
+                '-',
             ]
             if compress:
                 pdftk_cmd.append('compress')
-            p = subprocess.run(pdftk_cmd, check=True, capture_output=True)
-            return BytesIO(p.stdout)
+            subprocess.run(pdftk_cmd, check=True, stdout=out_file)
     else:
         output = PdfWriter()
         for i, page in enumerate(fg_pdf.pages):
@@ -1118,10 +1117,7 @@ def merge_background(fg_pdf, bg_pdf, compress):
                 page.add_transformation(t)
             bg_page.merge_page(page)
             output.add_page(bg_page)
-        outbuffer = BytesIO()
-        output.write(outbuffer)
-        outbuffer.seek(0)
-        return outbuffer
+        output.write(out_file)
 
 
 @deconstructible

--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -63,7 +63,7 @@ from reportlab.pdfgen import canvas
 from pretix.base.exporter import BaseExporter
 from pretix.base.i18n import language
 from pretix.base.models import Order, OrderPosition, Question, QuestionAnswer
-from pretix.base.pdf import merge_background, Renderer
+from pretix.base.pdf import Renderer, merge_background
 from pretix.base.services.export import ExportError
 from pretix.base.settings import PERSON_NAME_SCHEMES
 from pretix.helpers.templatetags.jsonfield import JSONExtract
@@ -223,7 +223,7 @@ def render_pdf(event, positions, opt):
             bg_pdf.add_page(renderer.bg_pdf.pages[i])
         num_pages = new_num_pages
 
-    outbuffer = merge_background(fg_pdf, bg_pdf, compress=badges_per_page==1)
+    outbuffer = merge_background(fg_pdf, bg_pdf, compress=badges_per_page == 1)
 
     if badges_per_page == 1:
         # no need to place multiple badges on one page

--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -232,7 +232,7 @@ def render_pdf(event, positions, opt):
         '/Creator': 'pretix',
     })
     nup_page = None
-    max_nup_pages = 100
+    max_nup_pages = 20
     nup_pdf_files = []
     temp_dir = None
     merger = None

--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -213,7 +213,7 @@ def render_pdf(event, positions, opt):
             page.setPageSize(opt['pagesize'])
         page.save()
         buffer = renderer.render_background(buffer, _('Badge'))
-        merger.append(ContentFile(buffer.read()))
+        merger.append(buffer)
 
     outbuffer = BytesIO()
     merger.write(outbuffer)

--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -377,7 +377,7 @@ def render_pdf(event, positions, opt, output_file):
                 # that not every position has the same number of pages, as the n-up code can deal with that
                 fg_pdf, bg_pdf, num_pages = _render_badges(event, position_chunk, opt)
                 out_pdf_name = os.path.join(tmp_dir, f'chunk-{len(page_pdfs)}.pdf')
-                with open(out_pdf_name, 'w') as out_pdf:
+                with open(out_pdf_name, 'wb') as out_pdf:
                     merge_background(
                         fg_pdf,
                         bg_pdf,

--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -377,12 +377,13 @@ def render_pdf(event, positions, opt, output_file):
                 # that not every position has the same number of pages, as the n-up code can deal with that
                 fg_pdf, bg_pdf, num_pages = _render_badges(event, position_chunk, opt)
                 out_pdf_name = os.path.join(tmp_dir, f'chunk-{len(page_pdfs)}.pdf')
-                merge_background(
-                    fg_pdf,
-                    bg_pdf,
-                    out_pdf_name,
-                    compress=False,
-                )
+                with open(out_pdf_name, 'w') as out_pdf:
+                    merge_background(
+                        fg_pdf,
+                        bg_pdf,
+                        out_pdf,
+                        compress=False,
+                    )
                 page_pdfs.append(out_pdf_name)
                 total_num_pages += num_pages
                 del fg_pdf, bg_pdf  # free up memory

--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -377,13 +377,12 @@ def render_pdf(event, positions, opt, output_file):
                 # that not every position has the same number of pages, as the n-up code can deal with that
                 fg_pdf, bg_pdf, num_pages = _render_badges(event, position_chunk, opt)
                 out_pdf_name = os.path.join(tmp_dir, f'chunk-{len(page_pdfs)}.pdf')
-                with open(out_pdf_name, 'w') as out_pdf:
-                    merge_background(
-                        fg_pdf,
-                        bg_pdf,
-                        out_pdf,
-                        compress=False,
-                    )
+                merge_background(
+                    fg_pdf,
+                    bg_pdf,
+                    out_pdf_name,
+                    compress=False,
+                )
                 page_pdfs.append(out_pdf_name)
                 total_num_pages += num_pages
                 del fg_pdf, bg_pdf  # free up memory


### PR DESCRIPTION
This PR tries to optimize memory usage when placing multiple badges on one page. Previously the whole single-page PDF was held in memory as well as the NUP-PDF. This PR changes it so the NUP-PDF is split into several tempfiles (currently every 100 pages, not sure what a good value for this is though), then releases the single-page PDF from memory and joins the NUP-tempfiles into one big PDF.