### PR TITLE
Banktransfer: make row-headers sticky (Z#23127000)

### DIFF
--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/import_assign.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/import_assign.html
@@ -11,10 +11,10 @@
             <span class="icon icon-upload"></span> {% trans "Continue" %}
         </button>
         <div class="flipped-scroll-wrapper clearfix">
-            <table class="table table-condensed flipped-scroll-inner">
+            <table class="table table-condensed table-th-sticky-horizontal flipped-scroll-inner">
                 <thead>
                 <tr>
-                    <th>{% trans "Date" %}</th>
+                    <th scope="row">{% trans "Date" %}</th>
                     {% for col in rows.0 %}
                         <th>
                             <input type="radio" name="date" value="{{ forloop.counter0 }}"/>
@@ -22,7 +22,7 @@
                     {% endfor %}
                 </tr>
                 <tr>
-                    <th>{% trans "Amount" %}</th>
+                    <th scope="row">{% trans "Amount" %}</th>
                     {% for col in rows.0 %}
                         <th>
                             <input type="radio" name="amount" value="{{ forloop.counter0 }}" required="required"/>
@@ -30,7 +30,7 @@
                     {% endfor %}
                 </tr>
                 <tr>
-                    <th>{% trans "Reference" %}</th>
+                    <th scope="row">{% trans "Reference" %}</th>
                     {% for col in rows.0 %}
                         <th>
                             <input type="checkbox" name="reference" value="{{ forloop.counter0 }}"/>
@@ -38,7 +38,7 @@
                     {% endfor %}
                 </tr>
                 <tr>
-                    <th>{% trans "Payer" %}</th>
+                    <th scope="row">{% trans "Payer" %}</th>
                     {% for col in rows.0 %}
                         <th>
                             <input type="checkbox" name="payer" value="{{ forloop.counter0 }}"/>
@@ -46,7 +46,7 @@
                     {% endfor %}
                 </tr>
                 <tr>
-                    <th>
+                    <th scope="row">
                         {% trans "IBAN" %}
                         <label for="id_iban_clear">
                             <span class="btn btn-default btn-sm fa fa-close"></span>
@@ -62,7 +62,7 @@
                     {% endfor %}
                 </tr>
                 <tr>
-                    <th>
+                    <th scope="row">
                         {% trans "BIC" %}
                         <label for="id_bic_clear">
                             <span class="btn btn-default btn-sm fa fa-close"></span>

--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -813,7 +813,11 @@ tbody[data-dnd-url] {
 tbody th {
     background: $table-bg-hover;
 }
-
+.table-th-sticky-horizontal th[scope=row] {
+    position: sticky;
+    left: 0;
+    background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 96%, rgba(255,255,255,0) 100%);;
+}
 .large-link-group {
     a.list-group-item {
         &::before {


### PR DESCRIPTION
When uploading a banktransfer with lots of columns, the row-headers were scrolled out of view. This PR makes them sticky.

![Spaltenzuordnung(1)](https://github.com/pretix/pretix/assets/276509/ee769537-ba2e-421a-9efd-0947a9073932)

Sticky: 
![Bildschirmfoto 2023-08-22 um 09 45 50](https://github.com/pretix/pretix/assets/276509/57bb1ea9-434d-4abf-bea1-e93a77400a72)


Note: due to position:sticky and the needed background-color, the borders between rows were overlayed and hidden. A somewhat hacky fix is to use a linear-gradient as a background. Maybe there is another less hacky way?