### PR TITLE
PPv2 APM: Create referenced PPObjects for APM Orders; enable webhooks to capture them

### DIFF
--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -31,6 +31,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import messages
 from django.core.cache import cache
+from django.db import transaction
 from django.http import HttpRequest
 from django.template.loader import get_template
 from django.templatetags.static import static
@@ -55,6 +56,7 @@ from pretix.base.models import Event, Order, OrderPayment, OrderRefund, Quota
 from pretix.base.payment import BasePaymentProvider, PaymentException
 from pretix.base.services.mail import SendMailException
 from pretix.base.settings import SettingsSandbox
+from pretix.helpers import OF_SELF
 from pretix.helpers.urls import build_absolute_uri as build_global_uri
 from pretix.multidomain.urlreverse import build_absolute_uri, eventreverse
 from pretix.plugins.paypal2.client.core.environment import (
@@ -621,7 +623,13 @@ class PaypalMethod(BasePaymentProvider):
         }
         return template.render(ctx)
 
+    @transaction.atomic
     def execute_payment(self, request: HttpRequest, payment: OrderPayment):
+        payment = OrderPayment.objects.select_for_update(of=OF_SELF).get(pk=payment.pk)
+        if payment.state == OrderPayment.PAYMENT_STATE_CONFIRMED:
+            logger.warning('payment is already confirmed; possible return-view/webhook race-condition')
+            return
+
         try:
             if request.session.get('payment_paypal_oid', '') == '':
                 raise PaymentException(_('We were unable to process your payment. See below for details on how to '

--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -586,6 +586,9 @@ class PaypalMethod(BasePaymentProvider):
                 },
             })
             response = self.client.execute(paymentreq)
+
+            if payment:
+                ReferencedPayPalObject.objects.get_or_create(order=payment.order, payment=payment, reference=response.result.id)
         except IOError as e:
             if "RESOURCE_NOT_FOUND" in str(e):
                 messages.error(request, _('Your payment has failed due to a known issue within PayPal. Please try '

--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -507,7 +507,10 @@ def webhook(request, *args, **kwargs):
                     pass
         elif sale['status'] == 'APPROVED':
             request.session['payment_paypal_oid'] = payment.info_data['id']
-            payment.payment_provider.execute_payment(request, payment)
+            try:
+                payment.payment_provider.execute_payment(request, payment)
+            except PaymentException as e:
+                logger.exception('PayPal2 - Could not capture/execute_payment from Webhook: {}'.format(str(e)))
 
     return HttpResponse(status=200)
 


### PR DESCRIPTION
We are seeing some customers using APMs losing payments and bookings, as they seem to get lost in the process.

- Customer pays with APM such as giropay or SOFORT
- Order does not receive any webhook LogEntries for order being captureable
- pretix doesn't capture anything
- order expires
- PayPal refunds the money back after some days

As of right now, the only time a capture is occurring is when a the PayView POSTs (after a successful payment) or if the success-view is hit. This is done through the `execute_payment()`-function of the payment provider.

We are in the process of researching what the customer is doing exactly to apparently never hit these pages (or if they hit them, why nothing happens).

By manually removing the calls to `execute_payment` from `views.py`, I was able to recreate the behavior: An approved payment with no LogEntries for the "Order approved"-webhooks.

The latter is caused by a lack of `ReferencedPayPalObject` at this point - it also only gets written once the `execute_payment()` is run and we have something to capture.

This PR changes two things:
- Creating `ReferencedPayPalObjects` for orders, if a payment object already exists (aka: for APMs)
- Add handling logic to the webhook to send a `Order approved`-payment through the capture-process

Ref: Z#23141601, Z#23146632