### PR TITLE
Fix item column overflow in order-overview PDF-report

### DIFF
--- a/src/pretix/plugins/reports/exporters.py
+++ b/src/pretix/plugins/reports/exporters.py
@@ -352,7 +352,7 @@ class OverviewReport(Report):
             ('SPAN', (11, 1), (12, 1)),
             ('ALIGN', (0, 0), (-1, 1), 'CENTER'),
             ('ALIGN', (1, 2), (-1, -1), 'RIGHT'),
-            ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
+            ('VALIGN', (0, 0), (-1, -1), 'TOP'),
             ('FONTNAME', (0, 0), (-1, 1), 'OpenSansBd'),
             ('FONTNAME', (0, -1), (-1, -1), 'OpenSansBd'),
             ('FONTSIZE', (0, 0), (-1, -1), 8),

--- a/src/pretix/plugins/reports/exporters.py
+++ b/src/pretix/plugins/reports/exporters.py
@@ -417,7 +417,7 @@ class OverviewReport(Report):
                     tdata[-1].append(floatformat(tup[0].num[l][2 if net else 1], places))
             for item in tup[1]:
                 tdata.append([
-                    str(item)
+                    Paragraph(str(item), tstyle)
                 ])
                 for l, s in states:
                     tdata[-1].append(str(item.num[l][0]))


### PR DESCRIPTION
This PR fixes a column-overflow by adding a Paragraph around each item (as is already done to variations as well as categories).

The second commit valigns the tdata top instead of middle – IMHO looks better, but that is just personal preference, so can undo if someone has a strong opinion on this.

middle:
![Bildschirmfoto 2024-02-02 um 12 30 20](https://github.com/pretix/pretix/assets/276509/31b0ae7f-73f2-449e-90e1-396997c07276)

top:
![Bildschirmfoto 2024-02-02 um 12 30 37](https://github.com/pretix/pretix/assets/276509/9cdb0027-8bc0-436a-b4f7-14fc72694d71)
