### PR TITLE
PDF: use PDF-version from background-PDF if higher than foreground in pypdf

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1084,10 +1084,10 @@ class Renderer:
                 if float(self.bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
                     # To fix issues with pdftk and background-PDF using pdf-version greater
                     # than foreground-PDF, we stamp front onto back instead.
-                    # Just changing PDF-version in front.pdf to match the version of
-                    # back.pdf as we do with pypdf, does not work with pdftk.
+                    # Just changing PDF-version in fg.pdf to match the version of
+                    # bg.pdf as we do with pypdf, does not work with pdftk.
                     #
-                    # Make sure that back.pdf matches the number of pages of front.pdf
+                    # Make sure that bg.pdf matches the number of pages of fg.pdf
                     # note: self.bg_pdf is a PdfReader(), not a PdfWriter()
                     bg_pdf_to_merge = PdfWriter()
                     bg_pdf_to_merge.append(self.bg_pdf)
@@ -1153,8 +1153,8 @@ def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
             if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
                 # To fix issues with pdftk and background-PDF using pdf-version greater
                 # than foreground-PDF, we stamp front onto back instead.
-                # Just changing PDF-version in front.pdf to match the version of
-                # back.pdf as we do with pypdf, does not work with pdftk.
+                # Just changing PDF-version in fg.pdf to match the version of
+                # bg.pdf as we do with pypdf, does not work with pdftk.
 
                 # Make sure that bg.pdf matches the number of pages of fg.pdf
                 front_num_pages = fg_pdf.get_num_pages()

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1092,10 +1092,10 @@ class Renderer:
                     fg_num_pages = fg_pdf.get_num_pages()
                     bg_num_pages = self.bg_pdf.get_num_pages()
                     bg_pdf_to_merge = PdfWriter()
-                    bg_pdf_to_merge.append(self.bg_pdf, pages = (0, min(bg_num_pages, fg_num_pages)))
+                    bg_pdf_to_merge.append(self.bg_pdf, pages=(0, min(bg_num_pages, fg_num_pages)))
                     while bg_num_pages < fg_num_pages:
                         max_page_to_merge = min(bg_num_pages, fg_num_pages - bg_num_pages)
-                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages = (0, max_page_to_merge))
+                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages=(0, max_page_to_merge))
                         bg_num_pages = bg_pdf_to_merge.get_num_pages()
                     bg_pdf_to_merge.write(bg_filename)
 
@@ -1162,9 +1162,9 @@ def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
                 bg_num_pages = bg_pdf.get_num_pages()
                 while bg_num_pages < fg_num_pages:
                     max_page_to_merge = min(bg_num_pages, fg_num_pages - bg_num_pages)
-                    bg_pdf_to_merge.append(bg_pdf_to_merge, pages = (0, max_page_to_merge))
-                    bg_num_pages = bg_pdf_to_merge.get_num_pages()
-                bg_pdf_to_merge.write(bg_filename)
+                    bg_pdf.append(bg_pdf, pages=(0, max_page_to_merge))
+                    bg_num_pages = bg_pdf.get_num_pages()
+                bg_pdf.write(bg_filename)
 
                 pdftk_cmd = [
                     settings.PDFTK,

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1155,8 +1155,8 @@ def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
                 # than foreground-PDF, we stamp front onto back instead.
                 # Just changing PDF-version in front.pdf to match the version of
                 # back.pdf as we do with pypdf, does not work with pdftk.
-                #
-                # Make sure that back.pdf matches the number of pages of front.pdf
+
+                # Make sure that bg.pdf matches the number of pages of fg.pdf
                 front_num_pages = fg_pdf.get_num_pages()
                 while (bg_pdf.get_num_pages() < front_num_pages):
                     bg_pdf.append(bg_pdf)

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1080,7 +1080,7 @@ class Renderer:
                 buffer.seek(0)
                 with open(fg_filename, 'wb') as f:
                     f.write(buffer.read())
-
+                # pdf_header is a string like "%pdf-X.X"
                 if float(self.bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
                     # To fix issues with pdftk and background-PDF using pdf-version greater 
                     # than foreground-PDF, we stamp front onto back instead. 
@@ -1128,6 +1128,7 @@ class Renderer:
                 page.merge_page(bg_page, over=False)
                 output.add_page(page)
 
+            # pdf_header is a string like "%pdf-X.X"
             if float(self.bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
                 output.pdf_header = self.bg_pdf.pdf_header
 
@@ -1147,6 +1148,7 @@ def merge_background(fg_pdf, bg_pdf, out_file, compress):
             fg_filename = os.path.join(d, 'fg.pdf')
             bg_filename = os.path.join(d, 'bg.pdf')
 
+            # pdf_header is a string like "%pdf-X.X"
             if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
                 # To fix issues with pdftk and background-PDF using pdf-version greater 
                 # than foreground-PDF, we stamp front onto back instead. 
@@ -1188,6 +1190,7 @@ def merge_background(fg_pdf, bg_pdf, out_file, compress):
                 bg_page.transfer_rotation_to_content()
             page.merge_page(bg_page, over=False)
 
+        # pdf_header is a string like "%pdf-X.X"
         if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
             fg_pdf.pdf_header = bg_pdf.pdf_header
 

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1098,6 +1098,9 @@ class Renderer:
                 page.merge_page(bg_page, over=False)
                 output.add_page(page)
 
+            if float(self.bg_pdf.pdf_header[5:]) > float(new_pdf.pdf_header[5:]):
+                output.pdf_header = self.bg_pdf.pdf_header
+
             output.add_metadata({
                 '/Title': str(title),
                 '/Creator': 'pretix',
@@ -1134,6 +1137,10 @@ def merge_background(fg_pdf, bg_pdf, out_file, compress):
                 bg_page.transfer_rotation_to_content()
             page.merge_page(bg_page, over=False)
             output.add_page(page)
+
+        if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
+            output.pdf_header = bg_pdf.pdf_header
+
         output.write(out_file)
 
 

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1089,13 +1089,14 @@ class Renderer:
                     #
                     # Make sure that bg.pdf matches the number of pages of fg.pdf
                     # note: self.bg_pdf is a PdfReader(), not a PdfWriter()
+                    fg_num_pages = fg_pdf.get_num_pages()
+                    bg_num_pages = self.bg_pdf.get_num_pages()
                     bg_pdf_to_merge = PdfWriter()
-                    bg_pdf_to_merge.append(self.bg_pdf)
-                    front_num_pages = fg_pdf.get_num_pages()
-                    while (bg_pdf_to_merge.get_num_pages() < front_num_pages):
-                        bg_pdf_to_merge.append(bg_pdf_to_merge)
-                    if bg_pdf_to_merge.get_num_pages() > front_num_pages:
-                        bg_pdf_to_merge.pages = bg_pdf_to_merge.pages[:front_num_pages]
+                    bg_pdf_to_merge.append(self.bg_pdf, pages = (0, min(bg_num_pages, fg_num_pages)))
+                    while bg_num_pages < fg_num_pages:
+                        max_page_to_merge = min(bg_num_pages, fg_num_pages - bg_num_pages)
+                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages = (0, max_page_to_merge))
+                        bg_num_pages = bg_pdf_to_merge.get_num_pages()
                     bg_pdf_to_merge.write(bg_filename)
 
                     pdftk_cmd = [
@@ -1157,11 +1158,13 @@ def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
                 # bg.pdf as we do with pypdf, does not work with pdftk.
 
                 # Make sure that bg.pdf matches the number of pages of fg.pdf
-                front_num_pages = fg_pdf.get_num_pages()
-                while (bg_pdf.get_num_pages() < front_num_pages):
-                    bg_pdf.append(bg_pdf)
-                if bg_pdf.get_num_pages() > front_num_pages:
-                    bg_pdf.pages = bg_pdf.pages[:front_num_pages]
+                fg_num_pages = fg_pdf.get_num_pages()
+                bg_num_pages = bg_pdf.get_num_pages()
+                while bg_num_pages < fg_num_pages:
+                    max_page_to_merge = min(bg_num_pages, fg_num_pages - bg_num_pages)
+                    bg_pdf_to_merge.append(bg_pdf_to_merge, pages = (0, max_page_to_merge))
+                    bg_num_pages = bg_pdf_to_merge.get_num_pages()
+                bg_pdf_to_merge.write(bg_filename)
 
                 pdftk_cmd = [
                     settings.PDFTK,

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1082,8 +1082,8 @@ class Renderer:
                     f.write(buffer.read())
                 # pdf_header is a string like "%pdf-X.X"
                 if float(self.bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
-                    # To fix issues with pdftk and background-PDF using pdf-version greater 
-                    # than foreground-PDF, we stamp front onto back instead. 
+                    # To fix issues with pdftk and background-PDF using pdf-version greater
+                    # than foreground-PDF, we stamp front onto back instead.
                     # Just changing PDF-version in front.pdf to match the version of
                     # back.pdf as we do with pypdf, does not work with pdftk.
                     #
@@ -1142,6 +1142,7 @@ class Renderer:
             outbuffer.seek(0)
             return outbuffer
 
+
 # note: fg_pdf and bg_pdf are PdfWriter, not PdfReader!
 def merge_background(fg_pdf, bg_pdf, out_file, compress):
     if settings.PDFTK:
@@ -1151,8 +1152,8 @@ def merge_background(fg_pdf, bg_pdf, out_file, compress):
 
             # pdf_header is a string like "%pdf-X.X"
             if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
-                # To fix issues with pdftk and background-PDF using pdf-version greater 
-                # than foreground-PDF, we stamp front onto back instead. 
+                # To fix issues with pdftk and background-PDF using pdf-version greater
+                # than foreground-PDF, we stamp front onto back instead.
                 # Just changing PDF-version in front.pdf to match the version of
                 # back.pdf as we do with pypdf, does not work with pdftk.
                 #

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1090,9 +1090,10 @@ class Renderer:
                     # Make sure that back.pdf matches the number of pages of front.pdf
                     # note: self.bg_pdf is a PdfReader(), not a PdfWriter()
                     bg_pdf_to_merge = PdfWriter()
+                    bg_pdf_to_merge.append(self.bg_pdf)
                     front_num_pages = fg_pdf.get_num_pages()
                     while (bg_pdf_to_merge.get_num_pages() < front_num_pages):
-                        bg_pdf_to_merge.append(self.bg_pdf)
+                        bg_pdf_to_merge.append(bg_pdf_to_merge)
                     if bg_pdf_to_merge.get_num_pages() > front_num_pages:
                         bg_pdf_to_merge.pages = bg_pdf_to_merge.pages[:front_num_pages]
                     bg_pdf_to_merge.write(bg_filename)

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1068,37 +1068,67 @@ class Renderer:
                 canvas.showPage()
 
     def render_background(self, buffer, title=_('Ticket')):
+        buffer.seek(0)
+        fg_pdf = PdfReader(buffer)
+
         if settings.PDFTK:
-            buffer.seek(0)
             with tempfile.TemporaryDirectory() as d:
-                with open(os.path.join(d, 'back.pdf'), 'wb') as f:
-                    f.write(self.bg_bytes)
-                with open(os.path.join(d, 'front.pdf'), 'wb') as f:
+                fg_filename = os.path.join(d, 'fg.pdf')
+                bg_filename = os.path.join(d, 'bg.pdf')
+                out_filename = os.path.join(d, 'out.pdf')
+
+                buffer.seek(0)
+                with open(fg_filename, 'wb') as f:
                     f.write(buffer.read())
-                subprocess.run([
-                    settings.PDFTK,
-                    os.path.join(d, 'front.pdf'),
-                    'multibackground',
-                    os.path.join(d, 'back.pdf'),
-                    'output',
-                    os.path.join(d, 'out.pdf'),
-                    'compress'
-                ], check=True)
-                with open(os.path.join(d, 'out.pdf'), 'rb') as f:
+
+                if float(self.bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
+                    # To fix issues with pdftk and background-PDF using pdf-version greater 
+                    # than foreground-PDF, we stamp front onto back instead. 
+                    # Just changing PDF-version in front.pdf to match the version of
+                    # back.pdf as we do with pypdf, does not work with pdftk.
+                    #
+                    # Make sure that back.pdf matches the number of pages of front.pdf
+                    # note: self.bg_pdf is a PdfReader(), not a PdfWriter()
+                    bg_pdf_to_merge = PdfWriter()
+                    front_num_pages = fg_pdf.get_num_pages()
+                    while (bg_pdf_to_merge.get_num_pages() < front_num_pages):
+                        bg_pdf_to_merge.append(self.bg_pdf)
+                    if bg_pdf_to_merge.get_num_pages() > front_num_pages:
+                        bg_pdf_to_merge.pages = bg_pdf_to_merge.pages[:front_num_pages]
+                    bg_pdf_to_merge.write(bg_filename)
+
+                    pdftk_cmd = [
+                        settings.PDFTK,
+                        bg_filename,
+                        'multistamp',
+                        fg_filename
+                    ]
+
+                else:
+                    with open(bg_filename, 'wb') as f:
+                        f.write(self.bg_bytes)
+                    pdftk_cmd = [
+                        settings.PDFTK,
+                        fg_filename,
+                        'multibackground',
+                        bg_filename
+                    ]
+
+                pdftk_cmd.extend(('output', out_filename, 'compress'))
+                subprocess.run(pdftk_cmd, check=True)
+                with open(out_filename, 'rb') as f:
                     return BytesIO(f.read())
         else:
-            buffer.seek(0)
-            new_pdf = PdfReader(buffer)
             output = PdfWriter()
 
-            for i, page in enumerate(new_pdf.pages):
+            for i, page in enumerate(fg_pdf.pages):
                 bg_page = self.bg_pdf.pages[i]
                 if bg_page.rotation != 0:
                     bg_page.transfer_rotation_to_content()
                 page.merge_page(bg_page, over=False)
                 output.add_page(page)
 
-            if float(self.bg_pdf.pdf_header[5:]) > float(new_pdf.pdf_header[5:]):
+            if float(self.bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
                 output.pdf_header = self.bg_pdf.pdf_header
 
             output.add_metadata({
@@ -1110,38 +1140,58 @@ class Renderer:
             outbuffer.seek(0)
             return outbuffer
 
-
+# note: fg_pdf and bg_pdf are PdfWriter, not PdfReader!
 def merge_background(fg_pdf, bg_pdf, out_file, compress):
     if settings.PDFTK:
         with tempfile.TemporaryDirectory() as d:
             fg_filename = os.path.join(d, 'fg.pdf')
             bg_filename = os.path.join(d, 'bg.pdf')
-            fg_pdf.write(fg_filename)
-            bg_pdf.write(bg_filename)
-            pdftk_cmd = [
-                settings.PDFTK,
-                fg_filename,
-                'multibackground',
-                bg_filename,
-                'output',
-                '-',
-            ]
+
+            if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
+                # To fix issues with pdftk and background-PDF using pdf-version greater 
+                # than foreground-PDF, we stamp front onto back instead. 
+                # Just changing PDF-version in front.pdf to match the version of
+                # back.pdf as we do with pypdf, does not work with pdftk.
+                #
+                # Make sure that back.pdf matches the number of pages of front.pdf
+                front_num_pages = fg_pdf.get_num_pages()
+                while (bg_pdf.get_num_pages() < front_num_pages):
+                    bg_pdf.append(bg_pdf)
+                if bg_pdf.get_num_pages() > front_num_pages:
+                    bg_pdf.pages = bg_pdf.pages[:front_num_pages]
+
+                pdftk_cmd = [
+                    settings.PDFTK,
+                    bg_filename,
+                    'multistamp',
+                    fg_filename,
+                ]
+            else:
+                pdftk_cmd = [
+                    settings.PDFTK,
+                    fg_filename,
+                    'multibackground',
+                    bg_filename
+                ]
+
+            pdftk_cmd.extend(('output', '-'))
             if compress:
                 pdftk_cmd.append('compress')
+
+            fg_pdf.write(fg_filename)
+            bg_pdf.write(bg_filename)
             subprocess.run(pdftk_cmd, check=True, stdout=out_file)
     else:
-        output = PdfWriter()
         for i, page in enumerate(fg_pdf.pages):
             bg_page = bg_pdf.pages[i]
             if bg_page.rotation != 0:
                 bg_page.transfer_rotation_to_content()
             page.merge_page(bg_page, over=False)
-            output.add_page(page)
 
         if float(bg_pdf.pdf_header[5:]) > float(fg_pdf.pdf_header[5:]):
-            output.pdf_header = bg_pdf.pdf_header
+            fg_pdf.pdf_header = bg_pdf.pdf_header
 
-        output.write(out_file)
+        fg_pdf.write(out_file)
 
 
 @deconstructible

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1143,8 +1143,7 @@ class Renderer:
             return outbuffer
 
 
-# note: fg_pdf and bg_pdf are PdfWriter, not PdfReader!
-def merge_background(fg_pdf, bg_pdf, out_file, compress):
+def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
     if settings.PDFTK:
         with tempfile.TemporaryDirectory() as d:
             fg_filename = os.path.join(d, 'fg.pdf')

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1093,10 +1093,10 @@ class Renderer:
                     bg_num_pages = self.bg_pdf.get_num_pages()
                     bg_pdf_to_merge = PdfWriter()
                     bg_pdf_to_merge.append(self.bg_pdf, pages=(0, min(bg_num_pages, fg_num_pages)))
-                    while bg_num_pages < fg_num_pages:
-                        max_page_to_merge = min(bg_num_pages, fg_num_pages - bg_num_pages)
-                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages=(0, max_page_to_merge))
-                        bg_num_pages = bg_pdf_to_merge.get_num_pages()
+                    if fg_num_pages > bg_num_pages:
+                        # repeat last page in bg_pdf to match fg_pdf
+                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages=[bg_num_pages-1] * (fg_num_pages - bg_num_pages))
+
                     bg_pdf_to_merge.write(bg_filename)
 
                     pdftk_cmd = [
@@ -1160,10 +1160,10 @@ def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
                 # Make sure that bg.pdf matches the number of pages of fg.pdf
                 fg_num_pages = fg_pdf.get_num_pages()
                 bg_num_pages = bg_pdf.get_num_pages()
-                while bg_num_pages < fg_num_pages:
-                    max_page_to_merge = min(bg_num_pages, fg_num_pages - bg_num_pages)
-                    bg_pdf.append(bg_pdf, pages=(0, max_page_to_merge))
-                    bg_num_pages = bg_pdf.get_num_pages()
+                if fg_num_pages > bg_num_pages:
+                    # repeat last page in bg_pdf to match fg_pdf
+                    bg_pdf.append(bg_pdf, pages=[bg_num_pages-1] * (fg_num_pages - bg_num_pages))
+
                 bg_pdf.write(bg_filename)
 
                 pdftk_cmd = [

--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -1095,7 +1095,7 @@ class Renderer:
                     bg_pdf_to_merge.append(self.bg_pdf, pages=(0, min(bg_num_pages, fg_num_pages)))
                     if fg_num_pages > bg_num_pages:
                         # repeat last page in bg_pdf to match fg_pdf
-                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages=[bg_num_pages-1] * (fg_num_pages - bg_num_pages))
+                        bg_pdf_to_merge.append(bg_pdf_to_merge, pages=[bg_num_pages - 1] * (fg_num_pages - bg_num_pages))
 
                     bg_pdf_to_merge.write(bg_filename)
 
@@ -1162,7 +1162,7 @@ def merge_background(fg_pdf: PdfWriter, bg_pdf: PdfWriter, out_file, compress):
                 bg_num_pages = bg_pdf.get_num_pages()
                 if fg_num_pages > bg_num_pages:
                     # repeat last page in bg_pdf to match fg_pdf
-                    bg_pdf.append(bg_pdf, pages=[bg_num_pages-1] * (fg_num_pages - bg_num_pages))
+                    bg_pdf.append(bg_pdf, pages=[bg_num_pages - 1] * (fg_num_pages - bg_num_pages))
 
                 bg_pdf.write(bg_filename)
 


### PR DESCRIPTION
pypdf happily handles PDFs with versions greater than what our reportlab produces (1.4). When a background PDF uses features from versions higher than 1.4 that creates problems. This PR fixes it by:

- when using pypdf, the pdf_header of the output will match the bigger pdf-version of either background PDF or foreground PDF.
- when using pdftk, manually setting the pdf-version did not yield the same success, but instead of placing the background inside the foreground PDF, stamping the foreground PDF onto the background PDF worked. We now just need to make sure, that the background PDF has the same amount of pages as the foreground PDF.