### PR TITLE
UI: improve distinction between placeholder and input

### DIFF
--- a/src/pretix/static/bootstrap/scss/bootstrap/_variables.scss
+++ b/src/pretix/static/bootstrap/scss/bootstrap/_variables.scss
@@ -208,7 +208,7 @@ $input-border-radius-small:      $border-radius-small !default;
 $input-border-focus:             #66afe9 !default;
 
 //** Placeholder text color
-$input-color-placeholder:        #767676 !default;
+$input-color-placeholder:        #999 !default;
 
 //** Default `.form-control` height
 $input-height-base:              ($line-height-computed + ($padding-base-vertical * 2) + 2) !default;

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -13,6 +13,10 @@ input[type=number]::-webkit-outer-spin-button {
    padding: 8px 4px;
 }
 
+.form-control::placeholder {
+  font-style: italic;
+}
+
 .sidebar-nav li > a > .fa {
   color: $navbar-inverse-bg;
 }

--- a/src/pretix/static/pretixbase/scss/_variables.scss
+++ b/src/pretix/static/pretixbase/scss/_variables.scss
@@ -20,6 +20,7 @@ $gray-lightest: lighten(#000, 97.25%);
 $font-family-sans-serif:  "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $text-color: #222222 !default;
 $text-muted: #767676 !default;
+$input-color-placeholder: lighten(#000, 70%) !default;
 
 $brand-primary: #7f5a91 !default;
 $brand-success: #50a167 !default;


### PR DESCRIPTION
#1996 changed the placeholder color inside bootstrap dependency. This PR reverts this and uses the variable `$input-color-placeholder` instead to set a lighter shade of gray to improve the distinction between placeholder and real input. This breaks color contrast for a11y, but IMHO this is still worth it, as distinction between placeholder and input is more important than being able to read placeholder content. It furthermore makes placeholder-text italic.