### PR TITLE
Payment: Add setting to prevent reminder mails (Z#23123914)

### DIFF
--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -441,6 +441,13 @@ class BasePaymentProvider:
                      'Share this link with customers who should use this payment method.'
                  ),
              )),
+            ('_prevent_reminder_mail',
+             forms.BooleanField(
+                 label=_('Do not send a payment reminder mail'),
+                 help_text=_('Users will not receive a reminder mail to pay for their order before it expires if '
+                             'they have chosen this payment method.'),
+                 required=False,
+             )),
         ])
         d['_restricted_countries']._as_type = list
         d['_restrict_to_sales_channels']._as_type = list
@@ -496,6 +503,14 @@ class BasePaymentProvider:
         """
         if order.status == Order.STATUS_PAID:
             return _('paid')
+
+    def prevent_reminder_mail(self, order: Order, payment: OrderPayment) -> bool:
+        """
+        This is called when a periodic task runs and sends out reminder mails to orders that have not been paid yet
+        and are soon expiring.
+        The default implementation returns the content of the _prevent_reminder_mail configuration variable (a boolean value).
+        """
+        return self.settings.get('_prevent_reminder_mail', as_type=bool, default=False)
 
     @property
     def payment_form_fields(self) -> dict:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1294,7 +1294,11 @@ def send_expiry_warnings(sender, **kwargs):
     ).only('pk', 'event_id', 'expires').order_by('event_id'):
 
         lp = o.payments.last()
-        if lp and lp.payment_provider.prevent_reminder_mail(o, lp):
+        if (
+                lp and
+                lp.state in [OrderPayment.PAYMENT_STATE_CREATED, OrderPayment.PAYMENT_STATE_PENDING] and
+                lp.payment_provider.prevent_reminder_mail(o, lp)
+        ):
             continue
 
         if event_id != o.event_id:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1289,9 +1289,14 @@ def send_expiry_warnings(sender, **kwargs):
     event_id = None
 
     for o in Order.objects.filter(
-        expires__gte=today, expiry_reminder_sent=False, status=Order.STATUS_PENDING,
-        datetime__lte=now() - timedelta(hours=2), require_approval=False
+            expires__gte=today, expiry_reminder_sent=False, status=Order.STATUS_PENDING,
+            datetime__lte=now() - timedelta(hours=2), require_approval=False
     ).only('pk', 'event_id', 'expires').order_by('event_id'):
+
+        lp = o.payments.last()
+        if lp and lp.payment_provider.prevent_reminder_mail(o, lp):
+            continue
+
         if event_id != o.event_id:
             settings = o.event.settings
             days = cache.get_or_set('{}:{}:setting_mail_days_order_expire_warning'.format('event', o.event_id),


### PR DESCRIPTION
This adds a payment provider setting to prevent payment reminder mails to be sent if that provider is chosen for payment. The setting is accessed (via method that could be overwritten in specific payment providers if needed) during the periodic task sending out those reminder mails.