### PR TITLE
Allow to refund currencies with zero decimals

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/order/index.html
+++ b/src/pretix/control/templates/pretixcontrol/order/index.html
@@ -110,7 +110,7 @@
             <input type="hidden" name="start-action" value="do_nothing">
             <input type="hidden" name="start-mode" value="partial">
             {% localize off %}
-            <input type="hidden" name="start-partial_amount" value="{{ overpaid|floatformat:2 }}">
+            <input type="hidden" name="start-partial_amount" value="{{ overpaid|money_numberfield:request.event.currency }}">
             {% endlocalize %}
             <input type="hidden" name="comment" value="{% trans "Refund for overpayment" %}">
             <div class="alert alert-warning">

--- a/src/pretix/control/templates/pretixcontrol/order/refund_choose.html
+++ b/src/pretix/control/templates/pretixcontrol/order/refund_choose.html
@@ -51,9 +51,9 @@
                                     <div class="input-group">
                                         <input type="text" name="refund-{{ p.pk }}"
                                                 {% if p.propose_refund %}
-                                                    value="{{ p.propose_refund|floatformat:2 }}"
+                                                    value="{{ p.propose_refund|money_numberfield:request.event.currency }}"
                                                 {% else %}
-                                                    placeholder="{{ p.propose_refund|floatformat:2 }}"
+                                                    placeholder="{{ p.propose_refund|money_numberfield:request.event.currency }}"
                                                 {% endif %}
                                                 title="" class="form-control">
                                         <span class="input-group-addon">
@@ -63,7 +63,7 @@
                                 {% elif p.full_refund_possible %}
                                     <label class="checkbox">
                                         <input type="checkbox" name="refund-{{ p.pk }}"
-                                                value="{{ p.amount|floatformat:2 }}"
+                                                value="{{ p.amount|money_numberfield:request.event.currency }}"
                                                 {% if p.propose_refund == p.amount %}checked{% endif %}>
                                         {% trans "Full amount" %} ({{ p.amount|money:request.event.currency }})
                                     </label>
@@ -101,7 +101,7 @@
                             <td class="text-right flip refund-amount">
                                 <div class="input-group">
                                     <input type="text" name="newrefund-{{ prov }}"
-                                            placeholder="{{ 0|floatformat:2 }}"
+                                            placeholder="{{ 0|money_numberfield:request.event.currency }}"
                                             title="" class="form-control">
                                     <span class="input-group-addon">
                                         {{ request.event.currency }}
@@ -119,7 +119,7 @@
                         <td class="text-right flip refund-amount">
                             <div class="input-group">
                                 <input type="text" name="refund-offsetting"
-                                        title="" class="form-control" placeholder="{{ 0|floatformat:2 }}">
+                                        title="" class="form-control" placeholder="{{ 0|money_numberfield:request.event.currency }}">
                                 <span class="input-group-addon">
                                     {{ request.event.currency }}
                                 </span>
@@ -144,9 +144,9 @@
                                 <input type="text" name="refund-new-giftcard"
                                         title="" class="form-control"
                                         {% if giftcard_proposal %}
-                                            value="{{ giftcard_proposal|floatformat:2 }}"
+                                            value="{{ giftcard_proposal|money_numberfield:request.event.currency }}"
                                         {% else %}
-                                            placeholder="{{ giftcard_proposal|floatformat:2 }}"
+                                            placeholder="{{ giftcard_proposal|money_numberfield:request.event.currency }}"
                                         {% endif %}
                                 >
                                 <span class="input-group-addon">
@@ -172,9 +172,9 @@
                             <div class="input-group">
                                 <input type="text" name="refund-manual"
                                         {% if remainder %}
-                                            value="{{ remainder|floatformat:2 }}"
+                                            value="{{ remainder|money_numberfield:request.event.currency }}"
                                         {% else %}
-                                            placeholder="{{ remainder|floatformat:2 }}"
+                                            placeholder="{{ remainder|money_numberfield:request.event.currency }}"
                                         {% endif %}
                                         title="" class="form-control">
                                 <span class="input-group-addon">

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -1472,7 +1472,7 @@ class OrderTransition(OrderView):
                                 'organizer': self.request.event.organizer.slug,
                                 'code': self.order.code
                             }) + '?start-action=do_nothing&start-mode=partial&start-partial_amount={}&giftcard={}&comment={}'.format(
-                                round_decimal(self.order.pending_sum * -1),
+                                round_decimal(self.order.pending_sum * -1, self.order.event.currency),
                                 'true' if self.req and self.req.refund_as_giftcard else 'false',
                                 quote(gettext('Order canceled'))
                             ))


### PR DESCRIPTION
This is in relation to Z#23129921.

This fixes the immediate issue at hand, but we should probably comb through all templates and replace any `|floatformat:2` with `|money_numberfield:request.event.currency` where appropriate?