### PR TITLE
Subevent editor: Allow plugins to declare form titles

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
@@ -599,26 +599,27 @@
                     </button>
                 </p>
         </fieldset>
+        {% for f in plugin_forms %}
+            {% if f.title %}
+                <fieldset>
+                    <legend>{{ f.title }}</legend>
+                    {% if f.template %}
+                        {% include f.template with form=f %}
+                    {% else %}
+                        {% bootstrap_form f layout="control" %}
+                    {% endif %}
+                </fieldset>
+            {% endif %}
+        {% endfor %}
         <fieldset>
             <legend>{% trans "Additional settings" %}</legend>
             {% for f in plugin_forms %}
-                {% if f.title %}
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <h3 class="panel-title">
-                                {{ f.title }}
-                            </h3>
-                        </div>
-                        <div class="panel-body">
-                            {% if f.template %}
-                                {% include f.template with form=f %}
-                            {% else %}
-                                {% bootstrap_form f layout="control" %}
-                            {% endif %}
-                        </div>
-                    </div>
-                {% else %}
-                    {% bootstrap_form f layout="control" %}
+                {% if not f.title %}
+                    {% if f.template %}
+                        {% include f.template with form=f %}
+                    {% else %}
+                        {% bootstrap_form f layout="control" %}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         </fieldset>

--- a/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
@@ -602,7 +602,24 @@
         <fieldset>
             <legend>{% trans "Additional settings" %}</legend>
             {% for f in plugin_forms %}
-                {% bootstrap_form f layout="control" %}
+                {% if f.title %}
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">
+                                {{ f.title }}
+                            </h3>
+                        </div>
+                        <div class="panel-body">
+                            {% if f.template %}
+                                {% include f.template with form=f %}
+                            {% else %}
+                                {% bootstrap_form f layout="control" %}
+                            {% endif %}
+                        </div>
+                    </div>
+                {% else %}
+                    {% bootstrap_form f layout="control" %}
+                {% endif %}
             {% endfor %}
         </fieldset>
         <div class="form-group submit-group">

--- a/src/pretix/control/templates/pretixcontrol/subevents/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/detail.html
@@ -241,26 +241,27 @@
                             </button>
                         </p>
                 </fieldset>
+                {% for f in plugin_forms %}
+                    {% if f.title %}
+                        <fieldset>
+                            <legend>{{ f.title }}</legend>
+                            {% if f.template %}
+                                {% include f.template with form=f %}
+                            {% else %}
+                                {% bootstrap_form f layout="control" %}
+                            {% endif %}
+                        </fieldset>
+                    {% endif %}
+                {% endfor %}
                 <fieldset>
                     <legend>{% trans "Additional settings" %}</legend>
                     {% for f in plugin_forms %}
-                        {% if f.title %}
-                            <div class="panel panel-default">
-                                <div class="panel-heading">
-                                    <h3 class="panel-title">
-                                        {{ f.title }}
-                                    </h3>
-                                </div>
-                                <div class="panel-body">
-                                    {% if f.template %}
-                                        {% include f.template with form=f %}
-                                    {% else %}
-                                        {% bootstrap_form f layout="control" %}
-                                    {% endif %}
-                                </div>
-                            </div>
-                        {% else %}
-                            {% bootstrap_form f layout="control" %}
+                        {% if not f.title %}
+                            {% if f.template %}
+                                {% include f.template with form=f %}
+                            {% else %}
+                                {% bootstrap_form f layout="control" %}
+                            {% endif %}
                         {% endif %}
                     {% endfor %}
                 </fieldset>

--- a/src/pretix/control/templates/pretixcontrol/subevents/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/detail.html
@@ -244,7 +244,24 @@
                 <fieldset>
                     <legend>{% trans "Additional settings" %}</legend>
                     {% for f in plugin_forms %}
-                        {% bootstrap_form f layout="control" %}
+                        {% if f.title %}
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <h3 class="panel-title">
+                                        {{ f.title }}
+                                    </h3>
+                                </div>
+                                <div class="panel-body">
+                                    {% if f.template %}
+                                        {% include f.template with form=f %}
+                                    {% else %}
+                                        {% bootstrap_form f layout="control" %}
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% else %}
+                            {% bootstrap_form f layout="control" %}
+                        {% endif %}
                     {% endfor %}
                 </fieldset>
             </div>


### PR DESCRIPTION
Somewhat analog to #3492

The panel-`<div>`s might not be the best solution for this PR.

Another idea I had was the same `<fieldset>` and `<legend>`, that are already sectioning the page. For a cleaner style, this might be preferable.

However: in that case, all form-fields that are not part of a form with a title should be grouped together *and* moved within the `Additional Settings` block to the end of the page, else it could get confusing for the user when they see
- Legend: Additional settings
- random Formfield
- Legend: Plugin
- formfield plugin
- formfield plugin
- formfield plugin
- random formfield

(Excellent showcase for this, when enabling CineSend, Seating and Kulturpass)