### PR TITLE
Do not remove unavailable addons when changing order (Z#23150855)

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -2008,6 +2008,20 @@ class OrderChangeManager:
                     for a in current_addons[cp][k][:current_num - input_num]:
                         if a.canceled:
                             continue
+                        is_unavailable = (
+                            # If an item is no longer available due to time, it should usually also be no longer
+                            # user-removable, because e.g. the stock has already been ordered.
+                            # We always pass has_voucher=True because if a product now requires a voucher, it usually does
+                            # not mean it should be unremovable for others.
+                            # This also prevents accidental removal through the UI because a hidden product will no longer
+                            # be part of the input.
+                            (a.variation and a.variation.unavailability_reason(has_voucher=True, subevent=a.subevent))
+                            or (a.variation and self.order.sales_channel not in a.variation.sales_channels)
+                            or a.item.unavailability_reason(has_voucher=True, subevent=a.subevent)
+                            or self.order.sales_channel not in item.sales_channels
+                        )
+                        if is_unavailable:
+                            continue
                         if a.checkins.filter(list__consider_tickets_used=True).exists():
                             raise OrderError(
                                 error_messages['addon_already_checked_in'] % {


### PR DESCRIPTION
Scenario:

- Main ticket
- Addon product for t-shirts
- Addon product for workshops

Order with a main ticket and a t-shirt, now a user wants to change the order to include a workshop. However, `available_until` of the t-shirt is over since they already started production. Currently, pretix will automatically remove the t-shirt when trying to book a workshop because the t-shirt is no longer part of the `set_addons` input.

There are different approaches how to solve this:

- Show unavailable products in the order change view as if they were not unavailable, and allow keeping or reducing their amount, but not increasing it.
- Do not silently remove products that are no longer available.

This PR chooses the latter, because it was simpler to implement and seems to be the safer option to go with – if t-shirts already started production, I will probably not want them to be canceled now. So for now, modifying `set_addons` to ignore the removal of unavailable products should be the safest way forward. Still, we might need to revisit this in the future.