### PR TITLE
Checkout: improve heuristic to open invoice-panel (Z#23125697)

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1027,10 +1027,10 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
         ctx['invoice_address_asked'] = self.address_asked
 
         def reduce_initial(v):
-            try:
+            if isinstance(v, dict):
                 # try to flatten objects such as name_parts to a single string to determine whether they have any value set
                 return ''.join([v for k, v in v.items() if not k.startswith('_')])
-            except AttributeError:
+            else:
                 return v
 
         def is_form_filled(form, ignore_keys=()):

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1032,15 +1032,17 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                 return ''.join([v for k, v in v.items() if not k.startswith('_')])
             except AttributeError:
                 return v
-        def is_form_filled(form):
-            return any([reduce_initial(v) for k, v in form.initial.items() if k not in ('is_business', 'country')])
+
+        def is_form_filled(form, ignore_keys=()):
+            return any([reduce_initial(v) for k, v in form.initial.items() if k not in ignore_keys])
+
         ctx['invoice_address_open'] = (
             self.request.event.settings.invoice_address_required or
             self.request.event.settings.invoice_name_required or
             'invoice' in self.request.GET or
             # Checking for self.invoice_address.pk is not enough as when an invoice_address has been added and later edited to be empty, it’s not None.
             # So check initial values as invoice_form can receive pre-filled values from invoice_address, widget-data or overwrites from plug-ins.
-            is_form_filled(self.invoice_form)
+            is_form_filled(self.invoice_form, ignore_keys=('is_business', 'country'))
         )
 
         if self.cart_customer:

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1025,6 +1025,7 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
         ctx['cart'] = self.get_cart()
         ctx['cart_session'] = self.cart_session
         ctx['invoice_address_asked'] = self.address_asked
+
         def reduce_initial(v):
             try:
                 # try to flatten objects such as name_parts to a single string to determine whether they have any value set

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1032,13 +1032,15 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                 return ''.join([v for k, v in v.items() if not k.startswith('_')])
             except AttributeError:
                 return v
+        def is_form_filled(form):
+            return any([reduce_initial(v) for k, v in form.initial.items() if k not in ('is_business', 'country')])
         ctx['invoice_address_open'] = (
             self.request.event.settings.invoice_address_required or
             self.request.event.settings.invoice_name_required or
             'invoice' in self.request.GET or
             # Checking for self.invoice_address.pk is not enough as when an invoice_address has been added and later edited to be empty, it’s not None.
             # So check initial values as invoice_form can receive pre-filled values from invoice_address, widget-data or overwrites from plug-ins.
-            any([reduce_initial(v) for k, v in self.invoice_form.initial.items() if k not in ('is_business', 'country')])
+            is_form_filled(self.invoice_form)
         )
 
         if self.cart_customer:

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -76,7 +76,7 @@
                         <div class="panel-heading">
                             <h3 class="panel-title">
                                 {% trans "Invoice information" %}
-                                <a href="{% eventurl request.event "presale:event.checkout" step="questions" cart_namespace=cart_namespace|default_if_none:"" %}?invoice=1" aria-label="{% trans "Modify invoice information" %}" class="h6">
+                                <a href="{% eventurl request.event "presale:event.checkout" step="questions" cart_namespace=cart_namespace|default_if_none:"" %}?invoice=1#invoice-details" aria-label="{% trans "Modify invoice information" %}" class="h6">
                                     <span class="fa fa-edit" aria-hidden="true"></span>{% trans "Modify" %}
                                 </a>
                             </h3>

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
@@ -34,7 +34,7 @@
                 </div>
             </details>
             {% if invoice_address_asked %}
-                <details class="panel panel-default" {% if event.settings.invoice_address_required or event.settings.invoice_name_required %}open{% endif %}>
+                <details class="panel panel-default" {% if invoice_address_open %}open{% endif %} id="invoice-details">
                     <summary class="panel-heading">
                         <h3 class="panel-title">
                             <strong>{% trans "Invoice information" %}{% if not event.settings.invoice_address_required and not event.settings.invoice_name_required %}


### PR DESCRIPTION
When e.g. jumping in checkout-steps to edit invoice-info, this PR improves the heuristic, whether the invoice-panel needs to be shown open. Usually when invoice is optional it was closed. This PR adds the option to force-open the invoice panel by respecting the `GET.invoice` parameter (useful when linking to modify-invoice-info from the checkout-review-step), but also inspects initial values in the invoice-form to respect pre-filled values from widget-data or even plugins using the signal `contact_form_fields_overrides`.