### PR TITLE
Bank transfer: Discourage payments before an order code exists (Z#23135042)

### DIFF
--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/checkout_confirm.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/checkout_confirm.html
@@ -2,33 +2,41 @@
 {% load ibanformat %}
 {% load bootstrap3 %}
 
-<p>{% blocktrans trimmed %}
-    After completing your purchase, we will ask you to transfer the money to the following
-    bank account, using a personal reference code:
-{% endblocktrans %}</p>
+{% if details or code %}
+    <p>{% blocktrans trimmed %}
+        After completing your purchase, we will ask you to transfer the money to the following
+        bank account, using a personal reference code:
+    {% endblocktrans %}</p>
 
-{% if settings.bank_details_type == "sepa" %}
-    <dl class="dl-horizontal">
-        <dt>{% trans "Account holder" %}: </dt><dd>{{ settings.bank_details_sepa_name }}</dd>
-        <dt>{% trans "IBAN" %}: </dt><dd>{{ settings.bank_details_sepa_iban|ibanformat }}</dd>
-        <dt>{% trans "BIC" %}: </dt><dd>{{ settings.bank_details_sepa_bic }}</dd>
-        <dt>{% trans "Bank" %}: </dt><dd>{{ settings.bank_details_sepa_bank }}</dd>
-    </dl>
-{% endif %}
+    {% if not code %}<div class="user-select-none" data-toggle="tooltip" title="{% trans "Please do not yet start a payment. We'll assign you a personal reference code after you completed the order." %}">{% endif %}
+    {% if settings.bank_details_type == "sepa" %}
+        <dl class="dl-horizontal">
+            <dt>{% trans "Account holder" %}: </dt><dd>{{ settings.bank_details_sepa_name }}</dd>
+            <dt>{% trans "IBAN" %}: </dt><dd>{{ settings.bank_details_sepa_iban|ibanformat }}</dd>
+            <dt>{% trans "BIC" %}: </dt><dd>{{ settings.bank_details_sepa_bic }}</dd>
+            <dt>{% trans "Bank" %}: </dt><dd>{{ settings.bank_details_sepa_bank }}</dd>
+        </dl>
+    {% endif %}
 
-{% if details %}
     {{ details|linebreaks }}
-{% endif %}
-{% if code %}
-    <dl class="dl-horizontal">
-        <dt>{% trans "Reference code (important):" %} </dt><dd><strong>{{ code }}</strong></dd>
-    </dl>
+    {% if not code %}</div>{% endif %}
+
+    {% if code %}
+        <dl class="dl-horizontal">
+            <dt>{% trans "Reference code (important):" %} </dt><dd><strong>{{ code }}</strong></dd>
+        </dl>
+    {% else %}
+        <p>
+            <strong>
+                {% trans "We will assign you a personal reference code to use after you completed the order." %}
+            </strong>
+        </p>
+    {% endif %}
 {% else %}
-    <p>
-        <strong>
-            {% trans "We will assign you a personal reference code to use after you completed the order." %}
-        </strong>
-    </p>
+    <p>{% blocktrans trimmed %}
+        After completing your purchase, we will ask you to transfer the money to our bank account, using a personal
+        reference code.
+    {% endblocktrans %}</p>
 {% endif %}
 {% if request.session.payment_banktransfer_send_invoice and request.session.payment_banktransfer_send_invoice_to %}
     <p>

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/checkout_payment_form.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/checkout_payment_form.html
@@ -2,33 +2,41 @@
 {% load ibanformat %}
 {% load bootstrap3 %}
 
-<p>{% blocktrans trimmed %}
-    After completing your purchase, we will ask you to transfer the money to the following
-    bank account, using a personal reference code:
-{% endblocktrans %}</p>
+{% if details or code %}
+    <p>{% blocktrans trimmed %}
+        After completing your purchase, we will ask you to transfer the money to the following
+        bank account, using a personal reference code:
+    {% endblocktrans %}</p>
 
-{% if settings.bank_details_type == "sepa" %}
-    <dl class="dl-horizontal">
-        <dt>{% trans "Account holder" %}: </dt><dd>{{ settings.bank_details_sepa_name }}</dd>
-        <dt>{% trans "IBAN" %}: </dt><dd>{{ settings.bank_details_sepa_iban|ibanformat }}</dd>
-        <dt>{% trans "BIC" %}: </dt><dd>{{ settings.bank_details_sepa_bic }}</dd>
-        <dt>{% trans "Bank" %}: </dt><dd>{{ settings.bank_details_sepa_bank }}</dd>
-    </dl>
-{% endif %}
+    {% if not code %}<div class="user-select-none">{% endif %}
+    {% if settings.bank_details_type == "sepa" %}
+        <dl class="dl-horizontal" data-toggle="tooltip" title="{% trans "Please do not yet start a payment. We'll assign you a personal reference code after you completed the order." %}">
+            <dt>{% trans "Account holder" %}: </dt><dd>{{ settings.bank_details_sepa_name }}</dd>
+            <dt>{% trans "IBAN" %}: </dt><dd>{{ settings.bank_details_sepa_iban|ibanformat }}</dd>
+            <dt>{% trans "BIC" %}: </dt><dd>{{ settings.bank_details_sepa_bic }}</dd>
+            <dt>{% trans "Bank" %}: </dt><dd>{{ settings.bank_details_sepa_bank }}</dd>
+        </dl>
+    {% endif %}
 
-{% if details %}
     {{ details|linebreaks }}
-{% endif %}
-{% if code %}
-    <dl class="dl-horizontal">
-        <dt>{% trans "Reference code (important):" %} </dt><dd><strong>{{ code }}</strong></dd>
-    </dl>
+    {% if not code %}</div>{% endif %}
+
+    {% if code %}
+        <dl class="dl-horizontal">
+            <dt>{% trans "Reference code (important):" %} </dt><dd><strong>{{ code }}</strong></dd>
+        </dl>
+    {% else %}
+        <p>
+            <strong>
+                {% trans "We will assign you a personal reference code to use after you completed the order." %}
+            </strong>
+        </p>
+    {% endif %}
 {% else %}
-    <p>
-        <strong>
-            {% trans "We will assign you a personal reference code to use after you completed the order." %}
-        </strong>
-    </p>
+    <p>{% blocktrans trimmed %}
+        After completing your purchase, we will ask you to transfer the money to our bank account, using a personal
+        reference code.
+    {% endblocktrans %}</p>
 {% endif %}
 {% if form.fields %}
     <div class="col-md-12">

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/checkout_payment_form.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/checkout_payment_form.html
@@ -8,9 +8,9 @@
         bank account, using a personal reference code:
     {% endblocktrans %}</p>
 
-    {% if not code %}<div class="user-select-none">{% endif %}
+    {% if not code %}<div class="user-select-none" data-toggle="tooltip" title="{% trans "Please do not yet start a payment. We'll assign you a personal reference code after you completed the order." %}">{% endif %}
     {% if settings.bank_details_type == "sepa" %}
-        <dl class="dl-horizontal" data-toggle="tooltip" title="{% trans "Please do not yet start a payment. We'll assign you a personal reference code after you completed the order." %}">
+        <dl class="dl-horizontal">
             <dt>{% trans "Account holder" %}: </dt><dd>{{ settings.bank_details_sepa_name }}</dd>
             <dt>{% trans "IBAN" %}: </dt><dd>{{ settings.bank_details_sepa_iban|ibanformat }}</dd>
             <dt>{% trans "BIC" %}: </dt><dd>{{ settings.bank_details_sepa_bic }}</dd>

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -482,6 +482,10 @@ h2 .label {
     }
 }
 
+.user-select-none {
+    user-select: none;
+}
+
 @for $i from 0 through 100 {
     .progress-bar-#{$i} { width: 1% * $i; }
 }


### PR DESCRIPTION
- If there is only SEPA account information, the bank information will no longer be shown until the order is complete
- If there is "other information" available, this change would be backwards-incompatible for some users, so we go a different route:  The bank information is no longer copy-able and if you hover it, there is a warning. This will hopefully catch users who try to copy the IBAN to early ;) 