### PR TITLE
Add customizable terms of cancellation (Z#23135646)

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -795,6 +795,8 @@ class EventSettingsSerializer(SettingsSerializer):
         'cancel_allow_user_paid_refund_as_giftcard',
         'cancel_allow_user_paid_require_approval',
         'cancel_allow_user_paid_require_approval_fee_unknown',
+        'cancel_terms_paid',
+        'cancel_terms_unpaid',
         'change_allow_user_variation',
         'change_allow_user_addons',
         'change_allow_user_until',

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1926,6 +1926,32 @@ DEFAULTS = {
             label=_("Do not allow cancellations after"),
         )
     },
+    'cancel_terms_paid': {
+        'default': None,
+        'type': LazyI18nString,
+        'serializer_class': I18nField,
+        'form_class': I18nFormField,
+        'form_kwargs': dict(
+            label=_("Terms of cancellation"),
+            widget=I18nTextarea,
+            widget_kwargs={'attrs': {'rows': '2'}},
+            help_text=_("This text will be shown when cancellation is allowed for a paid order. Leave empty if you "
+                        "want pretix to automatically generate the terms of cancellation based on your settings.")
+        )
+    },
+    'cancel_terms_unpaid': {
+        'default': None,
+        'type': LazyI18nString,
+        'serializer_class': I18nField,
+        'form_class': I18nFormField,
+        'form_kwargs': dict(
+            label=_("Terms of cancellation"),
+            widget=I18nTextarea,
+            widget_kwargs={'attrs': {'rows': '2'}},
+            help_text=_("This text will be shown when cancellation is allowed for an unpaid or free order. Leave empty "
+                        "if you want pretix to automatically generate the terms of cancellation based on your settings.")
+        )
+    },
     'contact_mail': {
         'default': None,
         'type': str,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -728,6 +728,8 @@ class CancelSettingsForm(SettingsForm):
         'cancel_allow_user_paid_refund_as_giftcard',
         'cancel_allow_user_paid_require_approval',
         'cancel_allow_user_paid_require_approval_fee_unknown',
+        'cancel_terms_paid',
+        'cancel_terms_unpaid',
         'change_allow_user_variation',
         'change_allow_user_price',
         'change_allow_user_until',

--- a/src/pretix/control/templates/pretixcontrol/event/cancel.html
+++ b/src/pretix/control/templates/pretixcontrol/event/cancel.html
@@ -14,6 +14,7 @@
                 {% bootstrap_field form.cancel_allow_user_unpaid_keep layout="control" %}
                 {% bootstrap_field form.cancel_allow_user_unpaid_keep_percentage layout="control" %}
                 {% bootstrap_field form.cancel_allow_user_unpaid_keep_fees layout="control" %}
+                {% bootstrap_field form.cancel_terms_unpaid layout="control" %}
             </fieldset>
             <fieldset>
                 <legend>{% trans "Paid orders" %}</legend>
@@ -32,6 +33,7 @@
                     {% bootstrap_field form.cancel_allow_user_paid_adjust_fees_step layout="control" %}
                 </div>
                 {% bootstrap_field form.cancel_allow_user_paid_refund_as_giftcard layout="control" %}
+                {% bootstrap_field form.cancel_terms_paid layout="control" %}
                 {% if not gets_notification %}
                     <div class="alert alert-warning">
                         {% blocktrans trimmed %}

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -345,13 +345,7 @@
         <div class="panel panel-default panel-cancellation">
             <div class="panel-heading">
                 <h3 class="panel-title">
-                    {% if order.user_cancel_deadline %}
-                        {% blocktrans trimmed context "action" with deadline=order.user_cancel_deadline %}
-                            Change or cancel your order until {{ deadline }}
-                        {% endblocktrans %}
-                    {% else %}
-                        {% trans "Change or cancel your order" context "action" %}
-                    {% endif %}
+                    {% trans "Change or cancel your order" context "action" %}
                 </h3>
             </div>
             <ul class="list-group">
@@ -472,6 +466,16 @@
                                 {% endif %}
                                 {% trans "This will invalidate all tickets in this order." %}
                             </p>
+
+                            {% if order.user_cancel_deadline %}
+                                <p>
+                                {% with date_human=order.user_cancel_deadline|date:"DATETIME_FORMAT"|safe date_iso=order.user_cancel_deadline.isoformat %}
+                                    {% blocktrans trimmed with deadline='<time datetime="'|add:date_iso|add:'">'|add:date_human|add:"</time>"|safe %}
+                                        Cancelation is possible until {{ deadline }}.
+                                    {% endblocktrans %}
+                                {% endwith %}
+                                </p>
+                            {% endif %}
                             <p>
                                 <a href="{% eventurl event 'presale:event.order.cancel' secret=order.secret order=order.code %}"
                                         class="btn btn-danger">

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -368,7 +368,9 @@
                 {% if user_cancel_allowed %}
                     <li class="list-group-item">
                         {% if order.status == "p" and order.total != 0 %}
-                            {% if request.event.settings.cancel_allow_user_paid_require_approval and request.event.settings.cancel_allow_user_paid_require_approval_fee_unknown %}
+                            {% if request.event.settings.cancel_terms_paid %}
+                                {{ request.event.settings.cancel_terms_paid|rich_text }}
+                            {% elif request.event.settings.cancel_allow_user_paid_require_approval and request.event.settings.cancel_allow_user_paid_require_approval_fee_unknown %}
                                 <p>
                                     {% blocktrans trimmed %}
                                         You can request to cancel this order.
@@ -445,45 +447,31 @@
                                     {% trans "This will invalidate all tickets in this order." %}
                                 </p>
                             {% endif %}
+                        {% else %}
                             <p>
+                                {% if request.event.settings.cancel_terms_unpaid %}
+                                    {{ request.event.settings.cancel_terms_unpaid|rich_text }}
+                                {% elif order.total != 0 and order.user_cancel_fee %}
+                                    {% blocktrans trimmed with fee=order.user_cancel_fee|money:request.event.currency %}
+                                        You can cancel this order. As per our cancellation policy, you will still be required
+                                        to pay a cancellation fee of <strong>{{ fee }}</strong>.
+                                    {% endblocktrans %}
+                                    {% trans "This will invalidate all tickets in this order." %}
+                                {% else %}
+                                    {% blocktrans trimmed %}
+                                        You can cancel this order using the following button.
+                                    {% endblocktrans %}
+                                    {% trans "This will invalidate all tickets in this order." %}
+                                {% endif %}
+                            </p>
+                        {% endif %}
+                        <p>
                             <a href="{% eventurl event 'presale:event.order.cancel' secret=order.secret order=order.code %}"
                                     class="btn btn-danger">
                                 <span class="fa fa-remove" aria-hidden="true"></span>
                                 {% trans "Cancel order" %}
                             </a>
-                            </p>
-                        {% else %}
-                            <p>
-                                {% if order.total != 0 and order.user_cancel_fee %}
-                                    {% blocktrans trimmed with fee=order.user_cancel_fee|money:request.event.currency %}
-                                        You can cancel this order. As per our cancellation policy, you will still be required
-                                        to pay a cancellation fee of <strong>{{ fee }}</strong>.
-                                    {% endblocktrans %}
-                                {% else %}
-                                    {% blocktrans trimmed %}
-                                        You can cancel this order using the following button.
-                                    {% endblocktrans %}
-                                {% endif %}
-                                {% trans "This will invalidate all tickets in this order." %}
-                            </p>
-
-                            {% if order.user_cancel_deadline %}
-                                <p>
-                                {% with date_human=order.user_cancel_deadline|date:"DATETIME_FORMAT"|safe date_iso=order.user_cancel_deadline.isoformat %}
-                                    {% blocktrans trimmed with deadline='<time datetime="'|add:date_iso|add:'">'|add:date_human|add:"</time>"|safe %}
-                                        Cancelation is possible until {{ deadline }}.
-                                    {% endblocktrans %}
-                                {% endwith %}
-                                </p>
-                            {% endif %}
-                            <p>
-                                <a href="{% eventurl event 'presale:event.order.cancel' secret=order.secret order=order.code %}"
-                                        class="btn btn-danger">
-                                    <span class="fa fa-remove" aria-hidden="true"></span>
-                                    {% trans "Cancel order" %}
-                                </a>
-                            </p>
-                        {% endif %}
+                        </p>
                     </li>
                 {% endif %}
             </ul>

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -345,7 +345,13 @@
         <div class="panel panel-default panel-cancellation">
             <div class="panel-heading">
                 <h3 class="panel-title">
-                    {% trans "Change or cancel your order" context "action" %}
+                    {% if order.user_cancel_deadline %}
+                        {% blocktrans trimmed context "action" with deadline=order.user_cancel_deadline %}
+                            Change or cancel your order until {{ deadline }}
+                        {% endblocktrans %}
+                    {% else %}
+                        {% trans "Change or cancel your order" context "action" %}
+                    {% endif %}
                 </h3>
             </div>
             <ul class="list-group">


### PR DESCRIPTION
As discussed instead of showing a date, we add customizable text snippets for terms of cancellation for unpaid/free and paid orders. If terms are available, they replace pretix’ auto-generated terms.