### PR TITLE
Docker setup: Change default number of workers to `2 * $(nproc)`

### DIFF
--- a/deployment/docker/pretix.bash
+++ b/deployment/docker/pretix.bash
@@ -5,7 +5,7 @@ export DATA_DIR=/data/
 export HOME=/pretix
 
 AUTOMIGRATE=${AUTOMIGRATE:-yes}
-NUM_WORKERS_DEFAULT=$((2 * $(nproc --all)))
+NUM_WORKERS_DEFAULT=$((2 * $(nproc)))
 export NUM_WORKERS=${NUM_WORKERS:-$NUM_WORKERS_DEFAULT}
 
 if [ ! -d /data/logs ]; then


### PR DESCRIPTION
The current default `2 * $(nproc --all)` is based on the number of installed processors. Changing this to `2 * $(nproc)` only counts CPUs available to the current process.

This change is required since somewhere between glibc 2.31 (Debian 11) and 2.36 (Debian 12) the algorithm to determine the number of configured processors on Linux changed from [counting the number of `cpu[0-9]+` entries in `/sys/devices/system/cpu`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/getsysstats.c;h=1ef077f9af465384eb3098f545ec55b3b97f19d3;hb=refs/heads/release/2.31/master#l242) to [reading `/sys/devices/system/cpu/possible`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/getsysstats.c;h=064eaa08ae2f79b6f5ffb580c7d77b318494a804;hb=refs/heads/release/2.36/master#l231), which according to [this Stack Exchange answer](https://unix.stackexchange.com/a/609563) gives the number of CPUs the kernel has memory for (e.g. to support hot plugging).

On our pretix VM, for example, the latter is four times greater than the number of available processing units, thus creating too many workers and overloading the server.