### PR TITLE
BasePaymentProvider: skip country check if ia.country == '' (Z#23143749)

### DIFF
--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -849,6 +849,8 @@ class BasePaymentProvider:
             except InvoiceAddress.DoesNotExist:
                 pass
             else:
+                if str(ia.country) == '':
+                    pass
                 if str(ia.country) not in restricted_countries:
                     return False
 

--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -849,9 +849,7 @@ class BasePaymentProvider:
             except InvoiceAddress.DoesNotExist:
                 pass
             else:
-                if str(ia.country) == '':
-                    pass
-                if str(ia.country) not in restricted_countries:
+                if str(ia.country) != '' and str(ia.country) not in restricted_countries:
                     return False
 
         if order.sales_channel not in self.settings.get('_restrict_to_sales_channels', as_type=list, default=['web']):


### PR DESCRIPTION
Well, that was a fun one...

Setup:
- Limit Payment Provider to one or more countries
- Require approval for product
- Invoice address optional
- Do not provide Invoice Address during checkout

When selling an item that does *not* require approval, the Payment Provider can be selected, since this will trigger `InvoiceAddress.DoesNotExist`.

However, once approval is required and granted, the PaymentProvider cannot be selected, since `order_change_allowed` will compare `str(ia.country) not in restricted_countries` and fail: This is because once an order has been created, it will have an InvoiceAddress - even it is empty an `ia.country` is `''`.

Same thing for retrying a failed payment, it will fail due to the same cause.