### PR TITLE
Sendmail: Rename "automated emails" to "scheduled emails"

### DIFF
--- a/doc/api/resources/sendmail_rules.rst
+++ b/doc/api/resources/sendmail_rules.rst
@@ -1,10 +1,10 @@
-Automated email rules
+Scheduled email rules
 =====================
 
 Resource description
 --------------------
 
-Automated email rules that specify emails that the system will send automatically at a specific point in time, e.g.
+Scheduled email rules that specify emails that the system will send automatically at a specific point in time, e.g.
 the day of the event.
 
 .. rst-class:: rest-resource-table

--- a/src/pretix/locale/ang/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ang/LC_MESSAGES/django.po
@@ -24799,7 +24799,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24877,7 +24877,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24924,7 +24924,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/ar/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ar/LC_MESSAGES/django.po
@@ -28366,7 +28366,7 @@ msgstr[5] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "البريد الإلكتروني للحاضر"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28460,7 +28460,7 @@ msgstr "إنشاء مستخدم جديد"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28523,7 +28523,7 @@ msgstr "اختيار البيانات"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee e-mail address"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "عنوان البريد الإلكتروني للحاضر"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/ca/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ca/LC_MESSAGES/django.po
@@ -28023,7 +28023,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Correu electrònic de l'assistent"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28119,7 +28119,7 @@ msgstr "Crear un nou usuari"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28176,7 +28176,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee e-mail address"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Correu electrònic de l'assistent"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/cs/LC_MESSAGES/django.po
+++ b/src/pretix/locale/cs/LC_MESSAGES/django.po
@@ -27060,7 +27060,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27138,7 +27138,7 @@ msgstr "Vytvořit e-mailové pravidlo"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27185,7 +27185,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/cy/LC_MESSAGES/django.po
+++ b/src/pretix/locale/cy/LC_MESSAGES/django.po
@@ -24800,7 +24800,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24878,7 +24878,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24925,7 +24925,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/da/LC_MESSAGES/django.po
+++ b/src/pretix/locale/da/LC_MESSAGES/django.po
@@ -27171,7 +27171,7 @@ msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "E-mailadresse"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27258,7 +27258,7 @@ msgstr "Opret en ny bruger"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27311,7 +27311,7 @@ msgstr "intet valgt"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "E-mailadresse"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -28103,8 +28103,8 @@ msgstr[0] "%(count)d Tag vor Veranstaltungsbeginn um %(time)s"
 msgstr[1] "%(count)d Tage vor Veranstaltungsbeginn um %(time)s"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
-msgstr "Automatisierte E-Mails"
+msgid "Scheduled emails"
+msgstr "Geplante E-Mails"
 
 #: pretix/plugins/sendmail/signals.py:122
 msgid "Mass email was sent to customers or attendees."
@@ -28183,9 +28183,9 @@ msgstr "Neue Regel erstellen"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
-"Automatische E-Mails werden nicht verschickt, solange Ihr Ticketshop offline "
+"Geplante E-Mails werden nicht verschickt, solange Ihr Ticketshop offline "
 "ist."
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28236,8 +28236,8 @@ msgstr "Letzte Berechnung"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
-msgstr "Regeln für automatisierte E-Mails"
+msgid "Scheduled email rules"
+msgstr "Regeln für geplante E-Mails"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8
 msgid ""

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -28055,8 +28055,8 @@ msgstr[0] "%(count)d Tag vor Veranstaltungsbeginn um %(time)s"
 msgstr[1] "%(count)d Tage vor Veranstaltungsbeginn um %(time)s"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
-msgstr "Automatisierte E-Mails"
+msgid "Scheduled emails"
+msgstr "Geplante E-Mails"
 
 #: pretix/plugins/sendmail/signals.py:122
 msgid "Mass email was sent to customers or attendees."
@@ -28135,9 +28135,9 @@ msgstr "Neue Regel erstellen"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
-"Automatische E-Mails werden nicht verschickt, solange Ihr Ticketshop offline "
+"Geplante E-Mails werden nicht verschickt, solange Ihr Ticketshop offline "
 "ist."
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28188,8 +28188,8 @@ msgstr "Letzte Berechnung"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
-msgstr "Regeln für automatisierte E-Mails"
+msgid "Scheduled email rules"
+msgstr "Regeln für geplante E-Mails"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8
 msgid ""

--- a/src/pretix/locale/django.pot
+++ b/src/pretix/locale/django.pot
@@ -24800,7 +24800,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24878,7 +24878,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24925,7 +24925,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/el/LC_MESSAGES/django.po
+++ b/src/pretix/locale/el/LC_MESSAGES/django.po
@@ -29895,7 +29895,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Email συμμετεχόντος"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -29994,7 +29994,7 @@ msgstr "Δημιουργία νέου χρήστη"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -30060,7 +30060,7 @@ msgstr "Επιλογή δεδομένων"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Email συμμετεχόντος"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/enm/LC_MESSAGES/django.po
+++ b/src/pretix/locale/enm/LC_MESSAGES/django.po
@@ -24799,7 +24799,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24877,7 +24877,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24924,7 +24924,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/es/LC_MESSAGES/django.po
+++ b/src/pretix/locale/es/LC_MESSAGES/django.po
@@ -29453,7 +29453,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Correo electrónico del participante"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -29556,7 +29556,7 @@ msgstr "Crear un nuevo usuario"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -29617,7 +29617,7 @@ msgstr "Selección de datos"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Correo electrónico del participante"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/fi/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fi/LC_MESSAGES/django.po
@@ -25621,7 +25621,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -25700,7 +25700,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -25747,7 +25747,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/fr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fr/LC_MESSAGES/django.po
@@ -28317,7 +28317,7 @@ msgstr[0] "%(count)d jour avant le début de l'événement à %(time)s"
 msgstr[1] "%(count)d jours avant le début de l'événement à %(time)s"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "E-mails automatisés"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28398,7 +28398,7 @@ msgstr "Créer une règle d’e-mail"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 "Les e-mails automatisés ne sont pas envoyés tant que votre billetterie est "
 "hors ligne."
@@ -28451,7 +28451,7 @@ msgstr "Calcul du dernier planning"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Règles d’e-mails automatiques"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/gl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/gl/LC_MESSAGES/django.po
@@ -30019,7 +30019,7 @@ msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Correo electrónico del participante"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -30113,7 +30113,7 @@ msgstr "Crear un nuevo usuario"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -30168,7 +30168,7 @@ msgstr "Selección de datos"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Correo electrónico del participante"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/he/LC_MESSAGES/django.po
+++ b/src/pretix/locale/he/LC_MESSAGES/django.po
@@ -24825,7 +24825,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24903,7 +24903,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24950,7 +24950,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/hr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/hr/LC_MESSAGES/django.po
@@ -24809,7 +24809,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24887,7 +24887,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24934,7 +24934,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/hu/LC_MESSAGES/django.po
+++ b/src/pretix/locale/hu/LC_MESSAGES/django.po
@@ -25417,7 +25417,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -25503,7 +25503,7 @@ msgstr "Kifizetett megrendelések"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -25552,7 +25552,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/id/LC_MESSAGES/django.po
+++ b/src/pretix/locale/id/LC_MESSAGES/django.po
@@ -24799,7 +24799,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24877,7 +24877,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24924,7 +24924,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/it/LC_MESSAGES/django.po
+++ b/src/pretix/locale/it/LC_MESSAGES/django.po
@@ -25888,7 +25888,7 @@ msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Email partecipante"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -25978,7 +25978,7 @@ msgstr "Data di creazione"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -26028,7 +26028,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Email partecipante"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/ja/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ja/LC_MESSAGES/django.po
@@ -25094,7 +25094,7 @@ msgid_plural "%(count)d days before event start at %(time)s"
 msgstr[0] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -25172,7 +25172,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -25219,7 +25219,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/ko/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ko/LC_MESSAGES/django.po
@@ -24800,7 +24800,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24878,7 +24878,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24925,7 +24925,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/lt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/lt/LC_MESSAGES/django.po
@@ -24801,7 +24801,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24879,7 +24879,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24926,7 +24926,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/lv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/lv/LC_MESSAGES/django.po
@@ -26285,7 +26285,7 @@ msgstr[2] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Apmeklētāja e-pasts"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -26365,7 +26365,7 @@ msgstr "Datums un laiks"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -26422,7 +26422,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Apmeklētāja e-pasts"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/nan/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nan/LC_MESSAGES/django.po
@@ -24799,7 +24799,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24877,7 +24877,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24924,7 +24924,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
@@ -25337,7 +25337,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -25419,7 +25419,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -25466,7 +25466,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/nl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl/LC_MESSAGES/django.po
@@ -28479,7 +28479,7 @@ msgstr[0] "%(count)d dag voor de start van het evenement om %(time)s"
 msgstr[1] "%(count)d dagen voor de start van het evenement om %(time)s"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Automatische e-mails"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28567,7 +28567,7 @@ msgstr "Maak e-mailregel"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28622,7 +28622,7 @@ msgstr "Laatst uitgevoerd"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Automatische e-mailregels"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
@@ -24801,7 +24801,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24879,7 +24879,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24926,7 +24926,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
@@ -28783,7 +28783,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "E-mailadres van gast"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28877,7 +28877,7 @@ msgstr "Maak een nieuwe gebruiker aan"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28941,7 +28941,7 @@ msgstr "Datakeuze"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee e-mail address"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "E-mailadres van gast"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/pl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl/LC_MESSAGES/django.po
@@ -26566,7 +26566,7 @@ msgstr[2] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Adres email uczestnika"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -26660,7 +26660,7 @@ msgstr "Data stworzenia"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -26711,7 +26711,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Adres email uczestnika"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
@@ -24820,7 +24820,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24898,7 +24898,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24945,7 +24945,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/pt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt/LC_MESSAGES/django.po
@@ -25093,7 +25093,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -25171,7 +25171,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -25218,7 +25218,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
@@ -27358,7 +27358,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "E-mail do participante"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27452,7 +27452,7 @@ msgstr "Tipo de dispositivo"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27506,7 +27506,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "E-mail do participante"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
@@ -28193,7 +28193,7 @@ msgstr[0] "%(count)d dia antes do início do evento às %(time)s"
 msgstr[1] "%(count)d dias antes do início do evento às %(time)s"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "E -mails automatizados"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28275,7 +28275,7 @@ msgstr "Crie regra de email"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28326,7 +28326,7 @@ msgstr "Última programação Computação"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Regras de email automatizadas"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/ro/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ro/LC_MESSAGES/django.po
@@ -28777,7 +28777,7 @@ msgstr[1] "cu %(count)d zile înainte de începerea evenimentului la %(time)s"
 msgstr[2] "cu %(count)d zile înainte de începerea evenimentului la %(time)s"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "E-mailuri automate"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28861,7 +28861,7 @@ msgstr "Creați o regulă de e-mail"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28914,7 +28914,7 @@ msgstr "Calculul ultimului program"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Reguli automatizate de e-mail"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/ru/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ru/LC_MESSAGES/django.po
@@ -27155,7 +27155,7 @@ msgstr[2] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Адрес электронной почты посетителя"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27241,7 +27241,7 @@ msgstr "Дата и время"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27297,7 +27297,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Адрес электронной почты посетителя"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/si/LC_MESSAGES/django.po
+++ b/src/pretix/locale/si/LC_MESSAGES/django.po
@@ -24872,7 +24872,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24950,7 +24950,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24997,7 +24997,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/sl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sl/LC_MESSAGES/django.po
@@ -26953,7 +26953,7 @@ msgstr[3] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Email udeleženca"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27041,7 +27041,7 @@ msgstr "Datum ustvarjenja"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27094,7 +27094,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee e-mail address"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "E-poštni naslov udeleženca"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/sv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sv/LC_MESSAGES/django.po
@@ -26970,7 +26970,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Epost till deltagare"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27056,7 +27056,7 @@ msgstr "Avbryt beställning"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27107,7 +27107,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Epost till deltagare"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/th/LC_MESSAGES/django.po
+++ b/src/pretix/locale/th/LC_MESSAGES/django.po
@@ -24802,7 +24802,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24880,7 +24880,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24927,7 +24927,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/tr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/tr/LC_MESSAGES/django.po
@@ -29881,7 +29881,7 @@ msgstr[1] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Katılımcı e-postası"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -29986,7 +29986,7 @@ msgstr "Yeni bir kullanıcı oluştur"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -30050,7 +30050,7 @@ msgstr "Veri seçimi"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "Katılımcı e-postası"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/uk/LC_MESSAGES/django.po
+++ b/src/pretix/locale/uk/LC_MESSAGES/django.po
@@ -27634,7 +27634,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "Автоматизовані електронні листи"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -27718,7 +27718,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -27768,7 +27768,7 @@ msgstr "Останній розрахунок графіка"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/vi/LC_MESSAGES/django.po
+++ b/src/pretix/locale/vi/LC_MESSAGES/django.po
@@ -24809,7 +24809,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr ""
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -24887,7 +24887,7 @@ msgstr ""
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -24934,7 +24934,7 @@ msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
@@ -28499,7 +28499,7 @@ msgstr[0] ""
 #: pretix/plugins/sendmail/signals.py:99
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "观众Email"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -28604,7 +28604,7 @@ msgstr "创建一个新用户"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr ""
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -28667,7 +28667,7 @@ msgstr "数据选择"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
 #, fuzzy
 #| msgid "Attendee email"
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "观众Email"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hant/LC_MESSAGES/django.po
@@ -26261,7 +26261,7 @@ msgstr[0] ""
 "%(count)d 事件在%(time)s開始的前一天 , 事件在%(time)s開始前的%(count)d天"
 
 #: pretix/plugins/sendmail/signals.py:99
-msgid "Automated emails"
+msgid "Scheduled emails"
 msgstr "自動電子郵件"
 
 #: pretix/plugins/sendmail/signals.py:122
@@ -26339,7 +26339,7 @@ msgstr "建立電子郵件規則"
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html:14
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:15
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html:10
-msgid "Automated emails are not sent as long as your ticket shop is offline."
+msgid "Scheduled emails are not sent as long as your ticket shop is offline."
 msgstr "只要你的售票店處於離線狀態，就不會發送自動電子郵件。"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html:44
@@ -26388,7 +26388,7 @@ msgstr "最後排程計算"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:4
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:6
-msgid "Automated email rules"
+msgid "Scheduled email rules"
 msgstr "自動電子郵件規則"
 
 #: pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html:8

--- a/src/pretix/plugins/sendmail/signals.py
+++ b/src/pretix/plugins/sendmail/signals.py
@@ -96,7 +96,7 @@ def control_nav_import(sender, request=None, **kwargs):
                     'active': (url.namespace == 'plugins:sendmail' and url.url_name.startswith('send')),
                 },
                 {
-                    'label': _('Automated emails'),
+                    'label': _('Scheduled emails'),
                     'url': reverse('plugins:sendmail:rule.list', kwargs={
                         'event': request.event.slug,
                         'organizer': request.event.organizer.slug,

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_create.html
@@ -6,7 +6,7 @@
     <h1>{% trans "Create Email Rule" %}</h1>
     {% if not request.event.live %}
         <div class="alert alert-warning">
-            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+            {% trans "Scheduled emails are not sent as long as your ticket shop is offline." %}
         </div>
     {% endif %}
     {% block inner %}

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_inspect.html
@@ -11,7 +11,7 @@
     </p>
     {% if not request.event.live %}
         <div class="alert alert-warning">
-            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+            {% trans "Scheduled emails are not sent as long as your ticket shop is offline." %}
         </div>
     {% endif %}
     <dl class="dl-horizontal">

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_list.html
@@ -1,9 +1,9 @@
 {% extends "pretixcontrol/event/base.html" %}
 {% load i18n %}
 {% load static %}
-{% block title %}{% trans "Automated email rules" %}{% endblock %}
+{% block title %}{% trans "Scheduled email rules" %}{% endblock %}
 {% block content %}
-    <h1>{% trans "Automated email rules" %}</h1>
+    <h1>{% trans "Scheduled email rules" %}</h1>
     <p>
         {% blocktrans trimmed %}
             Email rules allow you to automatically send emails to your customers at a specific time before or after
@@ -12,7 +12,7 @@
     </p>
     {% if not request.event.live %}
         <div class="alert alert-warning">
-            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+            {% trans "Scheduled emails are not sent as long as your ticket shop is offline." %}
         </div>
     {% endif %}
 

--- a/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html
+++ b/src/pretix/plugins/sendmail/templates/pretixplugins/sendmail/rule_update.html
@@ -7,7 +7,7 @@
     <h1>{% trans "Update Email Rule" %}</h1>
     {% if not request.event.live %}
         <div class="alert alert-warning">
-            {% trans "Automated emails are not sent as long as your ticket shop is offline." %}
+            {% trans "Scheduled emails are not sent as long as your ticket shop is offline." %}
         </div>
     {% endif %}
     {% block inner %}


### PR DESCRIPTION
It's more precise and does not confuse things with transactional emailing