### PR TITLE
PDF: fix export with the same image used multiple times (Z#23126314)

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -866,7 +866,7 @@ class Renderer:
 
         if image_file:
             try:
-                ir = ThumbnailingImageReader(image_file)
+                ir = ThumbnailingImageReader(image_file.path)
                 ir.resize(float(o['width']) * mm, float(o['height']) * mm, 300)
                 canvas.drawImage(
                     image=ir,


### PR DESCRIPTION
When exporting e.g. badges that use an image from a question multiple times, when exporting mutliple badges at once, the export failed with a closed-file error:

```
ERROR 2023-07-21 08:39:11,525 pretix.base.pdf pdf Can not load or resize image
Traceback (most recent call last):
  File "/Users/rami/Code/pretix/pretix/env/lib/python3.9/site-packages/reportlab/lib/utils.py", line 645, in __init__
    tfp, fp = fp, BytesIO(fp.read())
ValueError: read of closed file

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/rami/Code/pretix/pretix/src/pretix/base/pdf.py", line 866, in _draw_imagearea
    ir = ThumbnailingImageReader(image_file)
  File "/Users/rami/Code/pretix/pretix/env/lib/python3.9/site-packages/reportlab/lib/utils.py", line 655, in __init__
    annotateException('\nfileName=%r identity=%s'%(fileName,self.identity()))
  File "/Users/rami/Code/pretix/pretix/env/lib/python3.9/site-packages/reportlab/lib/utils.py", line 1176, in annotateException
    rl_reraise(t,t(sep.join((_ for _ in (msg,str(v),postMsg) if _))),b)
  File "/Users/rami/Code/pretix/pretix/env/lib/python3.9/site-packages/reportlab/lib/utils.py", line 138, in rl_reraise
    raise v.with_traceback(b)
  File "/Users/rami/Code/pretix/pretix/env/lib/python3.9/site-packages/reportlab/lib/utils.py", line 645, in __init__
    tfp, fp = fp, BytesIO(fp.read())
ValueError: 
fileName=<FieldFile: cachedfiles/answers/rocking-50ies/rockclock/Ptt9B8D7reMRME3PLGVJh8ZhRo3vXij2.richard-profil.jpeg> identity=[ThumbnailingImageReader@0x115629a00] read of closed file
```

I could not find out why this happens when exporting multiple badges, but does not happen when exporting one single badge that uses the same question/answer-image twice.

Honestly, this PR feels a bit like a hack, so feel free to dismiss.