### PR TITLE
Check-in rules: New variables

### DIFF
--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -265,7 +265,7 @@ class CheckinList(LoggedModel):
         # * in pretix.helpers.jsonlogic_boolalg
         # * in checkinrules.js
         # * in libpretixsync
-        # * in pretixscan-ios (in the future)
+        # * in pretixscan-ios
         top_level_operators = {
             '<', '<=', '>', '>=', '==', '!=', 'inList', 'isBefore', 'isAfter', 'or', 'and'
         }
@@ -274,7 +274,7 @@ class CheckinList(LoggedModel):
         }
         allowed_vars = {
             'product', 'variation', 'now', 'now_isoweekday', 'entries_number', 'entries_today', 'entries_days',
-            'minutes_since_last_entry', 'minutes_since_first_entry',
+            'minutes_since_last_entry', 'minutes_since_first_entry', 'gate',
         }
         if not rules or not isinstance(rules, dict):
             return rules

--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -270,7 +270,7 @@ class CheckinList(LoggedModel):
             '<', '<=', '>', '>=', '==', '!=', 'inList', 'isBefore', 'isAfter', 'or', 'and'
         }
         allowed_operators = top_level_operators | {
-            'buildTime', 'objectList', 'lookup', 'var',
+            'buildTime', 'objectList', 'lookup', 'var', 'entries_since', 'entries_before'
         }
         allowed_vars = {
             'product', 'variation', 'now', 'now_isoweekday', 'entries_number', 'entries_today', 'entries_days',
@@ -298,6 +298,10 @@ class CheckinList(LoggedModel):
             if values[0] not in allowed_vars:
                 raise ValidationError(f'Logic variable "{values[0]}" is currently not allowed.')
             return rules
+
+        if operator in ('entries_since', 'entries_before'):
+            if len(values) != 1 or "buildTime" not in values[0]:
+                raise ValidationError(f'Operator "{operator}" takes exactly one "buildTime" argument.')
 
         if operator in ('or', 'and') and seen_nonbool:
             raise ValidationError('You cannot use OR/AND logic on a level below a comparison operator.')

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -87,7 +87,7 @@ def _build_time(t=None, value=None, ev=None, now_dt=None):
 
 
 def _logic_annotate_for_graphic_explain(rules, ev, rule_data, now_dt):
-    logic_environment = _get_logic_environment(ev, now_dt)
+    logic_environment = _get_logic_environment(ev, rule_data, now_dt)
     event = ev if isinstance(ev, Event) else ev.event
 
     def _evaluate_inners(r):
@@ -154,7 +154,7 @@ def _logic_explain(rules, ev, rule_data, now_dt=None):
     get in before 17:00". In the middle of the night it would switch to "You can only get in after 09:00".
     """
     now_dt = now_dt or now()
-    logic_environment = _get_logic_environment(ev, now_dt)
+    logic_environment = _get_logic_environment(ev, rule_data, now_dt)
     _var_values = {'False': False, 'True': True}
     _var_explanations = {}
 
@@ -176,15 +176,22 @@ def _logic_explain(rules, ev, rule_data, now_dt=None):
         _var_values[new_var_name] = result
         if not result:
             # Operator returned false, let's dig deeper
-            if "var" not in values[0]:
+            if "var" in values[0]:
+                if isinstance(values[0]["var"], list):
+                    values[0]["var"] = values[0]["var"][0]
+                _var_explanations[new_var_name] = {
+                    'operator': operator,
+                    'var': values[0]["var"],
+                    'rhs': values[1:],
+                }
+            elif "entries_since" in values[0] or "entries_before" in values[0]:
+                _var_explanations[new_var_name] = {
+                    'operator': operator,
+                    'var': values[0],
+                    'rhs': values[1:],
+                }
+            else:
                 raise ValueError("Binary operators should be normalized to have a variable on their left-hand side")
-            if isinstance(values[0]["var"], list):
-                values[0]["var"] = values[0]["var"][0]
-            _var_explanations[new_var_name] = {
-                'operator': operator,
-                'var': values[0]["var"],
-                'rhs': values[1:],
-            }
         return {'var': new_var_name}
     try:
         rules = _evaluate_inners(rules)
@@ -254,11 +261,14 @@ def _logic_explain(rules, ev, rule_data, now_dt=None):
         elif var == 'gate':
             var_weights[vname] = (10, 0)
             var_texts[vname] = _('Wrong entrance gate')
-        elif var in ('entries_number', 'entries_today', 'entries_days', 'minutes_since_last_entry', 'minutes_since_first_entry', 'now_isoweekday'):
+        elif var in ('entries_number', 'entries_today', 'entries_days', 'minutes_since_last_entry', 'minutes_since_first_entry', 'now_isoweekday') \
+                or (isinstance(var, dict) and ("entries_since" in var or "entries_before" in var)):
             w = {
                 'minutes_since_first_entry': 80,
                 'minutes_since_last_entry': 90,
                 'entries_days': 100,
+                'entries_since': 110,
+                'entries_before': 110,
                 'entries_number': 120,
                 'entries_today': 140,
                 'now_isoweekday': 210,
@@ -277,8 +287,24 @@ def _logic_explain(rules, ev, rule_data, now_dt=None):
                 'entries_days': _('number of days with an entry'),
                 'entries_number': _('number of entries'),
                 'entries_today': _('number of entries today'),
+                'entries_since': _('number of entries since {datetime}'),
+                'entries_before': _('number of entries before {datetime}'),
                 'now_isoweekday': _('week day'),
             }
+
+            if isinstance(var, dict) and ("entries_since" in var or "entries_before" in var):
+                varname = list(var.keys())[0]
+                cutoff = _build_time(*var[varname][0]['buildTime'], ev=ev, now_dt=now_dt).astimezone(ev.timezone)
+                if abs(now_dt - cutoff) < timedelta(hours=12):
+                    compare_to_text = date_format(cutoff, 'TIME_FORMAT')
+                else:
+                    compare_to_text = date_format(cutoff, 'SHORT_DATETIME_FORMAT')
+                l[varname] = str(l[varname].format(datetime=compare_to_text))
+                var = varname
+                var_result = getattr(rule_data, var)(cutoff)
+            else:
+                var_result = rule_data[var]
+
             compare_to = rhs[0]
             penalty = 0
 
@@ -295,7 +321,7 @@ def _logic_explain(rules, ev, rule_data, now_dt=None):
                     # These are "technical" comparisons without real meaning, we don't want to show them.
                     penalty = 1000
 
-            var_weights[vname] = (w[var] + operator_weights.get(operator, 0) + penalty, abs(compare_to - rule_data[var]))
+            var_weights[vname] = (w[var] + operator_weights.get(operator, 0) + penalty, abs(compare_to - var_result))
 
             if var == 'now_isoweekday':
                 compare_to = {
@@ -342,7 +368,7 @@ def _logic_explain(rules, ev, rule_data, now_dt=None):
     return ', '.join(var_texts[v] for v in paths_with_min_weight[0] if not _var_values[v])
 
 
-def _get_logic_environment(ev, now_dt):
+def _get_logic_environment(ev, rule_data, now_dt):
     # Every change to our supported JSON logic must be done
     # * in pretix.base.services.checkin
     # * in pretix.base.models.checkin
@@ -364,6 +390,8 @@ def _get_logic_environment(ev, now_dt):
     logic.add_operation('buildTime', partial(_build_time, ev=ev, now_dt=now_dt))
     logic.add_operation('isBefore', is_before)
     logic.add_operation('isAfter', lambda t1, t2, tol=None: is_before(t2, t1, tol))
+    logic.add_operation('entries_since', lambda t1: rule_data.entries_since(t1))
+    logic.add_operation('entries_before', lambda t1: rule_data.entries_before(t1))
     return logic
 
 
@@ -373,6 +401,7 @@ class LazyRuleVars:
         self._clist = clist
         self._dt = dt
         self._gate = gate
+        self.__cache = {}
 
     def __getitem__(self, item):
         if item[0] != '_' and hasattr(self, item):
@@ -409,6 +438,16 @@ class LazyRuleVars:
         tz = self._clist.event.timezone
         midnight = self._dt.astimezone(tz).replace(hour=0, minute=0, second=0, microsecond=0)
         return self._position.checkins.filter(type=Checkin.TYPE_ENTRY, list=self._clist, datetime__gte=midnight).count()
+
+    def entries_since(self, cutoff):
+        if ('entries_since', cutoff) not in self.__cache:
+            self.__cache['entries_since', cutoff] = self._position.checkins.filter(type=Checkin.TYPE_ENTRY, list=self._clist, datetime__gte=cutoff).count()
+        return self.__cache['entries_since', cutoff]
+
+    def entries_before(self, cutoff):
+        if ('entries_before', cutoff) not in self.__cache:
+            self.__cache['entries_before', cutoff] = self._position.checkins.filter(type=Checkin.TYPE_ENTRY, list=self._clist, datetime__lt=cutoff).count()
+        return self.__cache['entries_before', cutoff]
 
     @cached_property
     def entries_days(self):
@@ -476,7 +515,7 @@ class SQLLogic:
             "isBefore": partial(self.comparison_to_q, operator=LowerThan, modifier=partial(tolerance, sign=1)),
             "isAfter": partial(self.comparison_to_q, operator=GreaterThan, modifier=partial(tolerance, sign=-1)),
         }
-        self.expression_ops = {'buildTime', 'objectList', 'lookup', 'var'}
+        self.expression_ops = {'buildTime', 'objectList', 'lookup', 'var', 'entries_since', 'entries_before'}
 
     def operation_to_expression(self, rule):
         if not isinstance(rule, dict):
@@ -524,6 +563,36 @@ class SQLLogic:
             return [self.operation_to_expression(v) for v in values]
         elif operator == 'lookup':
             return int(values[1])
+        elif operator == 'entries_since':
+            return Coalesce(
+                Subquery(
+                    Checkin.objects.filter(
+                        position_id=OuterRef('pk'),
+                        type=Checkin.TYPE_ENTRY,
+                        list_id=self.list.pk,
+                        datetime__gte=self.operation_to_expression(values[0]),
+                    ).values('position_id').order_by().annotate(
+                        c=Count('*')
+                    ).values('c')
+                ),
+                Value(0),
+                output_field=IntegerField()
+            )
+        elif operator == 'entries_before':
+            return Coalesce(
+                Subquery(
+                    Checkin.objects.filter(
+                        position_id=OuterRef('pk'),
+                        type=Checkin.TYPE_ENTRY,
+                        list_id=self.list.pk,
+                        datetime__lt=self.operation_to_expression(values[0]),
+                    ).values('position_id').order_by().annotate(
+                        c=Count('*')
+                    ).values('c')
+                ),
+                Value(0),
+                output_field=IntegerField()
+            )
         elif operator == 'var':
             if values[0] == 'now':
                 return Value(now().astimezone(timezone.utc))
@@ -878,7 +947,7 @@ def perform_checkin(op: OrderPosition, clist: CheckinList, given_answers: dict, 
 
         if type == Checkin.TYPE_ENTRY and clist.rules:
             rule_data = LazyRuleVars(op, clist, dt, gate=gate)
-            logic = _get_logic_environment(op.subevent or clist.event, now_dt=dt)
+            logic = _get_logic_environment(op.subevent or clist.event, rule_data, now_dt=dt)
             if not logic.apply(clist.rules, rule_data):
                 if force:
                     force_used = True

--- a/src/pretix/control/templates/pretixcontrol/checkin/list_edit.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/list_edit.html
@@ -29,6 +29,8 @@
                 id="product-select2">{% url "control:event.items.select2" event=request.event.slug organizer=request.organizer.slug %}</script>
         <script type="text/plain"
                 id="variations-select2">{% url "control:event.items.variations.select2" event=request.event.slug organizer=request.organizer.slug %}</script>
+        <script type="text/plain"
+                id="gates-select2">{% url "control:organizer.gates.select2" organizer=request.organizer.slug %}</script>
         {% csrf_token %}
         {% bootstrap_form_errors form %}
         <div class="tabbed-form">

--- a/src/pretix/control/templates/pretixcontrol/checkin/simulator.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/simulator.html
@@ -31,6 +31,7 @@
         {% bootstrap_field form.raw_barcode layout="control" %}
         {% bootstrap_field form.datetime layout="control" %}
         {% bootstrap_field form.checkin_type layout="control" %}
+        {% bootstrap_field form.gate layout="control" %}
         {% bootstrap_field form.ignore_unpaid layout="control" %}
         {% bootstrap_field form.questions_supported layout="control" %}
         <div class="row">

--- a/src/pretix/control/views/checkin.py
+++ b/src/pretix/control/views/checkin.py
@@ -491,6 +491,11 @@ class CheckInListSimulator(EventPermissionRequiredMixin, FormView):
         r['Content-Security-Policy'] = 'script-src \'unsafe-eval\''
         return r
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['event'] = self.request.event
+        return kwargs
+
     def get_initial(self):
         return {
             'datetime': now()
@@ -524,12 +529,13 @@ class CheckInListSimulator(EventPermissionRequiredMixin, FormView):
             request=self.request,  # this is not clean, but we need it in the serializers for URL generation
             legacy_url_support=False,
             simulate=True,
+            gate=form.cleaned_data.get("gate"),
         ).data
 
         if form.cleaned_data["checkin_type"] == Checkin.TYPE_ENTRY and self.list.rules and self.result.get("position")\
                 and (self.result["status"] in ("ok", "incomplete") or self.result["reason"] == "rules"):
             op = OrderPosition.objects.get(pk=self.result["position"]["id"])
-            rule_data = LazyRuleVars(op, self.list, form.cleaned_data["datetime"])
+            rule_data = LazyRuleVars(op, self.list, form.cleaned_data["datetime"], form.cleaned_data.get("gate"))
             rule_graph = _logic_annotate_for_graphic_explain(self.list.rules, op.subevent or self.list.event, rule_data,
                                                              form.cleaned_data["datetime"])
             self.result["rule_graph"] = rule_graph

--- a/src/pretix/control/views/typeahead.py
+++ b/src/pretix/control/views/typeahead.py
@@ -1010,7 +1010,7 @@ def devices_select2(request, **kwargs):
     return JsonResponse(doc)
 
 
-@organizer_permission_required(("can_view_orders", "can_change_organizer_settings"))
+@organizer_permission_required(("can_view_orders", "can_change_event_settings", "can_change_organizer_settings"))
 # This decorator is a bit of a hack since this is not technically an organizer permission, but it does the job here --
 # anyone who can see orders for any event can see the check-in log view where this is used as a filter
 def gate_select2(request, **kwargs):

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
@@ -35,6 +35,32 @@ $(function () {
         'cardinality': 2,
       },
     },
+    'int_by_datetime': {
+      '<': {
+        'label': '<',
+        'cardinality': 2,
+      },
+      '<=': {
+        'label': '≤',
+        'cardinality': 2,
+      },
+      '>': {
+        'label': '>',
+        'cardinality': 2,
+      },
+      '>=': {
+        'label': '≥',
+        'cardinality': 2,
+      },
+      '==': {
+        'label': '=',
+        'cardinality': 2,
+      },
+      '!=': {
+        'label': '≠',
+        'cardinality': 2,
+      },
+    },
     'int': {
       '<': {
         'label': '<',
@@ -90,6 +116,14 @@ $(function () {
     'entries_today': {
       'label': gettext('Number of previous entries since midnight'),
       'type': 'int',
+    },
+    'entries_since': {
+      'label': gettext('Number of previous entries since'),
+      'type': 'int_by_datetime',
+    },
+    'entries_before': {
+      'label': gettext('Number of previous entries before'),
+      'type': 'int_by_datetime',
     },
     'entries_days': {
       'label': gettext('Number of days with a previous entry'),

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules.js
@@ -3,8 +3,10 @@ $(function () {
     // Every change to our supported JSON logic must be done
     // * in pretix.base.services.checkin
     // * in pretix.base.models.checkin
+    // * in pretix.helpers.jsonlogic_boolalg
     // * in checkinrules.js
     // * in libpretixsync
+    // * in pretixscan-ios
     'product': {
       'inList': {
         'label': gettext('is one of'),
@@ -12,6 +14,12 @@ $(function () {
       }
     },
     'variation': {
+      'inList': {
+        'label': gettext('is one of'),
+        'cardinality': 2,
+      }
+    },
+    'gate': {
       'inList': {
         'label': gettext('is one of'),
         'cardinality': 2,
@@ -62,6 +70,10 @@ $(function () {
     'variation': {
       'label': gettext('Product variation'),
       'type': 'variation',
+    },
+    'gate': {
+      'label': gettext('Gate'),
+      'type': 'gate',
     },
     'now': {
       'label': gettext('Current date and time'),

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules/checkin-rule.vue
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules/checkin-rule.vue
@@ -48,6 +48,9 @@
         <lookup-select2 required v-if="vartype == 'variation' && operator == 'inList'" :multiple="true"
                         :value="rightoperand" v-on:input="setRightOperandVariationList"
                         :url="variationSelectURL"></lookup-select2>
+        <lookup-select2 required v-if="vartype == 'gate' && operator == 'inList'" :multiple="true"
+                        :value="rightoperand" v-on:input="setRightOperandGateList"
+                        :url="gateSelectURL"></lookup-select2>
         <div class="checkin-rule-childrules" v-if="operator === 'or' || operator === 'and'">
             <div v-for="(op, opi) in operands">
                 <checkin-rule :rule="op" :index="opi" :level="level + 1" v-if="typeof op === 'object'"></checkin-rule>
@@ -144,6 +147,9 @@
       variationSelectURL: function () {
         return $("#variations-select2").text();
       },
+      gateSelectURL: function () {
+        return $("#gates-select2").text();
+      },
       vars: function () {
         return this.$root.VARS;
       },
@@ -231,6 +237,25 @@
           products["objectList"].push({
             "lookup": [
               "variation",
+              val[i].id,
+              val[i].text
+            ]
+          });
+        }
+        if (this.rule[this.operator].length === 1) {
+          this.rule[this.operator].push(products);
+        } else {
+          this.$set(this.rule[this.operator], 1, products);
+        }
+      },
+      setRightOperandGateList: function (val) {
+        var products = {
+          "objectList": []
+        };
+        for (var i = 0; i < val.length; i++) {
+          products["objectList"].push({
+            "lookup": [
+              "gate",
               val[i].id,
               val[i].text
             ]

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules/checkin-rule.vue
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules/checkin-rule.vue
@@ -10,7 +10,7 @@
             <button type="button" class="checkin-rule-remove btn btn-xs btn-default" @click.prevent="wrapWithAND">AND
             </button>
             <button type="button" class="checkin-rule-remove btn btn-xs btn-default" @click.prevent="cutOut"
-                    v-if="operands && operands.length == 1 && (operator === 'or' || operator == 'and')"><span
+                    v-if="operands && operands.length === 1 && (operator === 'or' || operator === 'and')"><span
                     class="fa fa-cut"></span></button>
             <button type="button" class="checkin-rule-remove btn btn-xs btn-default" @click.prevent="remove"
                     v-if="level > 0"><span class="fa fa-trash"></span></button>
@@ -21,34 +21,39 @@
             <option v-for="(v, name) in vars" :value="name">{{ v.label }}</option>
         </select>
         <select v-bind:value="operator" v-on:input="setOperator" required class="form-control"
-                v-if="operator !== 'or' && operator !== 'and'">
+                v-if="operator !== 'or' && operator !== 'and' && vartype !== 'int_by_datetime'">
             <option></option>
             <option v-for="(v, name) in operators" :value="name">{{ v.label }}</option>
         </select>
         <select v-bind:value="timeType" v-on:input="setTimeType" required class="form-control"
-                v-if="vartype == 'datetime'">
+                v-if="vartype === 'datetime' || vartype === 'int_by_datetime'">
             <option value="date_from">{{texts.date_from}}</option>
             <option value="date_to">{{texts.date_to}}</option>
             <option value="date_admission">{{texts.date_admission}}</option>
             <option value="custom">{{texts.date_custom}}</option>
             <option value="customtime">{{texts.date_customtime}}</option>
         </select>
-        <datetimefield v-if="vartype == 'datetime' && timeType == 'custom'" :value="timeValue"
+        <datetimefield v-if="(vartype === 'datetime' || vartype === 'int_by_datetime') && timeType === 'custom'" :value="timeValue"
                        v-on:input="setTimeValue"></datetimefield>
-        <timefield v-if="vartype == 'datetime' && timeType == 'customtime'" :value="timeValue"
-            v-on:input="setTimeValue"></timefield>
+        <timefield v-if="(vartype === 'datetime' || vartype === 'int_by_datetime') && timeType === 'customtime'" :value="timeValue"
+                   v-on:input="setTimeValue"></timefield>
         <input class="form-control" required type="number"
-               v-if="vartype == 'datetime' && timeType && timeType != 'customtime' && timeType != 'custom'" v-bind:value="timeTolerance"
+               v-if="vartype === 'datetime' && timeType && timeType !== 'customtime' && timeType !== 'custom'" v-bind:value="timeTolerance"
                v-on:input="setTimeTolerance" :placeholder="texts.date_tolerance">
-        <input class="form-control" required type="number" v-if="vartype == 'int' && cardinality > 1"
+        <select v-bind:value="operator" v-on:input="setOperator" required class="form-control"
+                v-if="vartype === 'int_by_datetime'">
+          <option></option>
+          <option v-for="(v, name) in operators" :value="name">{{ v.label }}</option>
+        </select>
+        <input class="form-control" required type="number" v-if="(vartype === 'int' || vartype === 'int_by_datetime') && cardinality > 1"
                v-bind:value="rightoperand" v-on:input="setRightOperandNumber">
-        <lookup-select2 required v-if="vartype == 'product' && operator == 'inList'" :multiple="true"
+        <lookup-select2 required v-if="vartype === 'product' && operator === 'inList'" :multiple="true"
                         :value="rightoperand" v-on:input="setRightOperandProductList"
                         :url="productSelectURL"></lookup-select2>
-        <lookup-select2 required v-if="vartype == 'variation' && operator == 'inList'" :multiple="true"
+        <lookup-select2 required v-if="vartype === 'variation' && operator === 'inList'" :multiple="true"
                         :value="rightoperand" v-on:input="setRightOperandVariationList"
                         :url="variationSelectURL"></lookup-select2>
-        <lookup-select2 required v-if="vartype == 'gate' && operator == 'inList'" :multiple="true"
+        <lookup-select2 required v-if="vartype === 'gate' && operator === 'inList'" :multiple="true"
                         :value="rightoperand" v-on:input="setRightOperandGateList"
                         :url="gateSelectURL"></lookup-select2>
         <div class="checkin-rule-childrules" v-if="operator === 'or' || operator === 'and'">
@@ -82,6 +87,12 @@
         if (op === "and" || op === "or") {
           return op;
         } else if (this.rule[op] && this.rule[op][0]) {
+          if (this.rule[op][0]["entries_since"]) {
+            return "entries_since";
+          }
+          if (this.rule[op][0]["entries_before"]) {
+            return "entries_before";
+          }
           return this.rule[op][0]["var"];
         } else {
           return null;
@@ -116,7 +127,11 @@
         }
       },
       timeType: function () {
-        if (this.rightoperand && this.rightoperand['buildTime']) {
+        if (this.vartype === 'int_by_datetime') {
+          if (this.rule[this.operator][0][this.variable] && this.rule[this.operator][0][this.variable][0]['buildTime']) {
+            return this.rule[this.operator][0][this.variable][0]['buildTime'][0];
+          }
+        } else if (this.rightoperand && this.rightoperand['buildTime']) {
           return this.rightoperand['buildTime'][0];
         }
       },
@@ -129,7 +144,11 @@
         }
       },
       timeValue: function () {
-        if (this.rightoperand && this.rightoperand['buildTime']) {
+        if (this.vartype === 'int_by_datetime') {
+          if (this.rule[this.operator][0][this.variable][0]['buildTime']) {
+            return this.rule[this.operator][0][this.variable][0]['buildTime'][1];
+          }
+        } else if (this.rightoperand && this.rightoperand['buildTime']) {
           return this.rightoperand['buildTime'][1];
         }
       },
@@ -167,7 +186,19 @@
           this.$delete(this.rule, current_op);
         } else {
           if (current_val !== "and" && current_val !== "or" && current_val[0] && this.$root.VARS[event.target.value]['type'] === this.vartype) {
-            this.$set(this.rule[current_op][0], "var", event.target.value);
+            if (this.vartype === "int_by_datetime") {
+              var current_data = this.rule[current_op][0][this.variable];
+              var new_lhs = {};
+              new_lhs[event.target.value] = JSON.parse(JSON.stringify(current_data));
+              this.$set(this.rule[current_op], 0, new_lhs);
+            } else {
+              this.$set(this.rule[current_op][0], "var", event.target.value);
+            }
+          } else if (this.$root.VARS[event.target.value]['type'] === 'int_by_datetime') {
+            this.$delete(this.rule, current_op);
+            var o = {};
+            o[event.target.value] = [{"buildTime": [null, null]}]
+            this.$set(this.rule, "!!", [o]);
           } else {
             this.$delete(this.rule, current_op);
             this.$set(this.rule, "!!", [{"var": event.target.value}]);
@@ -198,17 +229,25 @@
         var time = {
           "buildTime": [event.target.value]
         };
-        if (this.rule[this.operator].length === 1) {
-          this.rule[this.operator].push(time);
+        if (this.vartype === "int_by_datetime") {
+          this.$set(this.rule[this.operator][0][this.variable], 0, time);
         } else {
-          this.$set(this.rule[this.operator], 1, time);
-        }
-        if (event.target.value === "custom") {
-          this.$set(this.rule[this.operator], 2, 0);
+          if (this.rule[this.operator].length === 1) {
+            this.rule[this.operator].push(time);
+          } else {
+            this.$set(this.rule[this.operator], 1, time);
+          }
+          if (event.target.value === "custom") {
+            this.$set(this.rule[this.operator], 2, 0);
+          }
         }
       },
       setTimeValue: function (val) {
-        this.$set(this.rule[this.operator][1]["buildTime"], 1, val);
+        if (this.vartype === "int_by_datetime") {
+          this.$set(this.rule[this.operator][0][this.variable][0]["buildTime"], 1, val);
+        } else {
+          this.$set(this.rule[this.operator][1]["buildTime"], 1, val);
+        }
       },
       setRightOperandProductList: function (val) {
         var products = {

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules/viz-node.vue
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules/viz-node.vue
@@ -44,7 +44,9 @@
                     </strong>
                 </span>
                 <span v-else-if="vardata && operator === 'inList'">
-                    <span class="fa fa-ticket"></span> {{ vardata.label }}
+                    <span class="fa fa-sign-in" v-if="variable === 'gate'"></span>
+                    <span class="fa fa-ticket" v-else></span>
+                    {{ vardata.label }}
                     <span v-if="varresult !== null">
                       ({{varresult}})
                     </span>
@@ -149,6 +151,8 @@
       varresult () {
         const op = this.operator;
         if (this.node.rule[op] && this.node.rule[op][0]) {
+          if (typeof this.node.rule[op][0]["__result"] === "undefined")
+            return null;
           return this.node.rule[op][0]["__result"];
         } else {
           return "";

--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules/viz-node.vue
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules/viz-node.vue
@@ -19,6 +19,26 @@
                       {{ op.label }} {{ rightoperand }}
                     </strong>
                 </span>
+                <span v-else-if="vardata && vardata.type === 'int_by_datetime'">
+                    <span v-if="variable.startsWith('entries_')" class="fa fa-sign-in"></span>
+                    {{ vardata.label }}
+                    <span v-if="node.rule[operator][0][variable][0].buildTime[0] === 'custom'">
+                      {{ df(node.rule[operator][0][variable][0].buildTime[1]) }}
+                    </span>
+                    <span v-else-if="node.rule[operator][0][variable][0].buildTime[0] === 'customtime'">
+                      {{ tf(node.rule[operator][0][variable][0].buildTime[1]) }}
+                    </span>
+                    <span v-else>
+                      {{ this.$root.texts[node.rule[operator][0][variable][0].buildTime[0]] }}
+                    </span>
+                    <br>
+                    <span v-if="varresult !== null">
+                      {{varresult}}
+                    </span>
+                    <strong>
+                      {{ op.label }} {{ rightoperand }}
+                    </strong>
+                </span>
                 <span v-else-if="vardata && variable === 'now'">
                     <span class="fa fa-clock-o"></span> {{ vardata.label }}<br>
                     <span v-if="varresult !== null">
@@ -140,6 +160,12 @@
       variable () {
         const op = this.operator;
         if (this.node.rule[op] && this.node.rule[op][0]) {
+          if (this.node.rule[op][0]["entries_since"]) {
+            return "entries_since";
+          }
+          if (this.node.rule[op][0]["entries_before"]) {
+            return "entries_before";
+          }
           return this.node.rule[op][0]["var"];
         } else {
           return "";


### PR DESCRIPTION
This PR adds three new things to the check-in rules engine:

- Current "gate" assigned to the device – useful for situations like the one discussed in #3466
- "Number of entries since a freely choosable date" – useful if you e.g. have a three-phase event "build-up / event / teardown" and you want to create a ticket type that is valid exactly once during build-up and exactly once again during teardown
- "Number of entries before a freely choosable date" – I struggle to come up with a real-world use case for this one, but it seemed wrong only giving the "since" option, and implementing both forced me to do a cleaner implementation overall ;)

The first one is a simple additional variable ``gate`` in the JSON logic engine. The second and third are unfortunately more complex since they need to be functions/operations in their own right.

### Checklist

- [x] implementation
- [x] tests
- [x] libpretixsync support https://github.com/pretix/libpretixsync/pull/30
  - [x] check proper syncing of current gate
  - [ ] pretixscan android release https://github.com/pretix/pretixscan-android/pull/73
  - [ ] pretixscan desktop release
  - [ ] pretixscan proxy release
- [ ] pretixscan-ios support