### PR TITLE
Fix backquotes in documentation

### DIFF
--- a/doc/development/structure.rst
+++ b/doc/development/structure.rst
@@ -41,6 +41,6 @@ pretix/
 
 tests/
     This is the root directory for all test codes. It includes subdirectories ``api``, ``base``,
-    ``control``, ``presale``, ``helpers`, ``multidomain`` and ``plugins`` to mirror the structure
+    ``control``, ``presale``, ``helpers``, ``multidomain`` and ``plugins`` to mirror the structure
     of the pretix source code as well as ``testdummy``, which is a pretix plugin used during
     testing.


### PR DESCRIPTION
One backquote was missing and because of that, the formatted documentation looks weird.

<img width="347" alt="Screenshot 2024-06-13 at 17 00 29" src="https://github.com/pretix/pretix/assets/382887/54d806d7-e94e-4a33-9156-0077cbe370ad">
