### PR TITLE
Select2: add option to close when clearing selection

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -613,6 +613,13 @@ var form_handlers = function (el) {
                 }, 50);
             }
         });
+        if ($s[0].hasAttribute("data-close-on-clear")) {
+            $s.on("select2:clear", function () {
+                window.setTimeout(function () {
+                    $s.select2('close');
+                }, 50);
+            });
+        }
     });
 
     el.find('[data-model-select2=event]').each(function () {


### PR DESCRIPTION
This PR adds an option, triggered by the HTML-attribute `data-close-on-clear`, to close the dropdown when all input is cleared. This is helpful when select2-inputs are optional/can be empty, as when clearing the input, but keeping the dropdown open, it feels that there needs to be input something. Latest Seating-plan selection uses this to better allow for empty setting „General admission“.