### PR TITLE
Recognise `title` and `template` attributes on `item_forms` signal

### DIFF
--- a/src/pretix/control/signals.py
+++ b/src/pretix/control/signals.py
@@ -304,6 +304,10 @@ an instance of a form class that you bind yourself when appropriate. Your form w
 as part of the standard validation and rendering cycle and rendered using default bootstrap
 styles. It is advisable to set a prefix for your form to avoid clashes with other plugins.
 
+Your forms may also have two special properties: ``template`` with a template that will be
+included to render the form, and ``title``, which will be used as a headline. Your template
+will be passed a ``form`` variable with your form.
+
 As with all plugin signals, the ``sender`` keyword argument will contain the event.
 """
 

--- a/src/pretix/control/templates/pretixcontrol/item/index.html
+++ b/src/pretix/control/templates/pretixcontrol/item/index.html
@@ -187,7 +187,11 @@
                         {% endif %}
                         {% for f in plugin_forms %}
                             {% if f.is_layouts and not f.title %}
-                                {% bootstrap_form f layout="control" %}
+                                {% if f.template %}
+                                    {% include f.template with form=f %}
+                                {% else %}
+                                    {% bootstrap_form f layout="control" %}
+                                {% endif %}
                             {% endif %}
                         {% endfor %}
                     </fieldset>
@@ -257,7 +261,11 @@
                         {% bootstrap_field form.show_quota_left layout="control" %}
                         {% for f in plugin_forms %}
                             {% if not f.is_layouts and not f.title %}
-                                {% bootstrap_form f layout="control" %}
+                                {% if f.template %}
+                                    {% include f.template with form=f %}
+                                {% else %}
+                                    {% bootstrap_form f layout="control" %}
+                                {% endif %}
                             {% endif %}
                         {% endfor %}
                     </fieldset>

--- a/src/pretix/control/templates/pretixcontrol/item/index.html
+++ b/src/pretix/control/templates/pretixcontrol/item/index.html
@@ -186,7 +186,7 @@
                             {% bootstrap_field form.media_type layout="control" %}
                         {% endif %}
                         {% for f in plugin_forms %}
-                            {% if f.is_layouts %}
+                            {% if f.is_layouts and not f.title %}
                                 {% bootstrap_form f layout="control" %}
                             {% endif %}
                         {% endfor %}
@@ -256,11 +256,23 @@
                         {% endif %}
                         {% bootstrap_field form.show_quota_left layout="control" %}
                         {% for f in plugin_forms %}
-                            {% if not f.is_layouts %}
+                            {% if not f.is_layouts and not f.title %}
                                 {% bootstrap_form f layout="control" %}
                             {% endif %}
                         {% endfor %}
                     </fieldset>
+                    {% for f in plugin_forms %}
+                        {% if not f.is_layouts and f.title %}
+                            <fieldset>
+                                <legend>{{ f.title }}</legend>
+                                {% if f.template %}
+                                    {% include f.template with form=f %}
+                                {% else %}
+                                    {% bootstrap_form f layout="control" %}
+                                {% endif %}
+                            </fieldset>
+                        {% endif %}
+                    {% endfor %}
                 </div>
                 <div class="form-group submit-group">
                     <button type="submit" class="btn btn-primary btn-save">

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -1302,9 +1302,6 @@ class ItemUpdateGeneral(ItemDetailMixin, EventPermissionRequiredMixin, MetaDataE
             if has_truthy_attr(form, "title") and has_truthy_attr(form, "is_layout"):
                 raise ValueError("`title` and `is_layout` must not both be truthy values")
 
-            if has_truthy_attr(form, "template") and not has_truthy_attr(form, "title"):
-                raise Exception("If `template` is set, so must `title`")
-
         return forms
 
     def get_success_url(self) -> str:

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -88,6 +88,10 @@ from ...helpers.compat import CompatDeleteView
 from . import ChartContainingView, CreateView, PaginationMixin, UpdateView
 
 
+def has_truthy_attr(cls, attr):
+    return hasattr(cls, attr) and getattr(cls, attr)
+
+
 class ItemList(ListView):
     model = Item
     context_object_name = 'items'
@@ -1293,6 +1297,14 @@ class ItemUpdateGeneral(ItemDetailMixin, EventPermissionRequiredMixin, MetaDataE
                 forms.extend(resp)
             else:
                 forms.append(resp)
+
+        for form in forms:
+            if has_truthy_attr(form, "title") and has_truthy_attr(form, "is_layout"):
+                raise ValueError("`title` and `is_layout` must not both be truthy values")
+
+            if has_truthy_attr(form, "template") and not has_truthy_attr(form, "title"):
+                raise Exception("If `template` is set, so must `title`")
+
         return forms
 
     def get_success_url(self) -> str:


### PR DESCRIPTION
The forms returned by the `item_forms` signal can now set the `title` and (optional) `template` attributes, which behave in the same way as `item_formsets`.

This was proposed in https://github.com/pretix/pretix/discussions/3480.

Currently, there are no automated tests for this feature, which is not ideal. I'm happy to work on some tests if you think it's necessary.