### PR TITLE
Stripe: Add Klarna

### DIFF
--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -59,7 +59,9 @@ from django_countries import countries
 from pretix import __version__
 from pretix.base.decimal import round_decimal
 from pretix.base.forms import SecretKeySettingsField
-from pretix.base.forms.questions import guess_country, guess_country_from_request
+from pretix.base.forms.questions import (
+    guess_country, guess_country_from_request,
+)
 from pretix.base.models import (
     Event, InvoiceAddress, Order, OrderPayment, OrderRefund, Quota,
 )

--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -85,10 +85,11 @@ from pretix.presale.views.cart import cart_session
 
 logger = logging.getLogger('pretix.plugins.stripe')
 
+
 # State of the payment methods
 #
 # Source: https://stripe.com/docs/payments/payment-methods/overview
-# Last Update: 2023-04-24
+# Last Update: 2023-12-20
 #
 # Cards
 # - Credit and Debit Cards: ✓
@@ -125,9 +126,11 @@ logger = logging.getLogger('pretix.plugins.stripe')
 # Buy now, pay later
 # - Affirm: ✓
 # - Afterpay/Clearpay: ✗
-# - Klarna: ✗
+# - Klarna: ✓
+# - Zip: ✗
 #
 # Real-time payments
+# - Swish: ✗
 # - PayNow: ✗
 # - PromptPay: ✗
 # - Pix: ✗
@@ -143,6 +146,7 @@ logger = logging.getLogger('pretix.plugins.stripe')
 # - Secure Remote Commerce: ✗
 # - Link: ✓ (PaymentRequestButton)
 # - Cash App Pay: ✗
+# - PayPal: ✗
 # - MobilePay: ✗
 # - Alipay: ✓
 # - WeChat Pay: ✓
@@ -330,7 +334,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('giropay'),
                      disabled=self.event.currency != 'EUR',
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_ideal',
@@ -338,7 +342,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('iDEAL'),
                      disabled=self.event.currency != 'EUR',
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_alipay',
@@ -346,7 +350,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('Alipay'),
                      disabled=self.event.currency not in ('EUR', 'AUD', 'CAD', 'GBP', 'HKD', 'JPY', 'NZD', 'SGD', 'USD'),
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_bancontact',
@@ -354,7 +358,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('Bancontact'),
                      disabled=self.event.currency != 'EUR',
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_sepa_debit',
@@ -404,7 +408,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('EPS'),
                      disabled=self.event.currency != 'EUR',
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_multibanco',
@@ -412,7 +416,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('Multibanco'),
                      disabled=self.event.currency != 'EUR',
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_przelewy24',
@@ -420,7 +424,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('Przelewy24'),
                      disabled=self.event.currency not in ['EUR', 'PLN'],
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_wechatpay',
@@ -428,7 +432,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('WeChat Pay'),
                      disabled=self.event.currency not in ['AUD', 'CAD', 'EUR', 'GBP', 'HKD', 'JPY', 'SGD', 'USD'],
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
-                                 'before work properly.'),
+                                 'before they work properly.'),
                      required=False,
                  )),
                 ('method_affirm',
@@ -436,8 +440,25 @@ class StripeSettingsHolder(BasePaymentProvider):
                      label=_('Affirm'),
                      disabled=self.event.currency not in ['USD', 'CAD'],
                      help_text=' '.join([
-                         str(_('Needs to be enabled in your Stripe account first.')),
+                         str(_('Some payment methods might need to be enabled in the settings of your Stripe account '
+                               'before they work properly.')),
                          str(_('Only available for payments between $50 and $30,000.'))
+                     ]),
+                     required=False,
+                 )),
+                ('method_klarna',
+                 forms.BooleanField(
+                     label=_('Klarna'),
+                     disabled=self.event.currency not in [
+                         'AUD', 'CAD', 'CHF', 'CZK', 'DKK', 'EUR', 'GBP', 'NOK', 'NZD', 'PLN', 'SEK', 'USD'
+                     ],
+                     help_text=' '.join([
+                         str(_('Some payment methods might need to be enabled in the settings of your Stripe account '
+                               'before they work properly.')),
+                         str(_('Klarna and Stripe will decide which of the payment methods offered by Klarna are '
+                               'available to the user.')),
+                         str(_('Klarna\'s terms of services do not allow it to be used by charities or political '
+                               'organizations.')),
                      ]),
                      required=False,
                  )),

--- a/src/pretix/plugins/stripe/signals.py
+++ b/src/pretix/plugins/stripe/signals.py
@@ -46,15 +46,15 @@ from pretix.presale.signals import html_head, process_response
 def register_payment_provider(sender, **kwargs):
     from .payment import (
         StripeAffirm, StripeAlipay, StripeBancontact, StripeCC, StripeEPS,
-        StripeGiropay, StripeIdeal, StripeMultibanco, StripePrzelewy24,
-        StripeSEPADirectDebit, StripeSettingsHolder, StripeSofort,
-        StripeWeChatPay,
+        StripeGiropay, StripeIdeal, StripeKlarna, StripeMultibanco,
+        StripePrzelewy24, StripeSEPADirectDebit, StripeSettingsHolder,
+        StripeSofort, StripeWeChatPay,
     )
 
     return [
         StripeSettingsHolder, StripeCC, StripeGiropay, StripeIdeal, StripeAlipay, StripeBancontact,
         StripeSofort, StripeEPS, StripeMultibanco, StripePrzelewy24, StripeWeChatPay,
-        StripeSEPADirectDebit, StripeAffirm,
+        StripeSEPADirectDebit, StripeAffirm, StripeKlarna,
     ]
 
 

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -174,14 +174,19 @@ var pretixstripe = {
                         pretixstripe.affirm.mount('#stripe-affirm');
                     }
                     if ($("#stripe-klarna").length) {
-                        pretixstripe.klarna = pretixstripe.elements.create('paymentMethodMessaging', {
-                            'amount': parseInt($("#stripe_klarna_total").val()),
-                            'currency': $("#stripe_klarna_currency").val(),
-                            'countryCode': $.trim($("body").attr("data-locale")).toUpperCase(),
-                            'paymentMethodTypes': ['klarna'],
-                        });
+                        try {
+                            pretixstripe.klarna = pretixstripe.elements.create('paymentMethodMessaging', {
+                                'amount': parseInt($("#stripe_klarna_total").val()),
+                                'currency': $("#stripe_klarna_currency").val(),
+                                'countryCode': $("#stripe_klarna_country").val(),
+                                'paymentMethodTypes': ['klarna'],
+                            });
 
-                        pretixstripe.klarna.mount('#stripe-klarna');
+                            pretixstripe.klarna.mount('#stripe-klarna');
+                        } catch (e) {
+                            console.error(e);
+                            $("#stripe-klarna").html("<div class='alert alert-danger'>Technical error, please contact support: " + e + "</div>");
+                        }
                     }
                     if ($("#stripe-payment-request-button").length && pretixstripe.paymentRequest != null) {
                         pretixstripe.paymentRequestButton = pretixstripe.elements.create('paymentRequestButton', {

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -7,6 +7,7 @@ var pretixstripe = {
     card: null,
     sepa: null,
     affirm: null,
+    klarna: null,
     paymentRequest: null,
     paymentRequestButton: null,
 
@@ -172,6 +173,16 @@ var pretixstripe = {
 
                         pretixstripe.affirm.mount('#stripe-affirm');
                     }
+                    if ($("#stripe-klarna").length) {
+                        pretixstripe.klarna = pretixstripe.elements.create('paymentMethodMessaging', {
+                            'amount': parseInt($("#stripe_klarna_total").val()),
+                            'currency': $("#stripe_klarna_currency").val(),
+                            'countryCode': $.trim($("body").attr("data-locale")).toUpperCase(),
+                            'paymentMethodTypes': ['klarna'],
+                        });
+
+                        pretixstripe.klarna.mount('#stripe-klarna');
+                    }
                     if ($("#stripe-payment-request-button").length && pretixstripe.paymentRequest != null) {
                         pretixstripe.paymentRequestButton = pretixstripe.elements.create('paymentRequestButton', {
                             paymentRequest: pretixstripe.paymentRequest,
@@ -280,11 +291,12 @@ $(function () {
         $("input[name=payment][value=stripe]").is(':checked')
         || $("input[name=payment][value=stripe_sepa_debit]").is(':checked')
         || $("input[name=payment][value=stripe_affirm]").is(':checked')
+        || $("input[name=payment][value=stripe_klarna]").is(':checked')
         || $(".payment-redo-form").length) {
         pretixstripe.load();
     } else {
         $("input[name=payment]").change(function () {
-            if (['stripe', 'stripe_sepa_debit', 'stripe_affirm'].indexOf($(this).val()) > -1) {
+            if (['stripe', 'stripe_sepa_debit', 'stripe_affirm', 'stripe_klarna'].indexOf($(this).val()) > -1) {
                 pretixstripe.load();
             }
         })

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_messaging_noform.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_messaging_noform.html
@@ -2,7 +2,7 @@
 {% load bootstrap3 %}
 
 <div class="form-horizontal stripe-container">
-    <div id="stripe-affirm">
+    <div id="stripe-{{ method }}">
         <span class="fa fa-spinner fa-spin"></span>
         <!-- a Stripe Element will be inserted here. -->
     </div>
@@ -15,6 +15,6 @@
         {% endblocktrans %}
     </p>
 
-    <input type="hidden" name="stripe_affirm_total" value="{{ total }}" id="stripe_affirm_total"/>
-    <input type="hidden" id="stripe_affirm_currency" value="{{ event.currency }}"/>
+    <input type="hidden" name="stripe_{{ method }}_total" value="{{ total }}" id="stripe_{{ method }}_total"/>
+    <input type="hidden" id="stripe_{{ method }}_currency" value="{{ event.currency }}"/>
 </div>

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_messaging_noform.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_messaging_noform.html
@@ -17,4 +17,7 @@
 
     <input type="hidden" name="stripe_{{ method }}_total" value="{{ total }}" id="stripe_{{ method }}_total"/>
     <input type="hidden" id="stripe_{{ method }}_currency" value="{{ event.currency }}"/>
+    {% if country %}
+        <input type="hidden" id="stripe_{{ method }}_country" value="{{ country }}"/>
+    {% endif %}
 </div>


### PR DESCRIPTION
Same story as Affirm...

Some things about this, that irk me a little bit:
- The messaging-Component is always advertising the "pay in x installments". This might be offputting for people who do not know Klarna and the different payment options that are offered.
- We do not know, which payment options will be offered to the customer.
- We could in theory include the matrix of countries and products (3/4 installments, financing, pay later, pay now/sofort). But I don't feel like keeping that list up to date and we don't even know what the customer will actually choose
- This is not really a 1:1 drop-in replacement for SOFORT. Account registration is required.
- We have to absolutely transmit the customers country. I'm doing that right now on a best effort basis, but no idea what/if any negative user experience this might cause if we guess the customer country wrong and the user tries to create an account/log into an account from another country.

I checked, and unfortunately with Stripe there is now way to limit the offer to the payment methods offered.

I feel like we might have to go the route of rolling a `pretix-klarna` - at least with that we can limit the offered payment methods to pay now if so desired. Or build our own paynow-product based on Nordigen/GoCardless...