### PR TITLE
Add signal seatingframe_html_head

### DIFF
--- a/src/pretix/presale/signals.py
+++ b/src/pretix/presale/signals.py
@@ -80,6 +80,17 @@ of every page in the frontend. You will get the request as the keyword argument
 As with all plugin signals, the ``sender`` keyword argument will contain the event.
 """
 
+seatingframe_html_head = EventPluginSignal()
+"""
+Arguments: ``request``
+
+This signal allows you to put code inside the HTML ``<head>`` tag
+of the seatingframe page in the frontend. You will get the request as the keyword argument
+``request`` and are expected to return plain HTML.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+"""
+
 html_page_header = EventPluginSignal()
 """
 Arguments: ``request``

--- a/src/pretix/presale/templates/pretixpresale/event/seatingplan.html
+++ b/src/pretix/presale/templates/pretixpresale/event/seatingplan.html
@@ -13,7 +13,7 @@
     {% if css_theme %}
         <link rel="stylesheet" type="text/css" href="{{ css_theme }}" />
     {% endif %}
-    {{ html_head|safe }}
+    {{ seatingframe_html_head|safe }}
     {% include "pretixpresale/fragment_js.html" %}
     <meta name="referrer" content="origin">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -82,7 +82,7 @@ from pretix.helpers.formats.en.formats import (
 from pretix.helpers.http import redirect_to_url
 from pretix.multidomain.urlreverse import eventreverse
 from pretix.presale.ical import get_public_ical
-from pretix.presale.signals import item_description
+from pretix.presale.signals import item_description, seatingframe_html_head
 from pretix.presale.views.organizer import (
     EventListMixin, add_subevents_for_days, days_for_template,
     filter_qs_by_attr, has_before_after, weeks_for_template,
@@ -849,6 +849,11 @@ class SeatingPlanView(EventViewMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        _html_head = []
+        for receiver, response in seatingframe_html_head.send(self.request.event, request=self.request):
+            _html_head.append(response)
+        context['seatingframe_html_head'] = "".join(_html_head)
         context['subevent'] = self.subevent
         context['cart_redirect'] = eventreverse(self.request.event, 'presale:event.checkout.start',
                                                 kwargs={'cart_namespace': kwargs.get('cart_namespace') or ''})


### PR DESCRIPTION
To not include all possible html_head responses into the stripped down seatingframe, we (temporarily?) add a new signal seatingframe_html_head