### PR TITLE
Do not take "optional" as part of error message label

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -781,7 +781,7 @@ function setup_basics(el) {
                 scrollTarget.id = "panel_" + $("input", scrollTarget).attr("id");
             }
         } else {
-            label = $("label", this).first().text();
+            label = $("label", this).first().contents().filter(function () { return this.nodeType != Node.ELEMENT_NODE || !this.classList.contains("optional") }).text();
             description = $(".help-block", this).first().text();
             scrollTarget = $(":input", this).get(0);
         }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b2fa03e8-c1a1-4250-b57c-50a58a185374)


After:

![image](https://github.com/user-attachments/assets/95cf413b-3fe8-4f42-9ed3-2d0c9711eda4)
