### PR TITLE
Docs: Fix metrics names

### DIFF
--- a/doc/admin/maintainance.rst
+++ b/doc/admin/maintainance.rst
@@ -103,10 +103,10 @@ pretix_celery_tasks_queued_count
 pretix_celery_tasks_queued_age_seconds
     The age of the longest-waiting in the worker queue in seconds, labeled with ``queue``.
 
-pretix_successful_logins
+pretix_logins_successful
     Counter. The number of successful backend logins.
 
-pretix_failed_logins
+pretix_logins_failed
     Counter. The number of failed backend logins, labeled with ``reason``.
 
 .. _metric types: https://prometheus.io/docs/concepts/metric_types/


### PR DESCRIPTION
The docs of 2024.4 describe the metric names to be `pretix_XX_logins` with `XX` being successful or failed. However, the `/metrics` endpoint returns:

```
pretix_logins_successful 2.0
pretix_logins_failed{reason="2fa"} 1.0
pretix_logins_failed{reason="invalid"} 1.0
```
