### PR TITLE
Name formats: Allow empty salutation

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -125,7 +125,7 @@ class NamePartsWidget(forms.MultiWidget):
             if fname == 'title' and self.titles:
                 widgets.append(Select(attrs=a, choices=[('', '')] + [(d, d) for d in self.titles[1]]))
             elif fname == 'salutation':
-                widgets.append(Select(attrs=a, choices=[('', '---')] + PERSON_NAME_SALUTATIONS))
+                widgets.append(Select(attrs=a, choices=[('', '---'), ('empty', '')] + PERSON_NAME_SALUTATIONS))
             else:
                 widgets.append(self.widget(attrs=a))
         super().__init__(widgets, attrs)
@@ -136,7 +136,11 @@ class NamePartsWidget(forms.MultiWidget):
         data = []
         for i, field in enumerate(self.scheme['fields']):
             fname, label, size = field
-            data.append(value.get(fname, ""))
+            fval = value.get(fname, "")
+            print(field, repr(fval))
+            if fname == "salutation" and fname in value and fval == "":
+                fval = "empty"
+            data.append(fval)
         if '_legacy' in value and not data[-1]:
             data[-1] = value.get('_legacy', '')
         elif not any(d for d in data) and '_scheme' in value:
@@ -190,7 +194,8 @@ class NamePartsFormField(forms.MultiValueField):
         data = {}
         data['_scheme'] = self.scheme_name
         for i, value in enumerate(data_list):
-            data[self.scheme['fields'][i][0]] = value or ''
+            key = self.scheme['fields'][i][0]
+            data[key] = value or ''
         return data
 
     def __init__(self, *args, **kwargs):
@@ -239,7 +244,7 @@ class NamePartsFormField(forms.MultiValueField):
                 d.pop('validators', None)
                 field = forms.ChoiceField(
                     **d,
-                    choices=[('', '---')] + PERSON_NAME_SALUTATIONS
+                    choices=[('', '---'), ('empty', '')] + PERSON_NAME_SALUTATIONS
                 )
             else:
                 field = forms.CharField(**defaults)
@@ -264,6 +269,9 @@ class NamePartsFormField(forms.MultiValueField):
 
         if sum(len(v) for v in value.values() if v) > 250:
             raise forms.ValidationError(_('Please enter a shorter name.'), code='max_length')
+
+        if value.get("salutation") == "empty":
+            value["salutation"] = ""
 
         return value
 

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -137,7 +137,6 @@ class NamePartsWidget(forms.MultiWidget):
         for i, field in enumerate(self.scheme['fields']):
             fname, label, size = field
             fval = value.get(fname, "")
-            print(field, repr(fval))
             if fname == "salutation" and fname in value and fval == "":
                 fval = "empty"
             data.append(fval)


### PR DESCRIPTION
Currently, if a name format with salutation is selected, we show the following choices:

* `---` (pre-selected, but choosing this is not allowed)
* Mr
* Ms
* Mx

The idea behind this design choice was:

- We do not allow the empty option since we don't want people skipping the field out of pure laziness
- We always provide an option for people who are neither Mr not Ms. If someone chooses Mx, that will later not be used e.g. in emails, instead, we'll be addressing the person simple as `{given_name} {family_name}`

Now, we've had a complaint that not only some people might not want to use Mx either, but furthermore some people might not want to *disclose* which salutation is appropriate for them, therefore an empty option should be selectable. I still think it is a good idea to disallow the pre-selected option to be used to increase data quality by forcing people to choose something, but this PR introduces an additional option that is really empty.

* `---` (pre-selected, but choosing this is not allowed)
* (empty option, may be selected)
* Mr
* Ms
* Mx

For technical reasons, the new option can't be the empty string on HTML level, otherwise the `required` HTML attribute would no longer work, so there's some encoding and decoding in the form layer required.