### PR TITLE
Fix the 'data-checkbox-dependency-visual' attribute

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -328,7 +328,7 @@ var form_handlers = function (el) {
             update = function () {
                 var enabled = dependency.prop('checked');
                 dependent.prop('disabled', !enabled).closest('.form-group, .form-field-boundary').toggleClass('disabled', !enabled);
-                if (!enabled && !$(this).is('[data-checkbox-dependency-visual]')) {
+                if (!enabled && !dependent.is('[data-checkbox-dependency-visual]')) {
                     dependent.prop('checked', false);
                 }
             };


### PR DESCRIPTION
Currently, it doesn't do anything if placed on the dependent element (as it seems to be supposed to be used). If it were placed on the dependency, it would work *sometimes* (only on change, but not on page load).