### PR TITLE
Fix: remove duplicate repeat rule in subevent bulk creation

### DIFF
--- a/src/pretix/control/forms/subevents.py
+++ b/src/pretix/control/forms/subevents.py
@@ -464,7 +464,7 @@ class RRuleFormSetForm(RRuleForm):
 RRuleFormSet = formset_factory(
     RRuleFormSetForm,
     min_num=1, validate_min=True,
-    can_order=False, can_delete=True, extra=1
+    can_order=False, can_delete=True, extra=0
 )
 
 


### PR DESCRIPTION
This PR fixes a bug probably introduced in commit 2acf043 that initially creates two repeat-rules for bulk-creating dates in an event series.