### PR TITLE
Add a community install guide page

### DIFF
--- a/doc/admin/installation/community.rst
+++ b/doc/admin/installation/community.rst
@@ -1,0 +1,13 @@
+.. highlight:: none
+
+.. _`community`:
+
+Community install guides
+================================
+
+.. warning:: The guides are maintained by the community and not by the pretix core team. If you encounter any issues with the guides, please report them to the maintainers of the guides. The pretix core team can not provide support for installs using these guides.
+
+Kubernetes
+------------
+- Helm Chart by techwolf12 - A Helm chart for deploying pretix on Kubernetes. The chart documentation is available on `ArtifactHub <https://artifacthub.io/packages/helm/techwolf12/pretix>`_ and the source code is available on `GitHub <https://github.com/Techwolf12/charts/tree/main/pretix-helm>`_.
+

--- a/doc/admin/installation/index.rst
+++ b/doc/admin/installation/index.rst
@@ -14,3 +14,4 @@ for your needs.
    manual_smallscale
    dev_version
    enterprise
+   community


### PR DESCRIPTION
As discussed in #4011, a separate community install guide page with the Helm chart for Kubernetes deployment