### PR TITLE
Fix: left align first column header on invoices without tax (Z#23147636)

### DIFF
--- a/src/pretix/base/invoice.py
+++ b/src/pretix/base/invoice.py
@@ -625,7 +625,7 @@ class ClassicInvoiceRenderer(BaseReportlabInvoiceRenderer):
             )]
         else:
             tdata = [(
-                Paragraph(self._normalize(pgettext('invoice', 'Description')), self.stylesheet['BoldRight']),
+                Paragraph(self._normalize(pgettext('invoice', 'Description')), self.stylesheet['Bold']),
                 Paragraph(self._normalize(pgettext('invoice', 'Qty')), self.stylesheet['BoldRightNoSplit']),
                 Paragraph(self._normalize(pgettext('invoice', 'Amount')), self.stylesheet['BoldRightNoSplit']),
             )]


### PR DESCRIPTION
When there is no tax on invoice, the column header for the first column (description) was aligned right, which caused an irritating gap. This PR moves „description“ to the left.