### PR TITLE
Build jsi18n for all supported languages

### DIFF
--- a/src/pretix/_base_settings.py
+++ b/src/pretix/_base_settings.py
@@ -111,6 +111,7 @@ LANGUAGES_RTL = {
 LANGUAGES_INCUBATING = {
     'fi', 'pt-br', 'gl',
 }
+LANGUAGES = ALL_LANGUAGES
 LOCALE_PATHS = [
     os.path.join(os.path.dirname(__file__), 'locale'),
 ]


### PR DESCRIPTION
Use our own ALL_LANGUAGES as default for LANGUAGES, instead of those provided by django.

Fixes the problem reported in https://github.com/NixOS/nixpkgs/issues/297708 and patched in https://github.com/NixOS/nixpkgs/pull/297729, which is also relevant to our wheel.