### PR TITLE
Ensure `customer_signed_in` signal is fired for popup login

### DIFF
--- a/src/pretix/presale/views/customer.py
+++ b/src/pretix/presale/views/customer.py
@@ -826,6 +826,8 @@ class SSOLoginReturnView(RedirectBackMixin, View):
                 popup_origin
             )
 
+        customer_signed_in.send(customer.organizer, customer=customer)
+
         if popup_origin:
             return render(self.request, 'pretixpresale/postmessage.html', {
                 'message': {
@@ -839,7 +841,6 @@ class SSOLoginReturnView(RedirectBackMixin, View):
             })
         else:
             customer_login(self.request, customer)
-            customer_signed_in.send(customer.organizer, customer=customer)
             return redirect_to_url(self.get_success_url(redirect_to))
 
     def _fail(self, message, popup_origin):


### PR DESCRIPTION
In a7f7c64, a `customer_signed_in` in signal was introduced. However, when a user currently logs in using a popup, the signal is not fired. This PR resolves this.