### PR TITLE
Fix redirect loop caused when both 2fa and password change are forced

### DIFF
--- a/src/pretix/control/middleware.py
+++ b/src/pretix/control/middleware.py
@@ -139,7 +139,7 @@ class PermissionMiddleware:
             return redirect_to_url(reverse('control:user.settings') + '?next=' + quote(request.get_full_path()))
 
         if not request.user.require_2fa and settings.PRETIX_OBLIGATORY_2FA \
-                and url_name not in self.EXCEPTIONS_2FA:
+                and url_name not in self.EXCEPTIONS_2FA and not request.user.needs_password_change:
             return redirect_to_url(reverse('control:user.settings.2fa'))
 
         if 'event' in url.kwargs and 'organizer' in url.kwargs:


### PR DESCRIPTION
When both two factor authentication and a password change are being forced, a redirect loop occurs. This commit resolves this by allowing the password change to occur between 2fa setup is forced. More specifically, 2fa is no longer forced whilst a forced password change is in operation.