### PR TITLE
Fix missing CSS in seatingframe

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/seatingplan.html
+++ b/src/pretix/presale/templates/pretixpresale/event/seatingplan.html
@@ -13,6 +13,7 @@
     {% if css_theme %}
         <link rel="stylesheet" type="text/css" href="{{ css_theme }}" />
     {% endif %}
+    {{ html_head|safe }}
     {% include "pretixpresale/fragment_js.html" %}
     <meta name="referrer" content="origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">


### PR DESCRIPTION
The change from precompiled CSS to Custom Properties broke seatingframe as no precompiled CSS is now loaded there. This PR adds the results from presale.signals.html_head to its HTML-head. This adds the needed CSS-files for seating to be displayed correctly.

CAVEAT: I am not sure though, what the implications are when using additional plugins as presale.signals.html_head does totally different things than just adding CSS – I looked through my plugins locally and they either filter for specific pages when adding stuff or „just“ add tracking javascript.