### PR TITLE
API: Add parent event slug to subevent list search

### DIFF
--- a/doc/api/resources/subevents.rst
+++ b/doc/api/resources/subevents.rst
@@ -70,7 +70,7 @@ last_modified                         datetime                   Last modificati
 
 .. versionchanged:: 2023.8.0
 
-    The ``search`` query parameter has been modified to filter sub-events by their parent events slug too.
+    For the organizer-wide endpoint, the ``search`` query parameter has been modified to filter sub-events by their parent events slug too.
 
 Endpoints
 ---------

--- a/doc/api/resources/subevents.rst
+++ b/doc/api/resources/subevents.rst
@@ -68,6 +68,10 @@ last_modified                         datetime                   Last modificati
     The ``date_from_before``, ``date_from_after``, ``date_to_before``, and ``date_to_after`` query parameters have been
     added.
 
+.. versionchanged:: 2023.8.0
+
+    The ``search`` query parameter has been modified to filter sub-events by their parent events slug too.
+
 Endpoints
 ---------
 
@@ -472,6 +476,7 @@ Endpoints
    :query date_to_after: If set to a date and time, only events that have an end date and end at or after the given time are returned.
    :query date_to_before: If set to a date and time, only events that have an end date and end at or before the given time are returned.
    :query ends_after: If set to a date and time, only events that happen during of after the given time are returned.
+   :query search: Only return events matching a given search query.
    :query sales_channel: If set to a sales channel identifier, the response will only contain subevents from events available on this sales channel.
    :param organizer: The ``slug`` field of a valid organizer
    :param event: The ``slug`` field of the event to fetch

--- a/src/pretix/api/views/event.py
+++ b/src/pretix/api/views/event.py
@@ -378,6 +378,7 @@ with scopes_disabled():
         def search_qs(self, queryset, name, value):
             return queryset.filter(
                 Q(name__icontains=i18ncomp(value))
+                | Q(event__slug__icontains=value)
                 | Q(location__icontains=i18ncomp(value))
             )
 

--- a/src/tests/api/test_subevents.py
+++ b/src/tests/api/test_subevents.py
@@ -208,6 +208,53 @@ def test_subevent_list_filter(token_client, organizer, event, subevent):
 
 
 @pytest.mark.django_db
+def test_all_subevents_list_filter(token_client, organizer, event, subevent):
+    resp = token_client.get('/api/v1/organizers/{}/subevents/?attr[type]=Workshop'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+
+    resp = token_client.get('/api/v1/organizers/{}/subevents/?attr[type]=Conference'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 0
+
+    resp = token_client.get('/api/v1/organizers/{}/subevents/?search=Foobar'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+
+    resp = token_client.get('/api/v1/organizers/{}/subevents/?search=Barfoo'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 0
+
+    resp = token_client.get('/api/v1/organizers/{}/subevents/?search=dummy'.format(organizer.slug))
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/subevents/?date_from_after=2017-12-27T10:00:00Z'.format(organizer.slug)
+    )
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/subevents/?date_from_after=2017-12-27T10:00:01Z'.format(organizer.slug)
+    )
+    assert resp.status_code == 200
+    assert resp.data['count'] == 0
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/subevents/?date_from_before=2017-12-27T10:00:00Z'.format(organizer.slug)
+    )
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/subevents/?date_from_before=2017-12-27T09:59:00Z'.format(organizer.slug)
+    )
+    assert resp.status_code == 200
+    assert resp.data['count'] == 0
+
+
+@pytest.mark.django_db
 def test_subevent_create(team, token_client, organizer, event, subevent, meta_prop, item):
     meta_prop.allowed_values = "Conference\nWorkshop"
     meta_prop.save()


### PR DESCRIPTION
Found while adding support for subevents to pretix kiosk:
If the sub-event _name_ contains the slug by accident, the sub-event is found by the `SubEventFilter`, but if not, no results are returned. The main `EventFilter` already supports search for the event slug thanks to https://github.com/pretix/pretix/commit/71e7df303812a6f2c2b80ace1ab42335ca022be6 - this adds it for the sub-events. 