### PR TITLE
Order change: Allow price reduction as long as no refund is required (Z#23135268)

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1677,8 +1677,8 @@ DEFAULTS = {
                 ('gte', _('Only allow changes if the resulting price is higher or equal than the previous price.')),
                 ('gt', _('Only allow changes if the resulting price is higher than the previous price.')),
                 ('eq', _('Only allow changes if the resulting price is equal to the previous price.')),
-                ('gte_paid', _('Allow changes regardless of price, as long as no refund is required (i.e. not more '
-                               'than the resulting price has already been paid).')),
+                ('gte_paid', _('Allow changes regardless of price, as long as no refund is required (i.e. the resulting '
+                               'price is not lower than what has already been paid).')),
                 ('any', _('Allow changes regardless of price, even if this results in a refund.')),
             )
         ),

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1677,6 +1677,8 @@ DEFAULTS = {
                 ('gte', _('Only allow changes if the resulting price is higher or equal than the previous price.')),
                 ('gt', _('Only allow changes if the resulting price is higher than the previous price.')),
                 ('eq', _('Only allow changes if the resulting price is equal to the previous price.')),
+                ('gte_paid', _('Allow changes regardless of price, as long as no refund is required (i.e. not more '
+                               'than the resulting price has already been paid).')),
                 ('any', _('Allow changes regardless of price, even if this results in a refund.')),
             )
         ),

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -1595,6 +1595,8 @@ class OrderChangeMixin:
             raise OrderError(_('You may only change your order in a way that increases the total price.'))
         if ocm._totaldiff != Decimal('0.00') and pr == 'eq':
             raise OrderError(_('You may not change your order in a way that changes the total price.'))
+        if ocm._totaldiff < Decimal('0.00') and self.order.total + ocm._totaldiff < self.order.payment_refund_sum and pr == 'gte_paid':
+            raise OrderError(_('You may not change your order in a way that would require a refund.'))
 
         if ocm._totaldiff > Decimal('0.00') and self.order.status == Order.STATUS_PAID:
             self.order.set_expires(


### PR DESCRIPTION
This adds a new strategy option for price changes in self-service order changes.