### PR TITLE
Improve help texts when deleting questions (Z#23134288)

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/items/question_delete.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question_delete.html
@@ -18,7 +18,7 @@
                 {% trans "Cancel" %}
             </a>
             <button type="submit" class="btn btn-danger btn-save">
-                {% trans "Delete" %}
+                {% trans "Delete question and all answers" %}
             </button>
 		</div>
 	</form>

--- a/src/pretix/control/templates/pretixcontrol/items/question_delete.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question_delete.html
@@ -8,7 +8,7 @@
 		{% csrf_token %}
 		<p>{% blocktrans %}Are you sure you want to delete the question <strong>{{ question }}</strong>?{% endblocktrans %}</p>
 		{% if dependent|length > 0 %}
-			<p>{% blocktrans %}All answers to the question given by the buyers of the following products will be <strong>lost</strong>.{% endblocktrans %}</p>
+			<p class="alert alert-warning">{% blocktrans %}All answers to the question given by the buyers of the following products will be <strong>lost</strong>.{% endblocktrans %}</p>
 			{% for item in dependent %}
 				<li><a href="{% url "control:event.item" organizer=request.event.organizer.slug event=request.event.slug item=item.pk %}">{{ item.name }}</a></li>
 			{% endfor %}

--- a/src/pretix/control/templates/pretixcontrol/items/question_delete.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question_delete.html
@@ -10,7 +10,7 @@
 		{% if dependent|length > 0 %}
 			<p class="alert alert-warning">{% blocktrans %}All answers to the question given by the buyers of the following products will be <strong>lost</strong>.{% endblocktrans %}</p>
 			{% for item in dependent %}
-				<li><a href="{% url "control:event.item" organizer=request.event.organizer.slug event=request.event.slug item=item.pk %}">{{ item.name }}</a></li>
+				<li><a href="{% url "control:event.item" organizer=request.event.organizer.slug event=request.event.slug item=item.pk %}">{{ item }}</a></li>
 			{% endfor %}
 		{% endif %}
 		<div class="form-group submit-group">

--- a/src/pretix/control/templates/pretixcontrol/items/question_delete.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question_delete.html
@@ -8,7 +8,11 @@
 		{% csrf_token %}
 		<p>{% blocktrans %}Are you sure you want to delete the question <strong>{{ question }}</strong>?{% endblocktrans %}</p>
 		{% if dependent|length > 0 %}
-			<p class="alert alert-warning">{% blocktrans %}All answers to the question given by the buyers of the following products will be <strong>lost</strong>.{% endblocktrans %}</p>
+			<div class="alert alert-warning">
+				<p>{% blocktrans %}All answers to the question given by the buyers of the following products will be <strong>lost</strong>.{% endblocktrans %}
+					{% blocktrans with url=edit_url|add:"#tab-0-1-open" %}If you want to keep the answers, <a href="{{url}}">edit the question</a> and set it to hidden.{% endblocktrans %}
+				</p>
+			</div>
 			{% for item in dependent %}
 				<li><a href="{% url "control:event.item" organizer=request.event.organizer.slug event=request.event.slug item=item.pk %}">{{ item }}</a></li>
 			{% endfor %}

--- a/src/pretix/control/views/item.py
+++ b/src/pretix/control/views/item.py
@@ -573,6 +573,11 @@ class QuestionDelete(EventPermissionRequiredMixin, CompatDeleteView):
     def get_context_data(self, *args, **kwargs) -> dict:
         context = super().get_context_data(*args, **kwargs)
         context['dependent'] = list(self.get_object().items.all())
+        context['edit_url'] = reverse('control:event.items.questions.edit', kwargs={
+            'organizer': self.request.event.organizer.slug,
+            'event': self.request.event.slug,
+            'question': self.get_object().pk,
+        })
         return context
 
     @transaction.atomic


### PR DESCRIPTION
This PR is hard for me to write a proper commit-message for. It adds a few tiny text improvements to make clear that deleting a question deletes the answer as well – although this could maybe be misinterpreted as the answer-options, that are created when having a „Choose one from a list“-question.

- changes delete-button to „Delete question and all answers“
- makes warning text more prominent by moving it inside an div.alert.alert-warning
- adding a help-text with link to set question ot hidden instead
- Fix: use internal of item if any

Is hiding a question a common operation? If so, we might add a button to do so directly in the questions overview? Or should the checkbox „hidden product“ be moved to the top of the first tab like the „Active“-checkbox on products?