### PR TITLE
Cart: make disabling sneak-peek more robust

### DIFF
--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -7,7 +7,9 @@ setup_collapsible_details = function (el) {
         var $elements = $("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)');
         var container = this;
 
-        if ($("> :not(summary)", this).show().filter(':not(.sneak-peek-trigger)').height() < 200) {
+        if (Array.prototype.reduce.call($elements, function (h, e) {
+            return h + $(e).outerHeight();
+        }, 0) < 200) {
             $(".sneak-peek-trigger", this).remove();
             $(container).removeClass('sneak-peek');
             container.style.removeProperty('height');


### PR DESCRIPTION
This PR improves #3512 in three ways:

1. It removes the doubling of the `$elements` selector
2. It uses `outerHeight()`, which takes margin into account
3. It makes height-calculation more robust as technically details/summary allow for more than one child other than summary, so it uses array-reduce to sum all outerHeights.