### PR TITLE
Add test for money filter + streamline rounding error protection logic

### DIFF
--- a/src/pretix/base/templatetags/money.py
+++ b/src/pretix/base/templatetags/money.py
@@ -48,11 +48,18 @@ def money_filter(value: Decimal, arg='', hide_currency=False):
     places = settings.CURRENCY_PLACES.get(arg, 2)
     rounded = value.quantize(Decimal('1') / 10 ** places, ROUND_HALF_UP)
     if places < 2 and rounded != value:
-        places = 2
+        # We display decimal places even if we shouldn't for this currency if rounding
+        # would make the numbers incorrect. If this branch executes, it's likely a bug in
+        # pretix, but we won't show wrong numbers!
+        if hide_currency:
+            return floatformat(value, 2)
+        else:
+            return '{} {}'.format(arg, floatformat(value, 2))
+
     if hide_currency:
         return floatformat(value, places)
 
-    locale_parts = translation.get_language().split('-', 1)
+    locale_parts = translation.get_language().split("-", 1)
     locale = locale_parts[0]
     if len(locale_parts) > 1 and len(locale_parts[1]) == 2:
         try:
@@ -61,20 +68,9 @@ def money_filter(value: Decimal, arg='', hide_currency=False):
             pass
 
     try:
-        if rounded != value:
-            # We display decimal places even if we shouldn't for this currency if rounding
-            # would make the numbers incorrect. If this branch executes, it's likely a bug in
-            # pretix, but we won't show wrong numbers!
-            return '{} {}'.format(
-                arg,
-                floatformat(value, 2)
-            )
         return format_currency(value, arg, locale=locale)
     except:
-        return '{} {}'.format(
-            arg,
-            floatformat(value, places)
-        )
+        return '{} {}'.format(arg, floatformat(value, places))
 
 
 @register.filter("money_numberfield")


### PR DESCRIPTION
This PR adds unit tests for the "money" template filter, which contains some complex logic. 

It also simplifies the rounding error protection, which was included twice, with minimally different logic, depending on the hide_currency flag (if True, only check for rounding errors if decimal places < 2; if False, always check for rounding errors). This PR only changes the behavior if hide_currency=False (the default), places >= 2.