### PR TITLE
Check-in: New scan type "print"

### DIFF
--- a/doc/api/resources/checkin.rst
+++ b/doc/api/resources/checkin.rst
@@ -34,7 +34,7 @@ Checking a ticket in
    :<json string secret: Scanned QR code corresponding to the ``secret`` attribute of a ticket.
    :<json string source_type: Type of source the ``secret`` was obtained form. Defaults to ``"barcode"``.
    :<json array lists: List of check-in list IDs to search on. No two check-in lists may be from the same event.
-   :<json string type: Send ``"exit"`` for an exit and ``"entry"`` (default) for an entry.
+   :<json string type: Send ``"exit"`` for an exit and ``"entry"`` (default) for an entry, ``"print"`` for a badge print scan.
    :<json datetime datetime: Specifies the datetime of the check-in. If not supplied, the current time will be used.
    :<json boolean force: Specifies that the check-in should succeed regardless of revoked barcode, previous check-ins or required
                          questions that have not been filled. This is usually used to upload offline scans that already happened,

--- a/doc/api/resources/checkinlists.rst
+++ b/doc/api/resources/checkinlists.rst
@@ -631,7 +631,7 @@ Order position endpoints
    :<json boolean force: Specifies that the check-in should succeed regardless of revoked barcode, previous check-ins or required
                          questions that have not been filled. This is usually used to upload offline scans that already happened,
                          because there's no point in validating them since they happened whether they are valid or not. Defaults to ``false``.
-   :<json string type: Send ``"exit"`` for an exit and ``"entry"`` (default) for an entry.
+   :<json string type: Send ``"exit"`` for an exit and ``"entry"`` (default) for an entry, ``"print"`` for a badge print scan.
    :<json boolean ignore_unpaid: Specifies that the check-in should succeed even if the order is in pending state.
                                  Defaults to ``false`` and only works when ``include_pending`` is set on the check-in
                                  list.

--- a/src/pretix/base/models/checkin.py
+++ b/src/pretix/base/models/checkin.py
@@ -179,7 +179,7 @@ class CheckinList(LoggedModel):
         # dedupliate by position and count it up.
         cl = self
         base_q, base_params = (
-            Checkin.all.filter(*c_q, successful=True, list=cl)
+            Checkin.all.filter(*c_q, successful=True, list=cl, type__in=[Checkin.TYPE_ENTRY, Checkin.TYPE_EXIT])
             .annotate(
                 cnt_exists_after=Window(
                     expression=Count("position_id", filter=Q(type=Value("exit"))),
@@ -322,9 +322,11 @@ class Checkin(models.Model):
     """
     TYPE_ENTRY = 'entry'
     TYPE_EXIT = 'exit'
+    TYPE_PRINT = 'print'
     CHECKIN_TYPES = (
         (TYPE_ENTRY, _('Entry')),
         (TYPE_EXIT, _('Exit')),
+        (TYPE_PRINT, _('Print')),
     )
 
     REASON_CANCELED = 'canceled'

--- a/src/pretix/base/services/checkin.py
+++ b/src/pretix/base/services/checkin.py
@@ -773,7 +773,7 @@ def perform_checkin(op: OrderPosition, clist: CheckinList, given_answers: dict, 
                 'blocked'
             )
 
-    if type != Checkin.TYPE_EXIT and op.valid_from and op.valid_from > dt:
+    if type not in (Checkin.TYPE_PRINT, Checkin.TYPE_EXIT) and op.valid_from and op.valid_from > dt:
         if force:
             force_used = True
         else:
@@ -787,7 +787,7 @@ def perform_checkin(op: OrderPosition, clist: CheckinList, given_answers: dict, 
                 ),
             )
 
-    if type != Checkin.TYPE_EXIT and op.valid_until and op.valid_until < dt:
+    if type not in (Checkin.TYPE_PRINT, Checkin.TYPE_EXIT) and op.valid_until and op.valid_until < dt:
         if force:
             force_used = True
         else:
@@ -886,9 +886,9 @@ def perform_checkin(op: OrderPosition, clist: CheckinList, given_answers: dict, 
         if isinstance(auth, Device):
             device = auth
 
-        last_cis = list(op.checkins.order_by('-datetime').filter(list=clist).only('type', 'nonce'))
+        last_cis = list(op.checkins.order_by('-datetime').filter(list=clist, type__in=(Checkin.TYPE_ENTRY, Checkin.TYPE_EXIT)).only('type', 'nonce'))
         entry_allowed = (
-            type == Checkin.TYPE_EXIT or
+            type in (Checkin.TYPE_EXIT, Checkin.TYPE_PRINT) or
             clist.allow_multiple_entries or
             not last_cis or
             all(c.type == Checkin.TYPE_EXIT for c in last_cis) or

--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -295,6 +295,20 @@ def _display_checkin(event, logentry):
                 posid=data.get('positionid'),
                 list=checkin_list
             )
+
+    if data.get('type') == Checkin.TYPE_PRINT:
+        if show_dt:
+            return _('Position #{posid} has been printed out at {datetime} for list "{list}".').format(
+                posid=data.get('positionid'),
+                datetime=dt_formatted,
+                list=checkin_list
+            )
+        else:
+            return _('Position #{posid} has been printed out for list "{list}".').format(
+                posid=data.get('positionid'),
+                list=checkin_list
+            )
+
     if data.get('first'):
         if show_dt:
             return _('Position #{posid} has been checked in at {datetime} for list "{list}".').format(

--- a/src/pretix/control/templates/pretixcontrol/checkin/checkins.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/checkins.html
@@ -95,6 +95,7 @@
                         <td>
                             {% if c.type == "exit" %}<span class="fa fa-fw fa-sign-out"></span>{% endif %}
                             {% if c.type == "entry" %}<span class="fa fa-fw fa-sign-in"></span>{% endif %}
+                            {% if c.type == "print" %}<span class="fa fa-fw fa-print"></span>{% endif %}
                             {{ c.get_type_display }}
                             <br>
                             <small>

--- a/src/pretix/control/templates/pretixcontrol/order/index.html
+++ b/src/pretix/control/templates/pretixcontrol/order/index.html
@@ -385,6 +385,8 @@
                                             {% else %}
                                                 <span class="fa fa-fw text-success fa-sign-out" data-toggle="tooltip_html" title="{{ c.list.name|force_escape|force_escape }}<br>{% blocktrans trimmed with date=c.datetime|date:'SHORT_DATETIME_FORMAT' %}Exit scan: {{ date }}{% endblocktrans %}{% if c.gate %}<br>{{ c.gate }}{% endif %}"></span>
                                             {% endif %}
+                                        {% elif c.type == "print" %}
+                                            <span class="fa fa-fw text-success fa-print" data-toggle="tooltip_html" title="{{ c.list.name|force_escape|force_escape }}<br>{% blocktrans trimmed with date=c.datetime|date:'SHORT_DATETIME_FORMAT' %}Print scan: {{ date }}{% endblocktrans %}{% if c.gate %}<br>{{ c.gate }}{% endif %}"></span>
                                         {% elif c.forced %}
                                             <span class="fa fa-fw fa-warning text-warning" data-toggle="tooltip_html" title="{{ c.list.name|force_escape|force_escape }}<br>{% blocktrans trimmed with date=c.datetime|date:'SHORT_DATETIME_FORMAT' %}Additional entry scan: {{ date }}{% endblocktrans %}{% if c.gate %}<br>{{ c.gate }}{% endif %}"></span>
                                         {% elif c.auto_checked_in %}


### PR DESCRIPTION
Scenario: An event has physically separated the concepts of "badge printing" and "access control". For example, there could be self-service badge printing stations in the foyer and access control happens only when you enter a specific corridor/door. The request is now that the self-service badge printing stations can be configured in a way that they do not already check the attendee in. The typical solution of using a separate check-in list falls short because the tickets would still be considered "checked in" for some purposes, such as reporting or self-service cancellation.

This PR therefore introduces a new check-in type "print" that could be used.

This requires a **lot** of opinionated design decisions, such as:

- [ ] Should a "print" scan only work if custom check-in rules are fulfilled? (My option: No. It makes sense to allow a print e.g. outside of access times.)
- [ ] Should a "print" scan work twice in a row? (My opinion: Yes, it's useful if badges get lost or broken or misprinted. It makes self-service printing more effective. However, this only makes sense if electronic access control is actually used and a badge around the neck is not good enough to get in.)
- [ ] Should a "print" work if check-in-time questions on the ticket are not yet answered? (My opinion: No, as the answers could be required for printing. However this has the downside that we need to show question son the self-service station which can be problematic if the question feature is used for data where we need "trusted input")
- [ ] Should a "printed" badge considered checked in for the purposes of `Order.user_change_allowed`, `Order.user_cancel_allowed`, `Order.can_modify_answers`, and `OrderChangeManager.set_addons`? (My opinion: No, if electronic access control is used. "Yes" is not an option, but "make it configurable" could be)
- [ ] Should a "printed" badge considered checked in for the purposes of `OrderFilterForm.filter_qs`, `VoucherFilterForm.filter_qs`, `pretix.plugins.sendmail.tasks.send_mails_to_orders`, `pretix.plugins.sendmail.views.OrderSendView.get_object_queryset` (don't really care, would normally say yes, but maybe no is better for consistency)
- [ ] Should a "printed" badge considered checked in for the purposes of the plugins ``pretix-noshow`` (no?), ``pretix-offlinesales`` (yes?), ``pretix-reports`` (no?), ``pretix-resellers`` (no/configurable?), ``pretix-ticketswap`` (no/configurable?)

If we don't feel happy with this, I see one alternative to this PR: Abandon the new type alltogether and introduce a flag on the `CheckinList` that marks a checkin list as excluded from reporting and from tickets being considered "used".

Other Todos:

- [ ] Implement design decisions from above
- [ ] Adjust pretix.base.pdf.get_first_scan
- [ ] Add tests
- [ ] Update flowcharts
- [ ] Add support in libpretixsync
- [ ] Add support in pretixscan-android
- [ ] Add support in pretixscan-desktop
- [ ] Make sure pretixscan-ios does not break