### PR TITLE
Allow customization of cache and log directory

### DIFF
--- a/doc/admin/config.rst
+++ b/doc/admin/config.rst
@@ -52,9 +52,17 @@ Example::
 ``currency``
     The default currency as a three-letter code. Defaults to ``EUR``.
 
+``cachedir``
+    The local path to a directory where temporary files will be stored.
+    Defaults to the ``cache`` directory below the ``datadir``.
+
 ``datadir``
     The local path to a data directory that will be used for storing user uploads and similar
     data. Defaults to the value of the environment variable ``DATA_DIR`` or ``data``.
+
+``logdir``
+    The local path to a directory where log files will be stored.
+    Defaults to the ``logs`` directory below the ``datadir``.
 
 ``plugins_default``
     A comma-separated list of plugins that are enabled by default for all new events.

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -65,10 +65,10 @@ config = EnvOrParserConfig(_config)
 
 CONFIG_FILE = config
 DATA_DIR = config.get('pretix', 'datadir', fallback=os.environ.get('DATA_DIR', 'data'))
-LOG_DIR = os.path.join(DATA_DIR, 'logs')
+LOG_DIR = config.get('pretix', 'logdir', fallback=os.path.join(DATA_DIR, 'logs'))
 MEDIA_ROOT = os.path.join(DATA_DIR, 'media')
 PROFILE_DIR = os.path.join(DATA_DIR, 'profiles')
-CACHE_DIR = os.path.join(DATA_DIR, 'cache')
+CACHE_DIR = config.get('pretix', 'cachedir', fallback=os.path.join(DATA_DIR, 'cache'))
 
 if not os.path.exists(DATA_DIR):
     os.mkdir(DATA_DIR)


### PR DESCRIPTION
On systems that follow the FHS it may be desirable to separate logs and cache files into dedicated base directories (e.g. /var/log/pretix or /var/cache/pretix).