### PR TITLE
Let plugins allow/prevent the download of individual tickets in an order

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -1144,7 +1144,6 @@ class Order(LockModel, LoggedModel):
     @property
     def positions_with_tickets(self):
         signal_response = allow_ticket_download.send(self.event, order=self)
-        print("signal_response", signal_response)
         if all([r is True for rr, r in signal_response]):
             return self.positions_with_tickets_ignoring_plugins
         elif any([r is False for rr, r in signal_response]):

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -44,7 +44,7 @@ from datetime import datetime, time, timedelta
 from decimal import Decimal
 from functools import reduce
 from time import sleep
-from typing import Any, Dict, List, Union, Iterable
+from typing import Any, Dict, Iterable, List, Union
 from zoneinfo import ZoneInfo
 
 import dateutil
@@ -79,7 +79,7 @@ from pretix.base.i18n import language
 from pretix.base.models import Customer, User
 from pretix.base.reldate import RelativeDateWrapper
 from pretix.base.settings import PERSON_NAME_SCHEMES
-from pretix.base.signals import order_gracefully_delete, allow_ticket_download
+from pretix.base.signals import allow_ticket_download, order_gracefully_delete
 
 from ...helpers import OF_SELF
 from ...helpers.countries import CachedCountries, FastCountryField
@@ -1207,7 +1207,6 @@ class Order(LockModel, LoggedModel):
         self._transaction_key_reset()
         _transactions_mark_order_clean(self.pk)
         return create
-
 
 
 def answerfile_name(instance, filename: str) -> str:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1418,12 +1418,8 @@ def send_download_reminders(sender, **kwargs):
             if o.status != Order.STATUS_PAID:
                 if o.status != Order.STATUS_PENDING or o.require_approval or (not o.valid_if_pending and not o.event.settings.ticket_download_pending):
                     continue
-            send = False
-            for p in positions:
-                if p.generate_ticket:
-                    send = True
-                    break
-            if not send:
+
+            if not any(p.generate_ticket for p in positions):
                 continue
 
             with language(o.locale, o.event.settings.region):

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1408,7 +1408,7 @@ def send_download_reminders(sender, **kwargs):
             if o.download_reminder_sent:
                 # Race condition
                 continue
-            if not all([r for rr, r in allow_ticket_download.send(event, order=o)]):
+            if not o.plugins_allow_ticket_download:
                 continue
 
             if not o.ticket_download_available:

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -98,10 +98,9 @@ from pretix.base.services.pricing import (
 from pretix.base.services.quotas import QuotaAvailability
 from pretix.base.services.tasks import ProfiledEventTask, ProfiledTask
 from pretix.base.signals import (
-    allow_ticket_download, order_approved, order_canceled, order_changed,
-    order_denied, order_expired, order_fee_calculation, order_paid,
-    order_placed, order_split, order_valid_if_pending, periodic_task,
-    validate_order,
+    order_approved, order_canceled, order_changed, order_denied, order_expired,
+    order_fee_calculation, order_paid, order_placed, order_split,
+    order_valid_if_pending, periodic_task, validate_order,
 )
 from pretix.celery_app import app
 from pretix.helpers import OF_SELF
@@ -1409,7 +1408,7 @@ def send_download_reminders(sender, **kwargs):
                 # Race condition
                 continue
             positions = o.positions_with_tickets
-            if not positions:
+            if not list(positions):
                 continue
 
             if not o.ticket_download_available:
@@ -1435,10 +1434,7 @@ def send_download_reminders(sender, **kwargs):
                     logger.exception('Reminder email could not be sent')
 
                 if event.settings.mail_send_download_reminder_attendee:
-                    for p in o.positions.all():
-                        if not p.generate_ticket:
-                            continue
-
+                    for p in o.positions_with_tickets:
                         if p.subevent_id:
                             reminder_date = (p.subevent.date_from - timedelta(days=days)).replace(
                                 hour=0, minute=0, second=0, microsecond=0

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1408,19 +1408,16 @@ def send_download_reminders(sender, **kwargs):
             if o.download_reminder_sent:
                 # Race condition
                 continue
-            if not o.plugins_allow_ticket_download:
+            positions = o.positions_with_tickets
+            if not positions:
                 continue
 
             if not o.ticket_download_available:
                 continue
-            positions = o.positions.select_related('item')
 
             if o.status != Order.STATUS_PAID:
                 if o.status != Order.STATUS_PENDING or o.require_approval or (not o.valid_if_pending and not o.event.settings.ticket_download_pending):
                     continue
-
-            if not any(p.generate_ticket for p in positions):
-                continue
 
             with language(o.locale, o.event.settings.region):
                 o.download_reminder_sent = True

--- a/src/pretix/base/services/tickets.py
+++ b/src/pretix/base/services/tickets.py
@@ -124,7 +124,7 @@ def preview(event: int, provider: str):
 
 
 def get_tickets_for_order(order, base_position=None):
-    can_download = all([r for rr, r in allow_ticket_download.send(order.event, order=order)])
+    can_download = order.plugins_allow_ticket_download
     if not can_download:
         return []
     if not order.ticket_download_available:

--- a/src/pretix/base/services/tickets.py
+++ b/src/pretix/base/services/tickets.py
@@ -21,6 +21,7 @@
 #
 import logging
 import os
+from typing import Iterable
 
 from django.core.files.base import ContentFile
 from django.utils.timezone import now
@@ -124,8 +125,8 @@ def preview(event: int, provider: str):
 
 
 def get_tickets_for_order(order, base_position=None):
-    can_download = order.plugins_allow_ticket_download
-    if not can_download:
+    positions_with_ticket = order.positions_with_tickets
+    if not positions_with_ticket:
         return []
     if not order.ticket_download_available:
         return []
@@ -138,7 +139,7 @@ def get_tickets_for_order(order, base_position=None):
 
     tickets = []
 
-    positions = list(order.positions_with_tickets)
+    positions = list(positions_with_ticket)
     if base_position:
         # Only the given position and its children
         positions = [

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3733,6 +3733,7 @@ class SettingsSandbox:
         del self._event.settings[self._convert_key(key)]
 
     def get(self, key: str, default: Any = None, as_type: type = str, binary_file: bool = False):
+        print(self._convert_key(key))
         return self._event.settings.get(
             self._convert_key(key), default=default, as_type=as_type, binary_file=binary_file
         )

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3733,7 +3733,6 @@ class SettingsSandbox:
         del self._event.settings[self._convert_key(key)]
 
     def get(self, key: str, default: Any = None, as_type: type = str, binary_file: bool = False):
-        print(self._convert_key(key))
         return self._event.settings.get(
             self._convert_key(key), default=default, as_type=as_type, binary_file=binary_file
         )

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -646,7 +646,7 @@ allow_ticket_download = EventPluginSignal()
 Arguments: ``order``
 
 This signal is sent out to check if tickets for an order can be downloaded. If any receiver returns false,
-a download will not be offered.
+a download will not be offered. If a receiver returns a list of OrderPositions, only those will be downloadable.
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """

--- a/src/pretix/base/ticketoutput.py
+++ b/src/pretix/base/ticketoutput.py
@@ -96,6 +96,9 @@ class BaseTicketOutput:
         """
         raise NotImplementedError()
 
+    def get_tickets_to_print(self, order):
+        return order.positions_with_tickets
+
     def generate_order(self, order: Order) -> Tuple[str, str, str]:
         """
         This method is the same as order() but should not generate one file per order position
@@ -116,7 +119,7 @@ class BaseTicketOutput:
         """
         with tempfile.TemporaryDirectory() as d:
             with ZipFile(os.path.join(d, 'tmp.zip'), 'w') as zipf:
-                for pos in order.positions_with_tickets:
+                for pos in self.get_tickets_to_print(order):
                     fname, __, content = self.generate(pos)
                     zipf.writestr('{}-{}{}'.format(
                         order.code, pos.positionid, os.path.splitext(fname)[1]

--- a/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
+++ b/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
@@ -115,7 +115,8 @@ class PdfTicketOutput(BaseTicketOutput):
     def generate_order(self, order: Order):
         merger = PdfWriter()
         with language(order.locale, self.event.settings.region):
-            for op in order.positions_with_tickets:
+            for op in self.get_tickets_to_print(order):
+                print("generating ticket ",op)
                 layout = override_layout.send_chained(
                     order.event, 'layout', orderposition=op, layout=self.layout_map.get(
                         (op.item_id, self.override_channel or order.sales_channel),

--- a/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
+++ b/src/pretix/plugins/ticketoutputpdf/ticketoutput.py
@@ -116,7 +116,6 @@ class PdfTicketOutput(BaseTicketOutput):
         merger = PdfWriter()
         with language(order.locale, self.event.settings.region):
             for op in self.get_tickets_to_print(order):
-                print("generating ticket ",op)
                 layout = override_layout.send_chained(
                     order.event, 'layout', orderposition=op, layout=self.layout_map.get(
                         (op.item_id, self.override_channel or order.sales_channel),

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -243,7 +243,7 @@
 
             {% if download %}
                 <div role="cell" class="download-desktop">
-                {% if line.ticket_download_allowed %}
+                {% if line in tickets_with_download %}
                     {% for b in download_buttons %}
                         <form action="{% if position_page and line.addon_to %}{% eventurl event "presale:event.order.position.download" secret=line.addon_to.web_secret order=order.code output=b.identifier pid=line.pk position=line.addon_to.positionid %}{% elif position_page %}{% eventurl event "presale:event.order.position.download" secret=line.web_secret order=order.code output=b.identifier pid=line.pk position=line.positionid %}{% else %}{% eventurl event "presale:event.order.download" secret=order.secret order=order.code output=b.identifier position=line.pk %}{% endif %}"
                                 method="post" data-asynctask data-asynctask-download class="download-btn-form{% if b.javascript_required %} requirejs{% endif %}">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -243,7 +243,7 @@
 
             {% if download %}
                 <div role="cell" class="download-desktop">
-                {% if line.generate_ticket %}
+                {% if line.ticket_download_allowed %}
                     {% for b in download_buttons %}
                         <form action="{% if position_page and line.addon_to %}{% eventurl event "presale:event.order.position.download" secret=line.addon_to.web_secret order=order.code output=b.identifier pid=line.pk position=line.addon_to.positionid %}{% elif position_page %}{% eventurl event "presale:event.order.position.download" secret=line.web_secret order=order.code output=b.identifier pid=line.pk position=line.positionid %}{% else %}{% eventurl event "presale:event.order.download" secret=order.secret order=order.code output=b.identifier position=line.pk %}{% endif %}"
                                 method="post" data-asynctask data-asynctask-download class="download-btn-form{% if b.javascript_required %} requirejs{% endif %}">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_downloads.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_downloads.html
@@ -35,7 +35,7 @@
             </p>
         </div>
     </div>
-{% elif can_download and download_buttons and order.count_positions %}
+{% elif can_download and download_buttons and order.count_positions and tickets_with_download  %}
     <div class="info-download">
         <h3 class="sr-only">{% trans "Ticket download" %}</h3>
         {% if cart.positions|length > 1 and can_download_multi %} {# never True on ticket page #}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_downloads.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_downloads.html
@@ -38,7 +38,7 @@
 {% elif can_download and download_buttons and order.count_positions and tickets_with_download  %}
     <div class="info-download">
         <h3 class="sr-only">{% trans "Ticket download" %}</h3>
-        {% if cart.positions|length > 1 and can_download_multi %} {# never True on ticket page #}
+        {% if tickets_with_download|length > 1 and can_download_multi %} {# never True on ticket page #}
             <div>
             {% for b in download_buttons %}
                 {% if b.multi %}

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -208,8 +208,6 @@ class TicketPageMixin:
         )
 
         ctx['tickets_with_download'] = [p for p in ctx['cart']['positions'] if p in positions_with_tickets]
-        for allowed_op in ctx['tickets_with_download']:
-            allowed_op.ticket_download_allowed = True
 
         ctx['download_buttons'] = self.download_buttons
 

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -80,9 +80,7 @@ from pretix.base.services.orders import (
 )
 from pretix.base.services.pricing import get_price
 from pretix.base.services.tickets import generate, invalidate_cache
-from pretix.base.signals import (
-    allow_ticket_download, order_modified, register_ticket_outputs,
-)
+from pretix.base.signals import order_modified, register_ticket_outputs
 from pretix.base.templatetags.money import money_filter
 from pretix.base.views.mixins import OrderQuestionsViewMixin
 from pretix.base.views.tasks import AsyncAction

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -177,7 +177,7 @@ class TicketPageMixin:
 
         ctx['order'] = self.order
 
-        can_download = all([r for rr, r in allow_ticket_download.send(self.request.event, order=self.order)])
+        can_download = self.order.plugins_allow_ticket_download
         ctx['plugins_allow_ticket_download'] = can_download
         if self.request.event.settings.ticket_download_date:
             ctx['ticket_download_date'] = self.order.ticket_download_date
@@ -1048,7 +1048,7 @@ class OrderDownloadMixin:
 
     @cached_property
     def output(self):
-        if not all([r for rr, r in allow_ticket_download.send(self.request.event, order=self.order)]):
+        if not self.order.plugins_allow_ticket_download:
             return None
         responses = register_ticket_outputs.send(self.request.event)
         for receiver, response in responses:

--- a/src/tests/base/test_orders.py
+++ b/src/tests/base/test_orders.py
@@ -55,6 +55,7 @@ from pretix.base.services.orders import (
     send_expiry_warnings,
 )
 from pretix.plugins.banktransfer.payment import BankTransfer
+from pretix.testutils.mock import mocker_context
 from pretix.testutils.scope import classscope
 
 
@@ -820,7 +821,7 @@ class DownloadReminderTests(TestCase):
             self.event = Event.objects.create(
                 organizer=self.o, name='Dummy', slug='dummy',
                 date_from=now() + timedelta(days=2),
-                plugins='pretix.plugins.banktransfer'
+                plugins='pretix.plugins.banktransfer,tests.testdummy'
             )
             self.order = Order.objects.create(
                 code='FOO', event=self.event, email='dummy@dummy.test',
@@ -852,6 +853,58 @@ class DownloadReminderTests(TestCase):
         self.ticket.save()
         send_download_reminders(sender=self.event)
         assert len(djmail.outbox) == 0
+
+    @classscope(attr='o')
+    def test_downloads_disabled_by_plugin(self):
+        with mocker_context() as mocker:
+            self.event.settings.mail_days_download_reminder = 2
+
+            from pretix.base.signals import allow_ticket_download
+            mocker.patch('pretix.base.signals.allow_ticket_download.send')
+            allow_ticket_download.send.return_value = [(None, [])]
+
+            send_download_reminders(sender=self.event)
+            assert len(djmail.outbox) == 0
+
+    @classscope(attr='o')
+    def test_downloads_all_allowed_by_plugin(self):
+        with mocker_context() as mocker:
+            self.event.settings.mail_days_download_reminder = 2
+            self.event.settings.mail_attach_tickets = True
+            self.event.settings.ticketoutput_testdummy__enabled = True
+
+            self.op2 = OrderPosition.objects.create(
+                order=self.order, item=self.ticket, variation=None,
+                price=Decimal("42.00"), attendee_name_parts={"full_name": "Mary"}, positionid=2
+            )
+
+            from pretix.base.signals import allow_ticket_download
+            mocker.patch('pretix.base.signals.allow_ticket_download.send')
+            allow_ticket_download.send.return_value = [(None, True)]
+
+            send_download_reminders(sender=self.event)
+            assert len(djmail.outbox) == 1
+            assert len(djmail.outbox[0].attachments) == 2
+
+    @classscope(attr='o')
+    def test_downloads_partially_disabled_by_plugin(self):
+        with mocker_context() as mocker:
+            self.event.settings.mail_days_download_reminder = 2
+            self.event.settings.mail_attach_tickets = True
+            self.event.settings.ticketoutput_testdummy__enabled = True
+
+            self.op2 = OrderPosition.objects.create(
+                order=self.order, item=self.ticket, variation=None,
+                price=Decimal("42.00"), attendee_name_parts={"full_name": "Mary"}, positionid=2
+            )
+
+            from pretix.base.signals import allow_ticket_download
+            mocker.patch('pretix.base.signals.allow_ticket_download.send')
+            allow_ticket_download.send.return_value = [(None, [self.op2])]
+
+            send_download_reminders(sender=self.event)
+            assert len(djmail.outbox) == 1
+            assert len(djmail.outbox[0].attachments) == 1
 
     @classscope(attr='o')
     def test_disabled(self):

--- a/src/tests/testdummy/ticketoutput.py
+++ b/src/tests/testdummy/ticketoutput.py
@@ -33,3 +33,7 @@ class DummyTicketOutput(BaseTicketOutput):
 
     def generate(self, op):
         return 'test.txt', 'text/plain', str(op.order.id)
+
+    @property
+    def multi_download_enabled(self) -> bool:
+        return False


### PR DESCRIPTION
The pretix-shipping plugin needs this to prevent the download only of the tickets which should be shipped physically to the customer, but not the tickets which should stay available for Print-at-home.

This modifies the `allow_ticket_download` signal so that it can not only return True or False to allow or block ticket download for an order as a whole, but alternatively return a list of OrderPositions, making only those downloadable.

https://github.com/pretix/pretix/pull/3836/files#diff-efaade2fa7bebe18526b3532280a3d750061a038953066c3a43b38be7d87c8d1R644-R652
