### PR TITLE
Widget: fix availability of variations whose base item is unavailable

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -256,7 +256,7 @@ Vue.component('availbox', {
             }
         },
         unavailability_reason_message: function () {
-            var reason = this.item.has_variations ? this.variation.current_unavailability_reason : this.item.current_unavailability_reason;
+            var reason = this.item.current_unavailability_reason || this.variation?.current_unavailability_reason;
             if (reason) {
                 return strings["unavailable_" + reason] || reason;
             }

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -211,7 +211,7 @@ Vue.component('availbox', {
         + strings.sold_out
         + '</div>'
         + '<div class="pretix-widget-waiting-list-link"'
-        + '     v-if="waiting_list_show">'
+        + '     v-if="waiting_list_show && !unavailability_reason_message">'
         + '<a :href="waiting_list_url" target="_blank" @click="$root.open_link_in_frame">' + strings.waiting_list + '</a>'
         + '</div>'
         + '<div class="pretix-widget-availability-available" v-if="!unavailability_reason_message && avail[0] === 100">'


### PR DESCRIPTION
in the following example, the product "T-Shirt":
- has an unavailable_from date which is not reached
- and unavailable_from_mode = "info":

current behaviour of widget: (t-shirt variations seem to be available, but adding to cart fails)
![grafik](https://github.com/pretix/pretix/assets/388142/1b5e9c40-250c-4802-98eb-0efa3bcdfddd)

fixed behaviour of widget: (all t-shirt variations are set to "Not yet available")
![grafik](https://github.com/pretix/pretix/assets/388142/5574fa2e-6782-49e7-a2ec-01da90f93d5f)


behaviour of regular presale is unchanged:
![grafik](https://github.com/pretix/pretix/assets/388142/730e1894-83a9-4eb4-842b-95e7316890eb)
