### PR TITLE
Import: Allow to import "False"-value (Z#23127414)

### DIFF
--- a/src/pretix/base/orderimport.py
+++ b/src/pretix/base/orderimport.py
@@ -805,7 +805,7 @@ class QuestionColumn(ImportColumn):
                 return self.q.clean_answer(value)
 
     def assign(self, value, order, position, invoice_address, **kwargs):
-        if value:
+        if value is not None:
             if not hasattr(order, '_answers'):
                 order._answers = []
             if isinstance(value, QuestionOption):


### PR DESCRIPTION
As of right now, it is only possible to import `True` values for Yes/Now-Questions, because `if value` on a bool is always skipped if the value happens to be `False`.

This should remedy the situation.

However with this change, there are only two ways to get a non-`False` value into the database:
- Verbatim `True` --> `True`
- `None` --> `None`/Not answered

Everything else will be `False`; without this change, everything else would have been `None`/Not answered.