### PR TITLE
Allow consistent deep links to tabs

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/item/index.html
+++ b/src/pretix/control/templates/pretixcontrol/item/index.html
@@ -238,7 +238,7 @@
                             </div>
                         </div>
                     </fieldset>
-                    <fieldset>
+                    <fieldset id="tab-item-additional-settings">
                         <legend>{% trans "Additional settings" %}</legend>
                         {% bootstrap_field form.issue_giftcard layout="control" %}
                         {% if form.grant_membership_type %}

--- a/src/pretix/control/templates/pretixcontrol/organizers/edit.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/edit.html
@@ -157,7 +157,7 @@
                         {% bootstrap_field sform.giftcard_expiry_years layout="control" %}
                         {% bootstrap_field sform.giftcard_length layout="control" %}
                     </fieldset>
-                    <fieldset>
+                    <fieldset id="tab-organizer-privacy">
                         <legend>{% trans "Privacy" %}</legend>
                         {% bootstrap_field sform.privacy_url layout="control" %}
                         <div class="alert alert-legal">

--- a/src/pretix/static/pretixcontrol/js/ui/tabs.js
+++ b/src/pretix/static/pretixcontrol/js/ui/tabs.js
@@ -12,7 +12,8 @@ $(function () {
         var validity_error = false;
         $form.find("fieldset").each(function () {
             var $fieldset = $(this);
-            var tid = "tab-" + j + "-" + i;
+            var tid = $fieldset.attr("id");
+            if (!tid) tid = "tab-" + j + "-" + i;
             var $tabli = $("<li>").appendTo($tabs);
             var $tablink = $("<a>").attr("role", "tab")
                 .attr("data-toggle", "tab")


### PR DESCRIPTION
Currently tab IDs are autogenerated from the form and fieldset indizes (e.g. tab-0-7), causing them to change if a new tab is inserted in-between (which can happen dynamically by a plugin).

This change allows tab IDs to be set in the HTML code, making them persistent.

This change also adds IDs to some tabs of the organizer and event settings, where links should be added from other places.