### PR TITLE
UI: in plugin-list only show border-top when necessary

### DIFF
--- a/src/pretix/static/pretixcontrol/scss/main.scss
+++ b/src/pretix/static/pretixcontrol/scss/main.scss
@@ -767,8 +767,10 @@ h1 .label {
     .plugin-container {
         flex-basis: 100%;
         flex-shrink: 0;
-        border-top: 1px solid #ccc;
         padding-top: 15px;
+    }
+    .plugin-container:not(.featured-plugin) + .plugin-container {
+        border-top: 1px solid #ccc;
     }
     h4 {
         margin-top: 0;


### PR DESCRIPTION
This PR does a micro-UI improvement by removing a border-top from the plugin-list.

Before with featured:

![Bildschirmfoto 2024-07-18 um 10 45 55](https://github.com/user-attachments/assets/dc968f2c-2f60-42c3-81c5-a046b5b372f8)

After with featured:

![Bildschirmfoto 2024-07-18 um 10 45 38](https://github.com/user-attachments/assets/fb508190-07e5-46c1-a6dc-801a2cd5e1e0)

Before without featured:

![Bildschirmfoto 2024-07-18 um 10 46 02](https://github.com/user-attachments/assets/fece7a6a-cd13-44d3-9fbd-782d9f1da44c)

After without featured:

![Bildschirmfoto 2024-07-18 um 10 45 30](https://github.com/user-attachments/assets/60ec9338-91f7-46f5-b95c-663f80ed0dc9)