### PR TITLE
Add "Partitioned" flag to our cookies

### DIFF
--- a/src/pretix/helpers/cookies.py
+++ b/src/pretix/helpers/cookies.py
@@ -44,6 +44,8 @@ def set_cookie_without_samesite(request, response, key, *args, **kwargs):
         # This will only work on secure cookies as well
         # https://www.chromestatus.com/feature/5633521622188032
         response.cookies[key]['secure'] = is_secure
+        # CHIPS
+        response.cookies[key]['Partitioned'] = True
 
 
 # Based on https://www.chromium.org/updates/same-site/incompatible-clients

--- a/src/pretix/helpers/monkeypatching.py
+++ b/src/pretix/helpers/monkeypatching.py
@@ -21,6 +21,7 @@
 #
 import types
 from datetime import datetime
+from http import cookies
 
 from PIL import Image
 from requests.adapters import HTTPAdapter
@@ -88,7 +89,14 @@ def monkeypatch_requests_timeout():
     HTTPAdapter.send = httpadapter_send
 
 
+def monkeypatch_cookie_morsel():
+    # See https://code.djangoproject.com/ticket/34613
+    cookies.Morsel._flags.add("partitioned")
+    cookies.Morsel._reserved.setdefault("partitioned", "Partitioned")
+
+
 def monkeypatch_all_at_ready():
     monkeypatch_vobject_performance()
     monkeypatch_pillow_safer()
     monkeypatch_requests_timeout()
+    monkeypatch_cookie_morsel()


### PR DESCRIPTION
Chrome is deprecating third-party cookies that may be used for tracking. The 1% trial is already running:

https://developers.google.com/privacy-sandbox/blog/cookie-countdown-2023oct

You can opt-in for the trial at chrome://flags/#test-third-party-cookie-phaseout

This breaks the widget entirely. The only suitable fix is marking our cookies as "Partitioned":
https://developers.google.com/privacy-sandbox/3pcd/chips

Unfortunately, Firefox and Safari not yet support that. If they do some day, it will also fix our cross-site issues there.

This PR sets Partitioned on all cookies that we set SameSite=None on, in all browsers that are known not to break with unknown cookie flags.