### PR TITLE
Widget: fix quantity cut-off on very narrow screens (Z#23141650)

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -1079,3 +1079,12 @@
     }
   }
 }
+
+@media (max-width: 300px) {
+  .pretix-widget.pretix-widget-mobile {
+    .pretix-widget-item-price-col, .pretix-widget-item-availability-col {
+      width: 100%;
+      float: none;
+    }
+  }
+}

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -974,6 +974,7 @@
   }
   .pretix-widget-item-price-col, .pretix-widget-item-availability-col {
     width: 50%;
+    min-width: 140px;
   }
   .pretix-widget-action {
     width: 100%;
@@ -1081,16 +1082,6 @@
     background: white;
     svg path {
       fill: $brand-primary;
-    }
-  }
-}
-
-@media (max-width: 300px) {
-  .pretix-widget.pretix-widget-mobile {
-    .pretix-widget-item-price-col, .pretix-widget-item-availability-col {
-      width: 100%;
-      float: none;
-      text-align: left;
     }
   }
 }

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -967,6 +967,11 @@
     float: none;
     margin-bottom: 5px;
   }
+  .pretix-widget-item-info-col:after {
+    display: block;
+    content: "";
+    clear: both;
+  }
   .pretix-widget-item-price-col, .pretix-widget-item-availability-col {
     width: 50%;
   }

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -1085,6 +1085,7 @@
     .pretix-widget-item-price-col, .pretix-widget-item-availability-col {
       width: 100%;
       float: none;
+      text-align: left;
     }
   }
 }


### PR DESCRIPTION
This PR fixes the quantity-input which was cut off on very narrow screens (or if the widget container was less than 310px wide).

Additionally it adds a clearfix after the product-image containing element on mobile to fix some indent/column issues for price.