### PR TITLE
Stripe/PayPal: Add explanatory texts (Z#23127572)

### DIFF
--- a/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_form.html
+++ b/src/pretix/plugins/paypal2/templates/pretixplugins/paypal2/checkout_payment_form.html
@@ -3,6 +3,10 @@
 <p>
     {% if method == "wallet" %}
         {% blocktrans trimmed %}
+            A PayPal account is required to use this online payment method. Please keep your account information
+            ready to enter in the next step.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
             Please click the "Pay with PayPal" button below to start your payment.
         {% endblocktrans %}
     {% else %}

--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -483,6 +483,7 @@ class StripeMethod(BasePaymentProvider):
     method = ''
     redirect_action_handling = 'iframe'  # or redirect
     confirmation_method = 'manual'
+    explanation = ''
 
     def __init__(self, event: Event):
         super().__init__(event)
@@ -1173,6 +1174,7 @@ class StripeRedirectMethod(StripeMethod):
             'request': request,
             'event': self.event,
             'settings': self.settings,
+            'explanation': self.explanation,
         }
         return template.render(ctx)
 
@@ -1203,6 +1205,7 @@ class StripeCC(StripeMethod):
             'event': self.event,
             'total': self._decimal_to_int(total),
             'settings': self.settings,
+            'explanation': self.explanation,
             'is_moto': self.is_moto(request)
         }
         return template.render(ctx)
@@ -1296,6 +1299,7 @@ class StripeSEPADirectDebit(StripeMethod):
             'event': self.event,
             'settings': self.settings,
             'form': self.payment_form(request),
+            'explanation': self.explanation,
             'email': order.email if order else cs.get('email', '')
         }
         return template.render(ctx)
@@ -1428,6 +1432,7 @@ class StripeAffirm(StripeMethod):
             'request': request,
             'event': self.event,
             'total': self._decimal_to_int(total),
+            'explanation': self.explanation,
             'method': self.method,
         }
         return template.render(ctx)
@@ -1490,6 +1495,7 @@ class StripeKlarna(StripeRedirectMethod):
             "event": self.event,
             "total": self._decimal_to_int(total),
             "method": self.method,
+            'explanation': self.explanation,
             "country": self._detect_country(request, order)
         }
         return template.render(ctx)
@@ -1521,6 +1527,7 @@ class StripeRedirectWithAccountNamePaymentIntentMethod(StripeRedirectMethod):
             'request': request,
             'event': self.event,
             'settings': self.settings,
+            'explanation': self.explanation,
             'form': self.payment_form(request)
         }
         return template.render(ctx)
@@ -1552,6 +1559,10 @@ class StripeGiropay(StripeRedirectWithAccountNamePaymentIntentMethod):
     verbose_name = _('giropay via Stripe')
     public_name = _('giropay')
     method = 'giropay'
+    explanation = _(
+        'giropay is an online payment method available to all customers of most German banks, usually after one-time '
+        'activation. Please keep your online banking account and login information available.'
+    )
 
     def _payment_intent_kwargs(self, request, payment):
         return {
@@ -1583,6 +1594,10 @@ class StripeIdeal(StripeRedirectMethod):
     verbose_name = _('iDEAL via Stripe')
     public_name = _('iDEAL')
     method = 'ideal'
+    explanation = _(
+        'iDEAL is an online payment method available to customers of Dutch banks. Please keep your online '
+        'banking account and login information available.'
+    )
 
     def payment_presale_render(self, payment: OrderPayment) -> str:
         pi = payment.info_data or {}
@@ -1604,6 +1619,10 @@ class StripeAlipay(StripeRedirectMethod):
     public_name = _('Alipay')
     method = 'alipay'
     confirmation_method = 'automatic'
+    explanation = _(
+        'This payment method is available to customers of the Chinese payment system Alipay. Please keep '
+        'your login information available.'
+    )
 
 
 class StripeBancontact(StripeRedirectWithAccountNamePaymentIntentMethod):
@@ -1649,6 +1668,7 @@ class StripeSofort(StripeMethod):
             'request': request,
             'event': self.event,
             'settings': self.settings,
+            'explanation': self.explanation,
             'form': self.payment_form(request)
         }
         return template.render(ctx)
@@ -1749,6 +1769,7 @@ class StripeMultibanco(StripeSourceMethod):
             'request': request,
             'event': self.event,
             'settings': self.settings,
+            'explanation': self.explanation,
             'form': self.payment_form(request)
         }
         return template.render(ctx)
@@ -1789,6 +1810,10 @@ class StripePrzelewy24(StripeRedirectMethod):
     verbose_name = _('Przelewy24 via Stripe')
     public_name = _('Przelewy24')
     method = 'p24'
+    explanation = _(
+        'Przelewy24 is an online payment method available to customers of Polish banks. Please keep your online '
+        'banking account and login information available.'
+    )
 
     def _payment_intent_kwargs(self, request, payment):
         return {
@@ -1824,6 +1849,10 @@ class StripeWeChatPay(StripeRedirectMethod):
     public_name = _('WeChat Pay')
     method = 'wechat_pay'
     confirmation_method = 'automatic'
+    explanation = _(
+        'This payment method is available to users of the Chinese app WeChat. Please keep your login information '
+        'available.'
+    )
 
     @property
     def is_enabled(self) -> bool:

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_card.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_card.html
@@ -1,5 +1,8 @@
 {% load i18n %}
 
+{% if explanation %}
+<p>{{ explanation }}</p>
+{% endif %}
 <div class="form-horizontal stripe-container">
     {% if is_moto %}
         <h1>

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_sepadirectdebit.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_sepadirectdebit.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 {% load bootstrap3 %}
 
+{% if explanation %}
+<p>{{ explanation }}</p>
+{% endif %}
 <div class="form-horizontal stripe-container">
     <div class="stripe-errors sr-only">
 

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple.html
@@ -1,7 +1,10 @@
 {% load i18n %}
 {% load bootstrap3 %}
+{% if explanation %}
+<p>{{ explanation }}</p>
+{% endif %}
 {% bootstrap_form form layout='horizontal' %}
-<p>{% blocktrans trimmed %}
+<p class="help-block">{% blocktrans trimmed %}
     After you submitted your order, we will redirect you to the payment service provider to complete your payment.
     You will then be redirected back here to get your tickets.
 {% endblocktrans %}</p>

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_messaging_noform.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_messaging_noform.html
@@ -1,6 +1,8 @@
 {% load i18n %}
 {% load bootstrap3 %}
-
+{% if explanation %}
+    <p>{{ explanation }}</p>
+{% endif %}
 <div class="form-horizontal stripe-container">
     <div id="stripe-{{ method }}">
         <span class="fa fa-spinner fa-spin"></span>
@@ -10,8 +12,7 @@
     <p class="help-block">
         {% blocktrans trimmed %}
             After you submitted your order, we will redirect you to the payment service provider to complete your
-            payment.
-            You will then be redirected back here to get your tickets.
+            payment. You will then be redirected back here to get your tickets.
         {% endblocktrans %}
     </p>
 

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_noform.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/checkout_payment_form_simple_noform.html
@@ -1,5 +1,8 @@
 {% load i18n %}
-<p>{% blocktrans trimmed %}
+{% if explanation %}
+<p>{{ explanation }}</p>
+{% endif %}
+<p class="help-block">{% blocktrans trimmed %}
     After you submitted your order, we will redirect you to the payment service provider to complete your payment.
     You will then be redirected back here to get your tickets.
 {% endblocktrans %}</p>


### PR DESCRIPTION
A customer reports that end-users are confused when they see payment methods like Przelewy24 they have never heard of and there is no indication that this is for a different target group. This PR therefore adds explanatory texts to some payment methods.