### PR TITLE
Add warning about configuration of Celery in development mode to docs

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -103,6 +103,13 @@ in ``pretix.cfg``. i.e., you should remove anything such as::
     backend=redis://redis:6379/2
     broker=redis://redis:6379/2
 
+If you choose to use Celery for development, you must also start a Celery worker
+process::
+
+    celery -A pretix.celery_app worker -l info
+
+However, beware that code changes will not auto-reload within Celery.
+
 .. _`checksandtests`:
 
 Code checks and unit tests

--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -96,6 +96,13 @@ http://localhost:8000/control/ for the admin view.
           port (for example because you develop on `pretixdroid`_), you can check
           `Django's documentation`_ for more options.
 
+When running the local development webserver, ensure Celery is not configured
+in ``pretix.cfg``. i.e., you should remove anything such as::
+
+    [celery]
+    backend=redis://redis:6379/2
+    broker=redis://redis:6379/2
+
 .. _`checksandtests`:
 
 Code checks and unit tests


### PR DESCRIPTION
I spent a long time debugging why certain things were not working during development. It ended up being because Celery was configured to use Redis in my `pretix.cfg`. This PR adds a warning in the docs about this.