### PR TITLE
Discount bugfix

### DIFF
--- a/src/pretix/base/models/discount.py
+++ b/src/pretix/base/models/discount.py
@@ -23,6 +23,7 @@
 from collections import defaultdict
 from decimal import Decimal
 from itertools import groupby
+from math import ceil
 from typing import Dict, Optional, Tuple
 
 from django.core.exceptions import ValidationError
@@ -257,6 +258,7 @@ class Discount(LoggedModel):
             result[idx] = new_price
 
     def _apply_min_count(self, positions, condition_idx_group, benefit_idx_group, result):
+        print("_apply_min_count", self)
         if len(condition_idx_group) < self.condition_min_count:
             return
 
@@ -272,9 +274,10 @@ class Discount(LoggedModel):
 
             # Prevent over-consuming of items, i.e. if our discount is "buy 2, get 1 free", we only
             # want to match multiples of 3
-            n_groups = min(len(condition_idx_group) // self.condition_min_count, len(benefit_idx_group))
+            n_groups = min(len(condition_idx_group) // self.condition_min_count, ceil(len(benefit_idx_group) / self.benefit_only_apply_to_cheapest_n_matches))
             consume_idx = condition_idx_group[:n_groups * self.condition_min_count]
             benefit_idx = benefit_idx_group[:n_groups * self.benefit_only_apply_to_cheapest_n_matches]
+            print("n_groups", n_groups, "consume", self.condition_min_count, consume_idx, "benefit", self.benefit_only_apply_to_cheapest_n_matches, benefit_idx)
         else:
             consume_idx = condition_idx_group
             benefit_idx = benefit_idx_group

--- a/src/pretix/base/models/discount.py
+++ b/src/pretix/base/models/discount.py
@@ -258,7 +258,6 @@ class Discount(LoggedModel):
             result[idx] = new_price
 
     def _apply_min_count(self, positions, condition_idx_group, benefit_idx_group, result):
-        print("_apply_min_count", self)
         if len(condition_idx_group) < self.condition_min_count:
             return
 

--- a/src/pretix/base/models/discount.py
+++ b/src/pretix/base/models/discount.py
@@ -277,7 +277,6 @@ class Discount(LoggedModel):
             n_groups = min(len(condition_idx_group) // self.condition_min_count, ceil(len(benefit_idx_group) / self.benefit_only_apply_to_cheapest_n_matches))
             consume_idx = condition_idx_group[:n_groups * self.condition_min_count]
             benefit_idx = benefit_idx_group[:n_groups * self.benefit_only_apply_to_cheapest_n_matches]
-            print("n_groups", n_groups, "consume", self.condition_min_count, consume_idx, "benefit", self.benefit_only_apply_to_cheapest_n_matches, benefit_idx)
         else:
             consume_idx = condition_idx_group
             benefit_idx = benefit_idx_group


### PR DESCRIPTION
Example:

Two discounts:
A) "For every 1 item1, you get three item2 for 10 % off."
B) "For every 1 item1, you get five item3 for 10 % off."

Cart: 2x item1, 2x item2, 6x item3

Expected result: 2x item1 full price, 2x item2 discounted, **5x item3 discounted, 1x item3 full price**

Current result without fix: 2x item1 full price, 2x item2 discounted, **6x item3 full price**
(because discount A erroneously "consumes" both item1, instead of just one)
