### PR TITLE
Control: add link to orders for each subevent in list of subevents (Z#23129436)

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/subevents/index.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/index.html
@@ -165,6 +165,8 @@
                                 {% endif %}
                             </td>
                             <td class="text-right flip">
+                                <a href="{% url "control:event.orders" organizer=request.event.organizer.slug event=request.event.slug %}?subevent={{ s.id }}" class="btn btn-default btn-sm" title="{% trans "Show orders" %}"><i class="fa fa-shopping-cart" aria-hidden="true"></i></a>
+
                                 <a href="{% url "control:event.subevent" organizer=request.event.organizer.slug event=request.event.slug subevent=s.id %}?returnto={{ request.GET.urlencode|urlencode }}" class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>
                                 <div class="btn-group {% if forloop.revcounter0 < 2 %}dropup{% endif %}">
                                     <button type="button" class="btn btn-default btn-sm dropdown-toggle"


### PR DESCRIPTION
This is the most naive approach to add a link to the orders overview to each element of the subevents list. Currently it does not even check the quotas if any orders are available for that subevent – maybe we could add that check and disable the link? 