### PR TITLE
This voucher code can only be redeemed %d more times.

### DIFF
--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -162,7 +162,7 @@ error_messages = {
         'to redeem it before but did not complete the checkout process. You can try to use it '
         'again in %d minutes.'
     ),
-    'voucher_redeemed_partial': gettext_lazy('This voucher code can only be redeemed %d more times.'),
+    'voucher_redeemed_partial': gettext_lazy('This voucher code can only be redeemed %d times.'),
     'voucher_whole_cart_not_combined': gettext_lazy('Applying a voucher to the whole cart should not be combined with other operations.'),
     'voucher_double': gettext_lazy(
         'You already used this voucher code. Remove the associated line from your '

--- a/src/pretix/locale/ang/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ang/LC_MESSAGES/django.po
@@ -6789,7 +6789,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/ar/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ar/LC_MESSAGES/django.po
@@ -7505,7 +7505,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "يمكن فقط استرداد رمز كود الخصم هذا %dمرات أخرى."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/ca/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ca/LC_MESSAGES/django.po
@@ -7569,7 +7569,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Aquest codi de val només es pot bescanviar %d vegada més."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/cs/LC_MESSAGES/django.po
+++ b/src/pretix/locale/cs/LC_MESSAGES/django.po
@@ -7254,7 +7254,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Tento kód poukázky lze uplatnit pouze %dkrát."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/cy/LC_MESSAGES/django.po
+++ b/src/pretix/locale/cy/LC_MESSAGES/django.po
@@ -6794,7 +6794,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/da/LC_MESSAGES/django.po
+++ b/src/pretix/locale/da/LC_MESSAGES/django.po
@@ -7348,7 +7348,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Denne rabatkode kan kun indløses %d gange mere."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/de/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de/LC_MESSAGES/django.po
@@ -7382,8 +7382,8 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
-msgstr "Dieser Gutschein kann nur noch %d mal eingelöst werden."
+msgid "This voucher code can only be redeemed %d times."
+msgstr "Dieser Gutscheincode kann nur %d mal eingelöst werden."
 
 #: pretix/base/services/cart.py:166
 msgid ""

--- a/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/de_Informal/LC_MESSAGES/django.po
@@ -7372,8 +7372,8 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
-msgstr "Dieser Gutschein kann nur noch %d mal eingelöst werden."
+msgid "This voucher code can only be redeemed %d times."
+msgstr "Dieser Gutscheincode kann nur %d mal eingelöst werden."
 
 #: pretix/base/services/cart.py:166
 msgid ""

--- a/src/pretix/locale/django.pot
+++ b/src/pretix/locale/django.pot
@@ -6790,7 +6790,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/el/LC_MESSAGES/django.po
+++ b/src/pretix/locale/el/LC_MESSAGES/django.po
@@ -7889,7 +7889,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Αυτός ο κωδικός κουπονιού μπορεί να εξαργυρωθεί %d περισσότερες φορές."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/enm/LC_MESSAGES/django.po
+++ b/src/pretix/locale/enm/LC_MESSAGES/django.po
@@ -6789,7 +6789,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/es/LC_MESSAGES/django.po
+++ b/src/pretix/locale/es/LC_MESSAGES/django.po
@@ -7488,7 +7488,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Este cupón sólo puede ser canjeado %d más veces."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/fi/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fi/LC_MESSAGES/django.po
@@ -6999,7 +6999,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/fr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/fr/LC_MESSAGES/django.po
@@ -7428,7 +7428,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Ce code de bon d'achat ne peut être échangé que %d fois."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/gl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/gl/LC_MESSAGES/django.po
@@ -7837,7 +7837,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Este cupón só pode ser trocado %d máis veces."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/he/LC_MESSAGES/django.po
+++ b/src/pretix/locale/he/LC_MESSAGES/django.po
@@ -6803,7 +6803,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/hr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/hr/LC_MESSAGES/django.po
@@ -6796,7 +6796,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/hu/LC_MESSAGES/django.po
+++ b/src/pretix/locale/hu/LC_MESSAGES/django.po
@@ -6987,7 +6987,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/id/LC_MESSAGES/django.po
+++ b/src/pretix/locale/id/LC_MESSAGES/django.po
@@ -7306,7 +7306,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Kode voucher ini hanya dapat ditukarkan %d kali lagi."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/it/LC_MESSAGES/django.po
+++ b/src/pretix/locale/it/LC_MESSAGES/django.po
@@ -7053,7 +7053,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/ja/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ja/LC_MESSAGES/django.po
@@ -6925,7 +6925,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/ko/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ko/LC_MESSAGES/django.po
@@ -6791,7 +6791,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/lt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/lt/LC_MESSAGES/django.po
@@ -6791,7 +6791,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/lv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/lv/LC_MESSAGES/django.po
@@ -7342,7 +7342,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Šo kupona kodu var izmantot tikai vēl %d reizes."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/nan/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nan/LC_MESSAGES/django.po
@@ -6789,7 +6789,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nb_NO/LC_MESSAGES/django.po
@@ -7325,7 +7325,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Denne kupongkoden kan bare brukes %d ganger til."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/nl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl/LC_MESSAGES/django.po
@@ -7432,8 +7432,8 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
-msgstr "Deze vouchercode kan nog %d keren worden gebruikt."
+msgid "This voucher code can only be redeemed %d times."
+msgstr "Deze vouchercode kan slechts %d keer gebruikt worden."
 
 #: pretix/base/services/cart.py:166
 msgid ""

--- a/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_BE/LC_MESSAGES/django.po
@@ -6791,7 +6791,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/nl_Informal/LC_MESSAGES/django.po
@@ -7525,7 +7525,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Deze vouchercode kan nog %d keren worden gebruikt."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/pl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl/LC_MESSAGES/django.po
@@ -7379,7 +7379,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pl_Informal/LC_MESSAGES/django.po
@@ -6796,7 +6796,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/pt/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt/LC_MESSAGES/django.po
@@ -6905,7 +6905,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_BR/LC_MESSAGES/django.po
@@ -7639,7 +7639,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
+++ b/src/pretix/locale/pt_PT/LC_MESSAGES/django.po
@@ -7451,7 +7451,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Este código de voucher só pode ser resgatado mais %d vezes."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/ro/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ro/LC_MESSAGES/django.po
@@ -7560,7 +7560,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Acest cod voucher mai poate fi revendicat de încă %d ori."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/ru/LC_MESSAGES/django.po
+++ b/src/pretix/locale/ru/LC_MESSAGES/django.po
@@ -7700,7 +7700,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Этот код ваучера можно использовать только ещё %d раз."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/si/LC_MESSAGES/django.po
+++ b/src/pretix/locale/si/LC_MESSAGES/django.po
@@ -6809,7 +6809,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/sl/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sl/LC_MESSAGES/django.po
@@ -7536,7 +7536,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "To kodo bona lahko unovčite le %d krat."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/sv/LC_MESSAGES/django.po
+++ b/src/pretix/locale/sv/LC_MESSAGES/django.po
@@ -7490,7 +7490,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/th/LC_MESSAGES/django.po
+++ b/src/pretix/locale/th/LC_MESSAGES/django.po
@@ -6792,7 +6792,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/tr/LC_MESSAGES/django.po
+++ b/src/pretix/locale/tr/LC_MESSAGES/django.po
@@ -7927,7 +7927,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Bu kupon kodu yalnızca %d daha fazla kez kullanılabilir."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/uk/LC_MESSAGES/django.po
+++ b/src/pretix/locale/uk/LC_MESSAGES/django.po
@@ -7471,7 +7471,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "Цей код ваучера можна активувати ще %d разів."
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/vi/LC_MESSAGES/django.po
+++ b/src/pretix/locale/vi/LC_MESSAGES/django.po
@@ -6791,7 +6791,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr ""
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hans/LC_MESSAGES/django.po
@@ -7555,7 +7555,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "此优惠券号码只能兑换 %d 次。"
 
 #: pretix/base/services/cart.py:166

--- a/src/pretix/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/pretix/locale/zh_Hant/LC_MESSAGES/django.po
@@ -7027,7 +7027,7 @@ msgstr ""
 
 #: pretix/base/services/cart.py:165
 #, python-format
-msgid "This voucher code can only be redeemed %d more times."
+msgid "This voucher code can only be redeemed %d times."
 msgstr "此優惠券代碼只能兌換 %d 次。"
 
 #: pretix/base/services/cart.py:166


### PR DESCRIPTION
Issue: To simulate: create a voucher that gives access to multiple tickets. 
Let's say 2, open the link generated by the code, add 5 tickets to your cart, click next. 

It will display the error message "This voucher code can only be redeemed 2 more times."
My expectation would be to display "This voucher code can only be redeemed 2 times."

So I did some find / replace stuff in the strings and updated the translations I was comfortable with,  the french translation was allready correct btw. I hope I didn't break anything. :-) 