### PR TITLE
Approval Process: Attach ical to approval-messages if properly configured

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -412,6 +412,9 @@ def approve_order(order, user=None, send_mail: bool=True, auth=None, force=False
                     email_subject, email_template, email_context,
                     'pretix.event.order.email.order_approved', user,
                     attach_tickets=True,
+                    attach_ical=order.event.settings.mail_attach_ical and (
+                        not order.event.settings.mail_attach_ical_paid_only or order.total == Decimal('0.00')
+                    ),
                     invoices=[invoice] if invoice and order.event.settings.invoice_email_attachment else []
                 )
             except SendMailException:


### PR DESCRIPTION
Up until now, there were two behaviors for orders within the approval process:
- `event.settings.mail_attach_ical = True` + `settings.mail_attach_ical_paid_only = False`: The initial email has the ical attached, the approval mail has no ical file attached
- `event.settings.mail_attach_ical = True` + `settings.mail_attach_ical_paid_only = True`: The initial email has no ical attached, the approval mail also has no ical file attached

Attaching/not attaching the ical to the first message is working as intended, this PR aims at the second, approval mail...