### PR TITLE
Improve order secret handling

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -35,6 +35,7 @@
 
 import copy
 import hashlib
+import hmac
 import json
 import logging
 import operator
@@ -59,7 +60,7 @@ from django.db.models.functions import Coalesce, Greatest
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.crypto import get_random_string
+from django.utils.crypto import get_random_string, salted_hmac
 from django.utils.encoding import escape_uri_path
 from django.utils.formats import date_format
 from django.utils.functional import cached_property
@@ -1218,6 +1219,37 @@ class Order(LockModel, LoggedModel):
         self._transaction_key_reset()
         _transactions_mark_order_clean(self.pk)
         return create
+
+    def tagged_secret(self, tag, secret_length=64):
+        return salted_hmac(key_salt=tag, value=self.secret, algorithm="sha256").hexdigest()[:secret_length]
+
+    @staticmethod
+    def get_with_secret_check(code, received_secret, tag, secret_length=64, qs=None):
+        if not qs: qs = Order.objects
+        dummy = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"[:secret_length]
+        try:
+            order = qs.get(code=code)
+            if not hmac.compare_digest(
+                order.tagged_secret(tag, secret_length) if tag else order.secret,
+                received_secret[:secret_length].lower() if tag else received_secret.lower()
+            ) and not (
+                    # TODO: remove this clause after a while (compatibility with old secrets currently in flight)
+                    tag and hmac.compare_digest(
+                        hashlib.sha1(order.secret.lower().encode()).hexdigest(),
+                        received_secret.lower()
+                    )
+            ):
+                raise Order.DoesNotExist
+            return order
+        except Order.DoesNotExist:
+            # Do a hash comparison as well to harden against timing attacks
+            if hmac.compare_digest(
+                salted_hmac(key_salt=tag, value=dummy, algorithm="sha256").hexdigest()[:secret_length],
+                received_secret[:secret_length]
+            ):
+                raise Order.DoesNotExist
+            else:
+                raise Order.DoesNotExist
 
 
 def answerfile_name(instance, filename: str) -> str:

--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <https://www.gnu.org/licenses/>.
 #
-import hashlib
 import json
 import logging
 import urllib.parse
@@ -1096,5 +1095,5 @@ class PaypalAPM(PaypalMethod):
         return eventreverse(self.event, 'plugins:paypal2:pay', kwargs={
             'order': payment.order.code,
             'payment': payment.pk,
-            'hash': hashlib.sha1(payment.order.secret.lower().encode()).hexdigest(),
+            'hash': payment.order.tagged_secret('plugins:paypal2:pay'),
         })

--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -32,7 +32,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 
-import hashlib
 import json
 import logging
 import re
@@ -628,7 +627,7 @@ class StripeMethod(BasePaymentProvider):
             'order': payment.order,
             'payment': payment,
             'payment_info': payment_info,
-            'payment_hash': hashlib.sha1(payment.order.secret.lower().encode()).hexdigest()
+            'payment_hash': payment.order.tagged_secret('plugins:stripe')
         }
         return template.render(ctx)
 
@@ -882,7 +881,7 @@ class StripeMethod(BasePaymentProvider):
                     return_url=build_absolute_uri(self.event, 'plugins:stripe:sca.return', kwargs={
                         'order': payment.order.code,
                         'payment': payment.pk,
-                        'hash': hashlib.sha1(payment.order.secret.lower().encode()).hexdigest(),
+                        'hash': payment.order.tagged_secret('plugins:stripe'),
                     }),
                     expand=['latest_charge'],
                     **params
@@ -980,7 +979,7 @@ class StripeMethod(BasePaymentProvider):
         url = build_absolute_uri(self.event, 'plugins:stripe:sca', kwargs={
             'order': payment.order.code,
             'payment': payment.pk,
-            'hash': hashlib.sha1(payment.order.secret.lower().encode()).hexdigest(),
+            'hash': payment.order.tagged_secret('plugins:stripe'),
         })
         if not self.redirect_in_widget_allowed and request.session.get('iframe_session', False):
             return build_absolute_uri(self.event, 'plugins:stripe:redirect') + '?data=' + signing.dumps({
@@ -1001,7 +1000,7 @@ class StripeMethod(BasePaymentProvider):
                 return_url=build_absolute_uri(self.event, 'plugins:stripe:sca.return', kwargs={
                     'order': payment.order.code,
                     'payment': payment.pk,
-                    'hash': hashlib.sha1(payment.order.secret.lower().encode()).hexdigest(),
+                    'hash': payment.order.tagged_secret('plugins:stripe'),
                 }),
                 expand=["latest_charge"],
                 **self.api_kwargs
@@ -1821,7 +1820,7 @@ class StripeMultibanco(StripeSourceMethod):
                 'return_url': build_absolute_uri(self.event, 'plugins:stripe:return', kwargs={
                     'order': payment.order.code,
                     'payment': payment.pk,
-                    'hash': hashlib.sha1(payment.order.secret.lower().encode()).hexdigest(),
+                    'hash': payment.order.tagged_secret('plugins:stripe'),
                 })
             },
             **self.api_kwargs

--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -32,7 +32,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 
-import hashlib
 import json
 import logging
 import urllib.parse
@@ -486,15 +485,12 @@ def oauth_disconnect(request, **kwargs):
 class StripeOrderView:
     def dispatch(self, request, *args, **kwargs):
         try:
-            self.order = request.event.orders.get(code=kwargs['order'])
-            if hashlib.sha1(self.order.secret.lower().encode()).hexdigest() != kwargs['hash'].lower():
-                raise Http404('')
+            self.order = Order.get_with_secret_check(
+                qs=request.event.orders, code=kwargs['order'], received_secret=kwargs['hash'].lower(),
+                tag='plugins:stripe'
+            )
         except Order.DoesNotExist:
-            # Do a hash comparison as well to harden timing attacks
-            if 'abcdefghijklmnopq'.lower() == hashlib.sha1('abcdefghijklmnopq'.encode()).hexdigest():
-                raise Http404('')
-            else:
-                raise Http404('')
+            raise Http404('Unknown order')
         self.payment = get_object_or_404(
             self.order.payments,
             pk=self.kwargs['payment'],

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -33,6 +33,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 import copy
+import hmac
 import inspect
 import json
 import mimetypes
@@ -102,18 +103,13 @@ class OrderDetailMixin(NoSearchIndexViewMixin):
 
     @cached_property
     def order(self):
-        order = self.request.event.orders.filter(code=self.kwargs['order']).select_related('event').first()
-        if order:
-            if order.secret.lower() == self.kwargs['secret'].lower():
-                return order
-            else:
-                return None
-        else:
-            # Do a comparison as well to harden timing attacks
-            if 'abcdefghijklmnopq'.lower() == self.kwargs['secret'].lower():
-                return None
-            else:
-                return None
+        try:
+            return Order.get_with_secret_check(
+                code=self.kwargs['order'], received_secret=self.kwargs['secret'], tag=None,
+                qs=self.request.event.orders.filter().select_related('event')
+            )
+        except Order.DoesNotExist:
+            return None
 
     def get_order_url(self):
         return eventreverse(self.request.event, 'presale:event.order', kwargs={
@@ -133,13 +129,13 @@ class OrderPositionDetailMixin(NoSearchIndexViewMixin):
         ).select_related('order', 'order__event')
         p = qs.first()
         if p:
-            if p.web_secret.lower() == self.kwargs['secret'].lower():
+            if hmac.compare_digest(p.web_secret.lower(), self.kwargs['secret'].lower()):
                 return p
             else:
                 return None
         else:
             # Do a comparison as well to harden timing attacks
-            if 'abcdefghijklmnopq'.lower() == self.kwargs['secret'].lower():
+            if hmac.compare_digest('abcdefghijklmnopq'.lower(), self.kwargs['secret'].lower()):
                 return None
             else:
                 return None


### PR DESCRIPTION
- use hmac.compare_digest for all secret comparisons
- use salted_hmac with sha256 instead of plain sha1 for hashed secrets
- move secret handling into helper functions

after this is merged, our payment provider plugins can be refactored to use tagged_secret / get_with_secret_check instead of hashlib.sha1