### PR TITLE
Fix: show human-readable country name in profile description for custom country-code questions (Z#23148948)

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -57,7 +57,9 @@ from django_scopes import scopes_disabled
 
 from pretix.base.models import Customer, Membership, Order
 from pretix.base.models.items import Question
-from pretix.base.models.orders import InvoiceAddress, OrderPayment, QuestionAnswer
+from pretix.base.models.orders import (
+    InvoiceAddress, OrderPayment, QuestionAnswer,
+)
 from pretix.base.models.tax import TaxedPrice, TaxRule
 from pretix.base.services.cart import (
     CartError, CartManager, add_payment_to_cart, error_messages, get_fees,

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -56,7 +56,8 @@ from django.views.generic.base import TemplateResponseMixin
 from django_scopes import scopes_disabled
 
 from pretix.base.models import Customer, Membership, Order
-from pretix.base.models.orders import InvoiceAddress, OrderPayment
+from pretix.base.models.items import Question
+from pretix.base.models.orders import InvoiceAddress, OrderPayment, QuestionAnswer
 from pretix.base.models.tax import TaxedPrice, TaxRule
 from pretix.base.services.cart import (
     CartError, CartManager, add_payment_to_cart, error_messages, get_fees,
@@ -1140,9 +1141,14 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                     data[k] = str(v)
 
                 for a in p.answers:
+                    value = a.get('value')
+                    if a["question_type"] == "CC":
+                        answer = QuestionAnswer(question=Question(type=a.get('question_type')), answer=str(value))
+                        value = {value: str(answer)}
+
                     data[a["field_name"]] = {
                         "label": a["field_label"],
-                        "value": a["value"],
+                        "value": value,
                         "identifier": a["question_identifier"],
                         "type": a["question_type"],
                     }


### PR DESCRIPTION
When using profiles in customer accounts, answers to custom questions for country codes showed the actual country code and not the human readable country name in the profile’s description. This PR formats country-code answers the same way select-from-list answers are formatted as a dict with key-value where country-code is the key and value is the human readable country name.