### PR TITLE
Cart: Disable sneak peek on very small carts

### DIFF
--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -4,9 +4,18 @@ setup_collapsible_details = function (el) {
 
     el.find('details.sneak-peek:not([open])').each(function() {
         this.open = true;
-        var $elements = $("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)').attr('aria-hidden', 'true');
-
+        var $elements = $("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)');
         var container = this;
+
+        if ($("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)').height() < 200) {
+            $(".sneak-peek-trigger", this).remove();
+            $(container).removeClass('sneak-peek');
+            container.style.removeProperty('height');
+            return;
+        }
+
+        $elements.attr('aria-hidden', 'true');
+
         var trigger = $('summary, .sneak-peek-trigger button', container);
         function onclick(e) {
             e.preventDefault();


### PR DESCRIPTION
Recently, we have introduced a "almost collapsed" state for the cart:

![image](https://github.com/pretix/pretix/assets/64280/066a842c-f9d3-44fb-9d16-4926b0c7cfef)

This however feels odd if the fully expanded cart is only a few pixels larger than the collapsed one. Therefore this PR adds a heuristic to only collapse when the full cart would take more than 200px