### PR TITLE
Presale: prefer event’s microdata from settings over generated microdata

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -265,6 +265,9 @@ class EventMixin:
 
     @property
     def event_microdata(self):
+        if self.settings.event_microdata:
+            return self.settings.event_microdata
+
         import json
 
         eventdict = {


### PR DESCRIPTION
To further test improving microdata this PR adds a hidden `event_microdata` to an event’s settings. This should contain a string of JSON-formatted microdata as described [here](https://developers.google.com/search/docs/appearance/structured-data/event?hl=de).