### PR TITLE
Fix: keep is_business heuristic result for a longer time (Z#23126061)

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1145,9 +1145,8 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
     def _get_is_business_heuristic(self):
         key = 'checkout_heuristic_is_business:' + str(self.event.pk)
         cached_result = caches['default'].get(key, default=False)
-        if not caches['default'].get(key + ':valid'):
-            if caches['default'].add(key + ':valid', True, timeout=10):  # set valid while query is running
-                QuestionsStep._update_is_business_heuristic.apply_async(args=(self.event.pk,))
+        if caches['default'].add(key + ':valid', True, timeout=10):  # set valid while query is running
+            QuestionsStep._update_is_business_heuristic.apply_async(args=(self.event.pk,))
         return cached_result
 
     @staticmethod


### PR DESCRIPTION
Otherwise, we present a wrong heuristic result every twelve hours.

This is fixed by storing the cached value (long-lived, 30 days) and a validity flag (short-lived, 12 hours) separately. If the validity flag is expired, we still return the old value for the current request, but trigger a new calculation in a background task. After calculating, we set a new validity flag and update the cached value.