### PR TITLE
Product settings: improve fallback labels for PDF-layouts

### DIFF
--- a/src/pretix/plugins/ticketoutputpdf/forms.py
+++ b/src/pretix/plugins/ticketoutputpdf/forms.py
@@ -49,7 +49,7 @@ class TicketLayoutItemForm(forms.ModelForm):
             self.fields['layout'].label = _('PDF ticket layout for {channel}').format(
                 channel=self.sales_channel.verbose_name
             )
-            self.fields['layout'].empty_label = _('(Same as above)')
+            self.fields['layout'].empty_label = _('(Same as PDF ticket layout)')
         else:
             self.fields['layout'].label = _('PDF ticket layout')
             self.fields['layout'].empty_label = _('(Event default)')


### PR DESCRIPTION
When setting PDF-layouts for products, empty labels cause a fallback to another layout, which currently is marked „As above“. This PR makes empty labels more explicit to which layout this fallback points to.

Note: PlugIns using PDF-layout might need updates as well.