### PR TITLE
Voucher redemption: Display event title in some cases (Z#23127871)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
@@ -1,0 +1,66 @@
+{% load i18n %}
+{% load eventurl %}
+{% if ev.location and show_location %}
+    <div class="info-row">
+        <span class="fa fa-map-marker fa-fw" aria-hidden="true" title="{% trans "Where does the event happen?" %}"></span>
+        <p><span class="sr-only">{% trans "Where does the event happen?" %}</span>
+            {{ ev.location|linebreaksbr }}
+        </p>
+    </div>
+{% endif %}
+{% if ev.settings.show_dates_on_frontpage %}
+    <div class="info-row">
+        <span class="fa fa-clock-o fa-fw" aria-hidden="true" title="{% trans "When does the event happen?" %}"></span>
+        <p><span class="sr-only">{% trans "When does the event happen?" %}</span>
+            {{ ev.get_date_range_display_as_html }}
+            {% if event.settings.show_times %}
+                <br>
+                <span data-time="{{ ev.date_from.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                    {% with time_human=ev.date_from|date:"TIME_FORMAT" time_24=ev.date_from|time:"H:i" %}
+                        {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
+                            Begin: {{ time }}
+                        {% endblocktrans %}
+                    {% endwith %}
+                </span>
+                {% if event.settings.show_date_to and ev.date_to %}
+                    <br>
+                    <span data-time="{{ ev.date_to.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                        {% with time_human=ev.date_to|date:"TIME_FORMAT" time_24=ev.date_to|time:"H:i" %}
+                            {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
+                                End: {{ time }}
+                            {% endblocktrans %}
+                        {% endwith %}
+                    </span>
+                {% endif %}
+            {% endif %}
+            {% if ev.date_admission %}
+                <br>
+                {% if ev.date_admission|date:"SHORT_DATE_FORMAT" == ev.date_from|date:"SHORT_DATE_FORMAT" %}
+                    <span data-time="{{ ev.date_admission.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                        {% with time_human=ev.date_admission|date:"TIME_FORMAT" time_24=ev.date_admission|time:"H:i" %}
+                            {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
+                                Admission: {{ time }}
+                            {% endblocktrans %}
+                        {% endwith %}
+                    </span>
+                {% else %}
+                    <span data-time="{{ ev.date_admission.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                        {% with datetime_human=ev.date_admission|date:"SHORT_DATETIME_FORMAT" datetime_iso=ev.date_admission|time:"Y-m-d H:i" %}
+                            {% blocktrans trimmed with datetime='<time datetime="'|add:datetime_iso|add:'">'|add:datetime_human|add:"</time>"|safe %}
+                                Admission: {{ datetime }}
+                            {% endblocktrans %}
+                        {% endwith %}
+                    </span>
+                {% endif %}
+            {% endif %}
+            <br>
+            {% if subevent %}
+                <a href="{% eventurl event "presale:event.ical.download" subevent=subevent.pk %}">
+            {% else %}
+                <a href="{% eventurl event "presale:event.ical.download" %}">
+            {% endif %}
+            {% trans "Add to Calendar" %}
+            </a>
+        </p>
+    </div>
+{% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -162,73 +162,8 @@
         {% endif %}
         {% if not cart_namespace or subevent %}
             <div>
-                {% if ev.location %}
-                    <div class="info-row">
-                        <span class="fa fa-map-marker fa-fw" aria-hidden="true" title="{% trans "Where does the event happen?" %}"></span>
-                        <p><span class="sr-only">{% trans "Where does the event happen?" %}</span>
-                            {{ ev.location|linebreaksbr }}
-                        </p>
-                    </div>
-                {% endif %}
-                {% if ev.settings.show_dates_on_frontpage %}
-                    <div class="info-row">
-                        <span class="fa fa-clock-o fa-fw" aria-hidden="true" title="{% trans "When does the event happen?" %}"></span>
-                        <p><span class="sr-only">{% trans "When does the event happen?" %}</span>
-                            {{ ev.get_date_range_display_as_html }}
-                            {% if event.settings.show_times %}
-                                <br>
-                                <span data-time="{{ ev.date_from.isoformat }}" data-timezone="{{ request.event.timezone }}">
-                                {% with time_human=ev.date_from|date:"TIME_FORMAT" time_24=ev.date_from|time:"H:i" %}
-                                    {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
-                                        Begin: {{ time }}
-                                    {% endblocktrans %}
-                                {% endwith %}
-                                </span>
-                                {% if event.settings.show_date_to and ev.date_to %}
-                                    <br>
-                                    <span data-time="{{ ev.date_to.isoformat }}" data-timezone="{{ request.event.timezone }}">
-                                    {% with time_human=ev.date_to|date:"TIME_FORMAT" time_24=ev.date_to|time:"H:i" %}
-                                        {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
-                                            End: {{ time }}
-                                        {% endblocktrans %}
-                                    {% endwith %}
-                                   </span>
-                                {% endif %}
-                            {% endif %}
-                            {% if ev.date_admission %}
-                                <br>
-                                {% if ev.date_admission|date:"SHORT_DATE_FORMAT" == ev.date_from|date:"SHORT_DATE_FORMAT" %}
-                                    <span data-time="{{ ev.date_admission.isoformat }}" data-timezone="{{ request.event.timezone }}">  
-                                    {% with time_human=ev.date_admission|date:"TIME_FORMAT" time_24=ev.date_admission|time:"H:i" %}
-                                        {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
-                                            Admission: {{ time }}
-                                        {% endblocktrans %}
-                                    {% endwith %}
-                                    </span>
-                                {% else %}
-                                    <span data-time="{{ ev.date_admission.isoformat }}" data-timezone="{{ request.event.timezone }}">
-                                    {% with datetime_human=ev.date_admission|date:"SHORT_DATETIME_FORMAT" datetime_iso=ev.date_admission|time:"Y-m-d H:i" %}
-                                        {% blocktrans trimmed with datetime='<time datetime="'|add:datetime_iso|add:'">'|add:datetime_human|add:"</time>"|safe %}
-                                            Admission: {{ datetime }}
-                                        {% endblocktrans %}
-                                    {% endwith %}
-                                    </span>
-                                {% endif %}
-                            {% endif %}
-                            <br>
-                            {% if subevent %}
-                                <a href="{% eventurl event "presale:event.ical.download" subevent=subevent.pk %}">
-                            {% else %}
-                                <a href="{% eventurl event "presale:event.ical.download" %}">
-                            {% endif %}
-                                {% trans "Add to Calendar" %}
-                            </a>
-                        </p>
-                    </div>
-                {% endif %}
-
+                {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=subevent ev=ev show_location=True %}
             </div>
-
             {% eventsignal event "pretix.presale.signals.front_page_top" request=request subevent=subevent %}
         {% endif %}
 

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -21,7 +21,7 @@
             </div>
         {% endif %}
         <h3>{{ subevent.name }}</h3>
-            {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=subevent ev=subevent show_location=True %}
+        {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=subevent ev=subevent show_location=True %}
     {% else %}
         {% if event_logo and event_logo_show_title %}
             <h2 class="content-header">

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -21,9 +21,7 @@
             </div>
         {% endif %}
         <h3>{{ subevent.name }}</h3>
-        {% with ev=subevent %}
             {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=subevent ev=subevent show_location=True %}
-        {% endwith %}
     {% else %}
         {% if event_logo and event_logo_show_title %}
             <h2 class="content-header">

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -13,9 +13,8 @@
         {% include "pretixpresale/event/fragment_cart_box.html" with open=request.GET.show_cart %}
     {% endif %}
 
-    <h2>{% trans "Voucher redemption" %}</h2>
-
     {% if subevent %}
+        <h2>{% trans "Voucher redemption" %}</h2>
         {% if request.GET.subevent and subevent.pk|stringformat:"i" != request.GET.subevent %}
             <div class="alert alert-warning">
                 {% trans "This voucher is valid only for the following specific date and time." %}
@@ -23,53 +22,21 @@
         {% endif %}
         <h3>{{ subevent.name }}</h3>
         {% with ev=subevent %}
-            <div class="info-row">
-                <span class="fa fa-clock-o fa-fw" aria-hidden="true"></span>
-                <p>
-                    {{ ev.get_date_range_display_as_html }}
-                    {% if event.settings.show_times %}
-                        <br>
-                        {% with time_human=ev.date_from|date:"TIME_FORMAT" time_24=ev.date_from|time:"H:i" %}
-                            {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
-                                Begin: {{ time }}
-                            {% endblocktrans %}
-                        {% endwith %}
-                        {% if event.settings.show_date_to and ev.date_to %}
-                            <br>
-                            {% with time_human=ev.date_to|date:"TIME_FORMAT" time_24=ev.date_to|time:"H:i" %}
-                                {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
-                                    End: {{ time }}
-                                {% endblocktrans %}
-                            {% endwith %}
-                        {% endif %}
-                    {% endif %}
-                    {% if ev.date_admission %}
-                        <br>
-                        {% if ev.date_admission|date:"SHORT_DATE_FORMAT" == ev.date_from|date:"SHORT_DATE_FORMAT" %}
-                            {% with time_human=ev.date_admission|date:"TIME_FORMAT" time_24=ev.date_admission|time:"H:i" %}
-                                {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
-                                    Admission: {{ time }}
-                                {% endblocktrans %}
-                            {% endwith %}
-                        {% else %}
-                            {% with datetime_human=ev.date_admission|date:"SHORT_DATETIME_FORMAT" datetime_iso=ev.date_admission|time:"Y-m-d H:i" %}
-                                {% blocktrans trimmed with datetime='<time datetime="'|add:datetime_iso|add:'">'|add:datetime_human|add:"</time>"|safe %}
-                                    Admission: {{ datetime }}
-                                {% endblocktrans %}
-                            {% endwith %}
-                        {% endif %}
-                    {% endif %}
-                    <br>
-                    {% if subevent %}
-                        <a href="{% eventurl event "presale:event.ical.download" subevent=subevent.pk %}">
-                    {% else %}
-                        <a href="{% eventurl event "presale:event.ical.download" %}">
-                    {% endif %}
-                        {% trans "Add to Calendar" %}
-                    </a>
-                </p>
-            </div>
+            {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=subevent ev=subevent show_location=True %}
         {% endwith %}
+    {% else %}
+        {% if event_logo and event_logo_show_title %}
+            <h2 class="content-header">
+                {{ event.name }}
+                {% if request.event.settings.show_dates_on_frontpage %}
+                    <small>{{ event.get_date_range_display_as_html }}</small>
+                {% endif %}
+            </h2>
+            {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=None ev=request.event show_location=True %}
+            <h3>{% trans "Voucher redemption" %}</h3>
+        {% else %}
+            <h2>{% trans "Voucher redemption" %}</h2>
+        {% endif %}
     {% endif %}
 
     <p>


### PR DESCRIPTION
If you have an event logo that does not include the event name, and have therefore enabled the "show event title anyways" option in the design settings, users who enter the shop through the voucher redemption page will not know what event they are buying for. This PR tries to fix that in the least invasive way possible.