### PR TITLE
Set cursor: not-allowed on labels for disabled checkboxes

### DIFF
--- a/src/pretix/control/forms/renderers.py
+++ b/src/pretix/control/forms/renderers.py
@@ -98,6 +98,13 @@ class ControlFieldRenderer(FieldRenderer):
             attrs = ''
         return '<div class="{klass}"{attrs}>{html}</div>'.format(klass=self.get_form_group_class(), html=html, attrs=attrs)
 
+    def wrap_widget(self, html):
+        if isinstance(self.widget, CheckboxInput):
+            css_class = "checkbox"
+            if self.field.field.disabled:
+                css_class += " disabled"
+            html = f'<div class="{css_class}">{html}</div>'
+        return html
 
 class ControlFieldWithVisibilityRenderer(ControlFieldRenderer):
     def __init__(self, *args, **kwargs):

--- a/src/pretix/control/forms/renderers.py
+++ b/src/pretix/control/forms/renderers.py
@@ -106,6 +106,7 @@ class ControlFieldRenderer(FieldRenderer):
             html = f'<div class="{css_class}">{html}</div>'
         return html
 
+
 class ControlFieldWithVisibilityRenderer(ControlFieldRenderer):
     def __init__(self, *args, **kwargs):
         kwargs['layout'] = 'horizontal'

--- a/src/pretix/presale/forms/renderers.py
+++ b/src/pretix/presale/forms/renderers.py
@@ -174,3 +174,11 @@ class CheckoutFieldRenderer(FieldRenderer):
         else:
             attrs = ''
         return '<div class="{klass}"{attrs}>{html}</div>'.format(klass=self.get_form_group_class(), html=html, attrs=attrs)
+
+    def wrap_widget(self, html):
+        if isinstance(self.widget, CheckboxInput):
+            css_class = "checkbox"
+            if self.field.field.disabled:
+                css_class += " disabled"
+            html = f'<div class="{css_class}">{html}</div>'
+        return html


### PR DESCRIPTION
Labels for disabled checkboxes currently show `cursor: pointer`. Bootstrap3 offers a class `.disabled` on `div.checkbox` to make contained lables have `cursor: not-allowed`. This PR adds it to the FieldRenderer.

Instead of changing the Renderer, thanks to the „new“ CSS-`:has` we could add a CSS rule such as

`.checkbox label:has(input:disabled) {cursor: not-allowed}`

I am not sure which way is preferable. I tend to the CSS only solution though.