### PR TITLE
Sidebar dropdown: remove menu load delay

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/typeahead.js
+++ b/src/pretix/static/pretixcontrol/js/ui/typeahead.js
@@ -1,7 +1,7 @@
 /*global $,u2f */
 $(function () {
     $('.sidebar .dropdown, ul.navbar-nav .dropdown, .navbar-events-collapse').on('shown.bs.collapse shown.bs.dropdown', function () {
-        $(this).parent().find("input").val("").change().focus();
+        $(this).parent().find("input").val("").trigger('forceRunQuery').focus();
     });
     $('.dropdown-menu .form-box input').click(function (e) {
         e.stopPropagation();
@@ -115,6 +115,9 @@ $(function () {
                 }
             );
         }
+        $query.on("forceRunQuery", function () {
+            runQuery();
+        });
         $query.on("change", function () {
             if ($container.attr("data-typeahead-field") && $query.val() === "") {
                 $container.removeClass('focused');


### PR DESCRIPTION
This forces a query of the typeahead menu to immediately occur once the sidebar dropdown is opened by the user, instead of waiting 250ms. 

The delay causes UX problems as users might see that the menu is empty and immediately close it again, not noticing that options would be available after a delay.