### PR TITLE
PDF-Editor: improve grouping of object attribute inputs

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/pdf/index.html
+++ b/src/pretix/control/templates/pretixcontrol/pdf/index.html
@@ -279,6 +279,30 @@
                     </div>
                     <div class="row control-group text">
                         <div class="col-sm-6">
+                            <label>{% trans "Width (mm)" %}</label><br>
+                            <input type="number" value="13" class="input-block-level form-control" step="0.01"
+                                    id="toolbox-textwidth">
+                        </div>
+                        <div class="col-sm-6">
+                            <label>{% trans "Rotation (°)" %}</label><br>
+                            <input type="number" value="0" class="input-block-level form-control" step="0.1"
+                                    id="toolbox-textrotation">
+                        </div>
+                    </div>
+                    <div class="row control-group text">
+                        <hr/>
+                        <div class="col-sm-12">
+                            <label>{% trans "Font" %}</label><br>
+                            <select class="input-block-level form-control" id="toolbox-fontfamily">
+                                <option>Open Sans</option>
+                                {% for family in fonts.keys %}
+                                    <option>{{ family }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row control-group text">
+                        <div class="col-sm-6">
                             <label>{% trans "Font size (pt)" %}</label><br>
                             <input type="number" value="13" class="input-block-level form-control" step="0.1"
                                     id="toolbox-fontsize">
@@ -335,29 +359,6 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row control-group text">
-                        <div class="col-sm-12">
-                            <label>{% trans "Font" %}</label><br>
-                            <select class="input-block-level form-control" id="toolbox-fontfamily">
-                                <option>Open Sans</option>
-                                {% for family in fonts.keys %}
-                                    <option>{{ family }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                    </div>
-                    <div class="row control-group text">
-                        <div class="col-sm-6">
-                            <label>{% trans "Width (mm)" %}</label><br>
-                            <input type="number" value="13" class="input-block-level form-control" step="0.01"
-                                    id="toolbox-textwidth">
-                        </div>
-                        <div class="col-sm-6">
-                            <label>{% trans "Rotation (°)" %}</label><br>
-                            <input type="number" value="0" class="input-block-level form-control" step="0.1"
-                                    id="toolbox-textrotation">
-                        </div>
-                    </div>
                     <div class="row control-group poweredby">
                         <div class="col-sm-12">
                             <label>{% trans "Style" %}</label><br>
@@ -368,6 +369,7 @@
                         </div>
                     </div>
                     <div class="row control-group imagecontent">
+                        <hr/>
                         <div class="col-sm-12">
                             <label>{% trans "Image content" %}</label><br>
                             <select class="input-block-level form-control" id="toolbox-imagecontent">
@@ -379,6 +381,7 @@
                         </div>
                     </div>
                     <div class="row control-group text textcontent">
+                        <hr/>
                         <div class="col-sm-12">
                             <label>{% trans "Content" %}</label><br>
                             <select class="input-block-level form-control" id="toolbox-content">

--- a/src/pretix/control/templates/pretixcontrol/pdf/index.html
+++ b/src/pretix/control/templates/pretixcontrol/pdf/index.html
@@ -234,7 +234,62 @@
                             </select>
                         </div>
                     </div>
+                    <div class="row control-group poweredby">
+                        <div class="col-sm-12">
+                            <label>{% trans "Style" %}</label><br>
+                            <select class="input-block-level form-control" id="toolbox-poweredby-style">
+                                <option value="dark">{% trans "Dark" %}</option>
+                                <option value="white">{% trans "Light" %}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row control-group imagecontent">
+                        <div class="col-sm-12">
+                            <label>{% trans "Image content" %}</label><br>
+                            <select class="input-block-level form-control" id="toolbox-imagecontent">
+                                <option value="">{% trans "Empty" %}</option>
+                                {% for varname, var in images.items %}
+                                    <option value="{{ varname }}">{{ var.label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row control-group text textcontent">
+                        <div class="col-sm-12">
+                            <label>{% trans "Content" %}</label><br>
+                            <select class="input-block-level form-control" id="toolbox-content">
+                                {% for varname, var in variables.items %}
+                                    {% if not var.hidden %}
+                                        <option data-sample="{{ var.editor_sample }}" {% if var.migrate_from %}data-old-value="{{ var.migrate_from }}"{% endif %} value="{{ varname }}">{{ var.label }}</option>
+                                    {% endif %}
+                                {% endfor %}
+                                {% for p in request.organizer.meta_properties.all %}
+                                    <option value="meta:{{ p.name }}">
+                                        {% trans "Event attribute:" %} {{ p.name }}
+                                    </option>
+                                {% endfor %}
+                                {% for p in request.event.item_meta_properties.all %}
+                                    <option value="itemmeta:{{ p.name }}">
+                                        {% trans "Item attribute:" %} {{ p.name }}
+                                    </option>
+                                {% endfor %}
+                                <option value="other_i18n">{% trans "Other… (multilingual)" %}</option>
+                                <option value="other">{% trans "Other…" %}</option>
+                            </select>
+                            <textarea type="text" value="" class="input-block-level form-control"
+                                    id="toolbox-content-other"></textarea>
+                            <div class="i18n-form-group" id="toolbox-content-other-i18n">
+                                {% for l in request.event.settings.locales %}
+                                    <textarea id="toolbox-content-other-{{ l }}" rows="3" class="input-block-level form-control" title="{{ l }}" lang="{{ l }}"></textarea>
+                                {% endfor %}
+                            </div>
+                            <p class="help-block" id="toolbox-content-other-help">
+                                <a href="?placeholders=true" target="_blank">{% trans "Show available placeholders" %}</a>
+                            </p>
+                        </div>
+                    </div>
                     <div class="row control-group position">
+                        <hr/>
                         <div class="col-sm-6">
                             <label>{% trans "x (mm)" %}</label><br>
                             <input type="number" value="13" class="input-block-level form-control" step="0.01"
@@ -357,62 +412,6 @@
                                     </button>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div class="row control-group poweredby">
-                        <div class="col-sm-12">
-                            <label>{% trans "Style" %}</label><br>
-                            <select class="input-block-level form-control" id="toolbox-poweredby-style">
-                                <option value="dark">{% trans "Dark" %}</option>
-                                <option value="white">{% trans "Light" %}</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="row control-group imagecontent">
-                        <hr/>
-                        <div class="col-sm-12">
-                            <label>{% trans "Image content" %}</label><br>
-                            <select class="input-block-level form-control" id="toolbox-imagecontent">
-                                <option value="">{% trans "Empty" %}</option>
-                                {% for varname, var in images.items %}
-                                    <option value="{{ varname }}">{{ var.label }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                    </div>
-                    <div class="row control-group text textcontent">
-                        <hr/>
-                        <div class="col-sm-12">
-                            <label>{% trans "Content" %}</label><br>
-                            <select class="input-block-level form-control" id="toolbox-content">
-                                {% for varname, var in variables.items %}
-                                    {% if not var.hidden %}
-                                        <option data-sample="{{ var.editor_sample }}" {% if var.migrate_from %}data-old-value="{{ var.migrate_from }}"{% endif %} value="{{ varname }}">{{ var.label }}</option>
-                                    {% endif %}
-                                {% endfor %}
-                                {% for p in request.organizer.meta_properties.all %}
-                                    <option value="meta:{{ p.name }}">
-                                        {% trans "Event attribute:" %} {{ p.name }}
-                                    </option>
-                                {% endfor %}
-                                {% for p in request.event.item_meta_properties.all %}
-                                    <option value="itemmeta:{{ p.name }}">
-                                        {% trans "Item attribute:" %} {{ p.name }}
-                                    </option>
-                                {% endfor %}
-                                <option value="other_i18n">{% trans "Other… (multilingual)" %}</option>
-                                <option value="other">{% trans "Other…" %}</option>
-                            </select>
-                            <textarea type="text" value="" class="input-block-level form-control"
-                                    id="toolbox-content-other"></textarea>
-                            <div class="i18n-form-group" id="toolbox-content-other-i18n">
-                                {% for l in request.event.settings.locales %}
-                                    <textarea id="toolbox-content-other-{{ l }}" rows="3" class="input-block-level form-control" title="{{ l }}" lang="{{ l }}"></textarea>
-                                {% endfor %}
-                            </div>
-                            <p class="help-block" id="toolbox-content-other-help">
-                                <a href="?placeholders=true" target="_blank">{% trans "Show available placeholders" %}</a>
-                            </p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
For the PDF-editor this PR moves some inputs around and visually groups them together by adding `<hr>`s.

- [x] should the „Content“-input be moved to the top? As discussed originally I placed to the top, but it was brought to my attention that on a video about the PDF editor, the content-field was prominently featured at the bottom. So I left it a the bottom for now. I like it better at the top though.

![Bildschirmfoto 2024-02-12 um 12 40 39](https://github.com/pretix/pretix/assets/276509/8146f017-8944-4c26-8b7f-3dd379429adb)
