### PR TITLE
Presale: improve handling max-count for add-on products clientside

### DIFF
--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -203,7 +203,7 @@ error_messages = {
         'You need to select at least %(min)s add-ons from the category %(cat)s for the product %(base)s.',
         'min'
     ),
-    'addon_no_multi': gettext_lazy('You can select every add-ons from the category %(cat)s for the product %(base)s at most once.'),
+    'addon_no_multi': gettext_lazy('You can select every add-on from the category %(cat)s for the product %(base)s at most once.'),
     'addon_only': gettext_lazy('One of the products you selected can only be bought as an add-on to another product.'),
     'bundled_only': gettext_lazy('One of the products you selected can only be bought part of a bundle.'),
     'seat_required': gettext_lazy('You need to select a specific seat.'),

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -197,7 +197,7 @@ error_messages = {
         'You need to select at least %(min)s add-ons from the category %(cat)s for the product %(base)s.',
         'min'
     ),
-    'addon_no_multi': gettext_lazy('You can select every add-ons from the category %(cat)s for the product %(base)s at most once.'),
+    'addon_no_multi': gettext_lazy('You can select every add-on from the category %(cat)s for the product %(base)s at most once.'),
     'addon_already_checked_in': gettext_lazy('You cannot remove the position %(addon)s since it has already been checked in.'),
 }
 

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -6,13 +6,13 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for c in form.categories %}
-    <fieldset{% if c.max_count == 1 %} data-addon-exclusive{% endif %}>
+    <fieldset data-addon-max-count="{{ c.max_count }}"{% if c.multi_allowed %} data-addon-multi-allowed{% endif %}>
         <legend>{{ c.category.name }}</legend>
         {% if c.category.description %}
             {{ c.category.description|rich_text }}
         {% endif %}
         {% if c.min_count == c.max_count %}
-            <p>
+            <p class="addon-count-desc">
                 {% blocktrans trimmed count min_count=c.min_count %}
                     You need to choose exactly one option from this category.
                 {% plural %}
@@ -21,7 +21,7 @@
             </p>
         {% elif c.min_count == 0 and c.max_count >= c.items|length and not c.multi_allowed %}
         {% elif c.min_count == 0 %}
-            <p>
+            <p class="addon-count-desc">
                 {% blocktrans trimmed count max_count=c.max_count %}
                     You can choose {{ max_count }} option from this category.
                 {% plural %}
@@ -29,7 +29,7 @@
                 {% endblocktrans %}
             </p>
         {% else %}
-            <p>
+            <p class="addon-count-desc">
                 {% blocktrans trimmed with min_count=c.min_count max_count=c.max_count %}
                     You can choose between {{ min_count }} and {{ max_count }} options from
                     this category.

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -6,7 +6,7 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for c in form.categories %}
-    <fieldset>
+    <fieldset{% if c.max_count == 1 or not c.multi_allowed %} data-addon-exclusive{% endif %}>
         <legend>{{ c.category.name }}</legend>
         {% if c.category.description %}
             {{ c.category.description|rich_text }}
@@ -193,7 +193,6 @@
                                                         {% endif %}
                                                         id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
-                                                        data-exclusive-prefix="cp_{{ form.pos.pk }}_"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" context "checkbox" %}
@@ -332,9 +331,6 @@
                                                 required="required"
                                             {% elif item.initial %}
                                                 checked="checked"
-                                            {% endif %}
-                                            {% if c.max_count == 1 %}
-                                            data-exclusive-prefix="cp_{{ form.pos.pk }}_"
                                             {% endif %}
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -333,6 +333,9 @@
                                             {% elif item.initial %}
                                                 checked="checked"
                                             {% endif %}
+                                            {% if c.max_count == 1 %}
+                                            data-exclusive-prefix="cp_{{ form.pos.pk }}_item_"
+                                            {% endif %}
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -193,7 +193,7 @@
                                                         {% endif %}
                                                         id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
-                                                        data-exclusive-prefix="cp_{{ form.pos.pk }}_variation_{{ item.id }}_"
+                                                        data-exclusive-prefix="cp_{{ form.pos.pk }}_"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" context "checkbox" %}
@@ -334,7 +334,7 @@
                                                 checked="checked"
                                             {% endif %}
                                             {% if c.max_count == 1 %}
-                                            data-exclusive-prefix="cp_{{ form.pos.pk }}_item_"
+                                            data-exclusive-prefix="cp_{{ form.pos.pk }}_"
                                             {% endif %}
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -6,7 +6,7 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for c in form.categories %}
-    <fieldset{% if c.max_count == 1 or not c.multi_allowed %} data-addon-exclusive{% endif %}>
+    <fieldset{% if c.max_count == 1 %} data-addon-exclusive{% endif %}>
         <legend>{{ c.category.name }}</legend>
         {% if c.category.description %}
             {{ c.category.description|rich_text }}

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -123,7 +123,7 @@ var form_handlers = function (el) {
         var controls = document.getElementById(this.getAttribute("data-controls"));
         var currentValue = parseFloat(controls.value);
         controls.value = Math.max(controls.min, Math.min(controls.max || Number.MAX_SAFE_INTEGER, (currentValue || 0) + step));
-        controls.dispatchEvent(new Event("change"));
+        controls.dispatchEvent(new Event("change", { bubbles: true }));
     });
     el.find(".btn-checkbox input").on("change", function (e) {
         $(this).closest(".btn-checkbox")

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -149,13 +149,11 @@ var form_handlers = function (el) {
         ).find("canvas").attr("role", "img").attr("aria-label", this.getAttribute("data-desc"));
     });
 
-    el.find("input[data-exclusive-prefix]").each(function () {
-        var $others = $("input[name^=" + $(this).attr("data-exclusive-prefix") + "]:not([name=" + $(this).attr("name") + "])");
-        $(this).on('click change', function () {
-            if ($(this).prop('checked')) {
-                $others.prop('checked', false).trigger('change');
-            }
-        });
+
+    el.find("fieldset:has(input[data-exclusive-prefix])").on('change', function (e) {
+        if (e.target.checked) {
+            $(".input[type=checkbox][name^=" + e.target.getAttribute("data-exclusive-prefix") + "]:checked", this).not(e.target).prop('checked', false).trigger('change');
+        }
     });
 
     el.find("input[name*=question], select[name*=question]").change(questions_toggle_dependent);

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -159,7 +159,7 @@ var form_handlers = function (el) {
         this.addEventListener("change", function (e) {
             var variations = e.target.closest(".variations");
             if (variations && !multipleAllowed && e.target.checked) {
-                // deactivate all other checkboxes inside this variations
+                // uncheck all other checkboxes inside this variations
                 $(".availability-box input:checked", variations).not(e.target).prop("checked", false).trigger("change");
             }
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -150,9 +150,9 @@ var form_handlers = function (el) {
     });
 
 
-    el.find("fieldset:has(input[data-exclusive-prefix])").on('change', function (e) {
+    el.find("fieldset[data-addon-exclusive]").on('change', function (e) {
         if (e.target.checked) {
-            $(".input[type=checkbox][name^=" + e.target.getAttribute("data-exclusive-prefix") + "]:checked", this).not(e.target).prop('checked', false).trigger('change');
+            $(".availability-box input:checked", this).not(e.target).prop('checked', false).trigger('change');
         }
     });
 


### PR DESCRIPTION
Two little things I noticed while reviewing https://github.com/pretix/pretix/pull/3968

- Extend the usage of "data-exclusive-prefix" to addon Items (currently only used on addon ItemVariations)
- Fix a typo in an error message