### PR TITLE
Display amounts with currency-derived decimals

### DIFF
--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/control.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/control.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load money %}
 
 {% if payment_info %}
     <dl class="dl-horizontal">
@@ -59,7 +60,7 @@
         {% endif %}
         {% if "amount" in payment_info %}
             <dt>{% trans "Total value" %}</dt>
-            <dd>{{ payment_info.amount|floatformat:2 }}</dd>
+            <dd>{{ payment_info.amount|money_numberfield:event.currency }}</dd>
         {% endif %}
         {% if "currency" in payment_info %}
             <dt>{% trans "Currency" %}</dt>

--- a/src/pretix/presale/templates/pretixpresale/event/order_pay.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order_pay.html
@@ -1,6 +1,7 @@
 {% extends "pretixpresale/event/base.html" %}
 {% load i18n %}
 {% load eventurl %}
+{% load money %}
 {% block title %}{% trans "Pay order" %}{% endblock %}
 {% block content %}
     <h2>
@@ -9,7 +10,7 @@
         {% endblocktrans %}
     </h2>
 
-    <form method="post" class="form-horizontal" href="" data-total="{{ order.total|floatformat:2 }}">
+    <form method="post" class="form-horizontal" href="" data-total="{{ order.total|money_numberfield:request.event.currency }}">
         {% csrf_token %}
         <input type="hidden" name="payment" value="{{ provider.identifier }}">
         <div class="form-horizontal payment-redo-form">

--- a/src/pretix/presale/templates/pretixpresale/event/order_pay_change.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order_pay_change.html
@@ -23,7 +23,7 @@
         {% csrf_token %}
         <div class="panel-group" id="payment_accordion">
             {% for p in providers %}
-                <div class="panel panel-default" data-total="{{ p.total|floatformat:2 }}">
+                <div class="panel panel-default" data-total="{{ p.total|money_numberfield:request.event.currency }}">
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <label class="radio">


### PR DESCRIPTION
This is the continuation of #3583.

I also did a quick scan for `round_decimal()` and I think we should have covered everything with this (except for plugins)