### PR TITLE
Add __Host- prefix to CSRF and session cookie, remove cookie_domain

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -42,7 +42,6 @@ Example::
     currency=EUR
     datadir=/data
     plugins_default=pretix.plugins.sendmail,pretix.plugins.statistics
-    cookie_domain=.pretix.de
 
 ``instance_name``
     The name of this installation. Default: ``pretix.de``
@@ -70,9 +69,6 @@ Example::
 
 ``auth_backends``
     A comma-separated list of available auth backends. Defaults to ``pretix.base.auth.NativeAuthBackend``.
-
-``cookie_domain``
-    The cookie domain to be set. Defaults to ``None``.
 
 ``registration``
     Enables or disables the registration of new admin users. Defaults to ``off``.

--- a/src/pretix/presale/views/__init__.py
+++ b/src/pretix/presale/views/__init__.py
@@ -54,7 +54,6 @@ from pretix.base.models import (
 from pretix.base.services.cart import get_fees
 from pretix.base.templatetags.money import money_filter
 from pretix.helpers.cookies import set_cookie_without_samesite
-from pretix.multidomain.middlewares import get_cookie_domain
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.presale.signals import question_form_fields
 
@@ -469,7 +468,6 @@ def iframe_entry_view_wrapper(view_func):
                 locale,
                 max_age=max_age,
                 expires=(datetime.utcnow() + timedelta(seconds=max_age)).strftime('%a, %d-%b-%Y %H:%M:%S GMT'),
-                domain=get_cookie_domain(request)
             )
             return resp
 

--- a/src/pretix/presale/views/locale.py
+++ b/src/pretix/presale/views/locale.py
@@ -40,7 +40,6 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import View
 
 from pretix.helpers.cookies import set_cookie_without_samesite
-from pretix.multidomain.middlewares import get_cookie_domain
 
 from .robots import NoSearchIndexViewMixin
 
@@ -63,7 +62,6 @@ class LocaleSet(NoSearchIndexViewMixin, View):
                 max_age=max_age,
                 expires=(datetime.utcnow() + timedelta(seconds=max_age)).strftime(
                     '%a, %d-%b-%Y %H:%M:%S GMT'),
-                domain=get_cookie_domain(request)
             )
 
         return resp

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -335,8 +335,6 @@ if HAS_CELERY:
 else:
     CELERY_TASK_ALWAYS_EAGER = True
 
-SESSION_COOKIE_DOMAIN = config.get('pretix', 'cookie_domain', fallback=None)
-
 CACHE_TICKETS_HOURS = config.getint('cache', 'tickets', fallback=24 * 3)
 
 ENTROPY = {


### PR DESCRIPTION
This is an additional security feature to avoid interference with broken applications on subdomains, see also:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes