### PR TITLE
Enable phonenumber question during checkin

### DIFF
--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -1463,7 +1463,7 @@ class Question(LoggedModel):
         (TYPE_PHONENUMBER, _("Phone number")),
     )
     UNLOCALIZED_TYPES = [TYPE_DATE, TYPE_TIME, TYPE_DATETIME]
-    ASK_DURING_CHECKIN_UNSUPPORTED = [TYPE_PHONENUMBER]
+    ASK_DURING_CHECKIN_UNSUPPORTED = []
 
     event = models.ForeignKey(
         Event,


### PR DESCRIPTION
This has been supported by our apps for some time now (Android with https://github.com/pretix/libpretixui-android/commit/795f855e6b8060f9680e9919de0aff46bebe3232, iOS with https://github.com/pretix/pretixscan-ios/commit/c31f06067dfe763cfff2369f496b014d7d80573e)