### PR TITLE
Presale: Fix booking period error message logic (Z#23115841)

### DIFF
--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -642,10 +642,10 @@ class RedeemView(NoSearchIndexViewMixin, EventViewMixin, CartMixin, TemplateView
             context['show_cart'] = context['cart']['positions']
             return render(request, 'pretixpresale/event/voucher_form.html', context)
 
-        if request.event.presale_start and now() < request.event.presale_start:
-            err = error_messages['not_started']
-        if request.event.presale_end and now() > request.event.presale_end:
+        if request.event.presale_has_ended or request.event.presale_end and now() > request.event.presale_end:
             err = error_messages['ended']
+        elif not request.event.presale_is_running or request.event.presale_start and now() < request.event.presale_start:
+            err = error_messages['not_started']
 
         self.subevent = None
         if request.event.has_subevents:


### PR DESCRIPTION
Fix the check whether to show error messages regarding to a not yet started or already ended booking period on the presale page. This covers the case where no start nor end date are set for the booking period, but the presale has ended automatically because the event is over.