### PR TITLE
API: Prefetch customer in order list view

### DIFF
--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -222,6 +222,8 @@ class OrderViewSetMixin:
             qs = qs.prefetch_related('refunds', 'refunds__payment')
         if 'invoice_address' not in self.request.GET.getlist('exclude'):
             qs = qs.select_related('invoice_address')
+        if 'customer' not in self.request.GET.getlist('exclude'):
+            qs = qs.select_related('customer')
 
         qs = qs.prefetch_related(self._positions_prefetch(self.request))
         return qs


### PR DESCRIPTION
Before this change, each order row needed an additional database query just to resolve the customer id (integer) to customer identifier (string).

With this change, django does a database JOIN.

This is a performance optimization. In my setup, querying a few hundred orders now takes ≈1.5s instead of 2 to 2.5s