### PR TITLE
Fix incorrect order status on customer profile orders

### DIFF
--- a/src/pretix/presale/views/customer.py
+++ b/src/pretix/presale/views/customer.py
@@ -400,7 +400,7 @@ class ProfileView(CustomerRequiredMixin, ListView):
         for o in ctx['orders']:
             if o.pk not in annotated:
                 continue
-            o.count_positions = annotated.get(o.pk)['pcnt']
+            o.pcnt = annotated.get(o.pk)['pcnt']
         return ctx
 
 


### PR DESCRIPTION
When a customer views the list of their orders on their profile, orders which have been cancelled with a fee are displayed as 'paid'. This commit fixes this by using the same logic from other places where order status badges are displayed.