### PR TITLE
Add links to invalid inputs on error alert (Z#23149061)

### DIFF
--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -200,6 +200,10 @@ input[type=number]::-webkit-outer-spin-button {
 .alert-primary {
   border-color: $brand-primary !important;
 }
+.alert-danger a {
+  color: $alert-danger-text;
+  text-decoration: underline;
+}
 
 .progress-bar {
   box-shadow: none;

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -169,6 +169,10 @@ input[type=number]::-webkit-outer-spin-button {
     background-position: 6px 6px;
     background-size: 38px 38px;
   }
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
 }
 .sr-only.alert::before {
   background: none !important;
@@ -199,10 +203,6 @@ input[type=number]::-webkit-outer-spin-button {
 }
 .alert-primary {
   border-color: $brand-primary !important;
-}
-.alert-danger a {
-  color: $alert-danger-text;
-  text-decoration: underline;
 }
 
 .progress-bar {

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -765,20 +765,40 @@ function setup_basics(el) {
         $($(this).attr("data-target")).collapse('show');
     });
     el.find("div.collapsed").removeClass("collapsed").addClass("collapse");
-    el.find(".has-error").each(function () {
-        var $panel = $(this).closest("div.panel-collapse").collapse("show");
+    el.find(".has-error, .panel-body .alert-danger:not(:has(.has-error))").each(function () {
+        var $this = $(this);
+        var $panel = $this.closest("div.panel-collapse").collapse("show");
         var alert = el.find(".alert-danger").get(0);
-        var input = $("input", this).get(0);
-        if (!alert || !input) {
+        var label = "";
+        var description = "";
+        var scrollTarget = null;
+        if ($this.hasClass('alert-danger')) {
+            // just a general error messages without a concrete input
+            label = $this.closest('.panel').find('.panel-title').contents().filter(function() { return this.nodeType == Node.TEXT_NODE; }).text()
+            description = $this.text();
+            scrollTarget = $this.closest('.panel').get(0);
+            if (!scrollTarget.id) {
+                scrollTarget.id = "panel_" + $("input", scrollTarget).attr("id")
+            }
+        } else {
+            label = $("label", this).first().text();
+            description = $(".help-block", this).first().text();
+            scrollTarget = $(":input", this).get(0);
+        }
+
+        if (!alert || !scrollTarget) {
             return;
         }
 
-        $('<li><a href="#' + input.id + '">' + $("label", this).text() + '</a> – ' + $(".help-block", this).first().text() + '</li>')
+        $('<li><a href="#' + scrollTarget.id + '">' + label + '</a> – ' + description + '</li>')
             .appendTo(alert.querySelector("ul") || $("<ul>").appendTo(alert))
             .find("a").on("click", function(e) {
                 $panel.collapse("show");
-                $(".nav-tabs a[href='#" + input.closest(".tab-pane").id + "']").click();
-                input.focus();
+                var tab = scrollTarget.closest(".tab-pane");
+                if (tab) {
+                    $(".nav-tabs a[href='#" + tab.id + "']").click();
+                }
+                scrollTarget.focus();
             });
     });
 

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -766,7 +766,20 @@ function setup_basics(el) {
     });
     el.find("div.collapsed").removeClass("collapsed").addClass("collapse");
     el.find(".has-error").each(function () {
-        $(this).closest("div.panel-collapse").collapse("show");
+        var $panel = $(this).closest("div.panel-collapse").collapse("show");
+        var alert = el.find(".alert-danger").get(0);
+        var input = $("input", this).get(0);
+        if (!alert || !input) {
+            return;
+        }
+
+        $('<li><a href="#' + input.id + '">' + $("label", this).text() + '</a> – ' + $(".help-block", this).first().text() + '</li>')
+            .appendTo(alert.querySelector("ul") || $("<ul>").appendTo(alert))
+            .find("a").on("click", function(e) {
+                $panel.collapse("show");
+                $(".nav-tabs a[href='#" + input.closest(".tab-pane").id + "']").click();
+                input.focus();
+            });
     });
 
     el.find('[data-toggle="tooltip"]').tooltip();

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -790,7 +790,7 @@ function setup_basics(el) {
             return;
         }
 
-        $('<li><a href="#' + scrollTarget.id + '">' + label + '</a> – ' + description + '</li>')
+        $('<li><a href="#' + scrollTarget.id + '">' + $.trim(label) + '</a> – ' + description + '</li>')
             .appendTo(alert.querySelector("ul") || $("<ul>").appendTo(alert))
             .find("a").on("click", function(e) {
                 $panel.collapse("show");

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -773,7 +773,7 @@ function setup_basics(el) {
         var description = "";
         var scrollTarget = null;
         if ($this.hasClass('alert-danger')) {
-            // just a general error messages without a concrete input
+            // just a general error messages without a actual errorenous input
             label = $this.closest('.panel').find('.panel-title').contents().filter(function() { return this.nodeType == Node.TEXT_NODE; }).text()
             description = $this.text();
             scrollTarget = $this.closest('.panel').get(0);

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -798,6 +798,7 @@ function setup_basics(el) {
                 if (tab) {
                     $(".nav-tabs a[href='#" + tab.id + "']").click();
                 }
+                scrollTarget.scrollIntoView();
                 scrollTarget.focus();
             });
     });

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -778,7 +778,7 @@ function setup_basics(el) {
             description = $this.text();
             scrollTarget = $this.closest('.panel').get(0);
             if (!scrollTarget.id) {
-                scrollTarget.id = "panel_" + $("input", scrollTarget).attr("id")
+                scrollTarget.id = "panel_" + $("input", scrollTarget).attr("id");
             }
         } else {
             label = $("label", this).first().text();


### PR DESCRIPTION
When an error-alert is given, this PR adds descriptive links to invalid inputs including label and first help-text (usually the error) of that input.

![default](https://github.com/pretix/pretix/assets/276509/9b453777-20c6-4583-bd13-280e339fa99d)

TODO: We might think about changing the link-style in alert-danger to e.g. red with underline?

![red-underline](https://github.com/pretix/pretix/assets/276509/a73bad43-dd8e-422a-b94c-424f098ca51a)
