### PR TITLE
Fix stripe SCA redirect/sandboxing (Z#23158598)

### DIFF
--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -295,7 +295,7 @@ var pretixstripe = {
             let iframe = document.createElement('iframe');
             iframe.src = payment_intent_next_action_redirect_url;
             iframe.className = 'embed-responsive-item';
-            iframe.setAttribute('sandbox', 'allow-scripts allow-top-navigation');
+            iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts allow-top-navigation');
             $('#scacontainer').append(iframe);
             $('#scacontainer iframe').on("load", function () {
                 waitingDialog.hide();

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -295,7 +295,7 @@ var pretixstripe = {
             let iframe = document.createElement('iframe');
             iframe.src = payment_intent_next_action_redirect_url;
             iframe.className = 'embed-responsive-item';
-            iframe.setAttribute('sandbox', 'allow-top-navigation');
+            iframe.setAttribute('sandbox', 'allow-scripts allow-top-navigation');
             $('#scacontainer').append(iframe);
             $('#scacontainer iframe').on("load", function () {
                 waitingDialog.hide();

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -295,6 +295,7 @@ var pretixstripe = {
             let iframe = document.createElement('iframe');
             iframe.src = payment_intent_next_action_redirect_url;
             iframe.className = 'embed-responsive-item';
+            iframe.setAttribute('sandbox', 'allow-top-navigation');
             $('#scacontainer').append(iframe);
             $('#scacontainer iframe').on("load", function () {
                 waitingDialog.hide();


### PR DESCRIPTION
It seems when having SCA in stripe that depending on the payment method a top-level redirect is initiated from within the emebedded iframe. This is not allowed in Chrome [without interaction](https://chromestatus.com/feature/5851021045661696), but according to [this post on WCIG](https://github.com/WICG/interventions/issues/16) adding `sandbox="allow-top-navigation"` to the iframe should allow it.

The problem is, once we use the sandbox-attribute, we need to make sure we add all features we need to allow. Of course without `allow-scripts` this does not work. But I guess having access to cookies of the same-origin is needed as well, so `allow-same-origin` should be set as well.

As I cannot test all payment methods, maybe someone with more experience regarding stripe’s payment methods might chip in. Do we need `allow-forms`, `allow-modals`, `allow-popups`, `allow-popups-to-escape-sandbox` in the SCA? AFAICT not adding the sandbox-attribute at all should behave the same as adding all allow-* to the sandbox-attribute (except of course the linked exception linked above)? So we would not break anything security-wise when adding at least the ones I listed above.

Note: I am hesitant to add this to the HTTP-CSP as I cannot assess how this affects other iframe interactions on other pretix-features/plugins.