### PR TITLE
Docs: Remove redundant package dependency

### DIFF
--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -65,7 +65,7 @@ Package dependencies
 To build and run pretix, you will need the following debian packages::
 
     # apt-get install git build-essential python3-dev python3-venv python3 python3-pip \
-                      libxml2-dev libxslt1-dev libffi-dev zlib1g-dev libssl-dev \
+                      python3-dev libxml2-dev libxslt1-dev libffi-dev zlib1g-dev libssl-dev \
                       gettext libpq-dev libjpeg-dev libopenjp2-7-dev
 
 Config file

--- a/doc/admin/installation/manual_smallscale.rst
+++ b/doc/admin/installation/manual_smallscale.rst
@@ -65,7 +65,7 @@ Package dependencies
 To build and run pretix, you will need the following debian packages::
 
     # apt-get install git build-essential python3-dev python3-venv python3 python3-pip \
-                      python3-dev libxml2-dev libxslt1-dev libffi-dev zlib1g-dev libssl-dev \
+                      libxml2-dev libxslt1-dev libffi-dev zlib1g-dev libssl-dev \
                       gettext libpq-dev libjpeg-dev libopenjp2-7-dev
 
 Config file

--- a/src/pretix/base/exporter.py
+++ b/src/pretix/base/exporter.py
@@ -256,7 +256,7 @@ class ListExporter(BaseExporter):
         ws = wb.create_sheet()
         self.prepare_xlsx_sheet(ws)
         try:
-            ws.title = str(self.verbose_name)
+            ws.title = str(self.verbose_name)[:30]
         except:
             pass
         total = 0
@@ -374,7 +374,7 @@ class MultiSheetListExporter(ListExporter):
         wb = SafeWorkbook(write_only=True)
         n_sheets = len(self.sheets)
         for i_sheet, (s, l) in enumerate(self.sheets):
-            ws = wb.create_sheet(str(l))
+            ws = wb.create_sheet(str(l)[:30])
             if hasattr(self, 'prepare_xlsx_sheet_' + s):
                 getattr(self, 'prepare_xlsx_sheet_' + s)(ws)
 

--- a/src/pretix/base/exporter.py
+++ b/src/pretix/base/exporter.py
@@ -256,7 +256,7 @@ class ListExporter(BaseExporter):
         ws = wb.create_sheet()
         self.prepare_xlsx_sheet(ws)
         try:
-            ws.title = str(self.verbose_name)[:30]
+            ws.title = str(self.verbose_name)
         except:
             pass
         total = 0
@@ -374,7 +374,7 @@ class MultiSheetListExporter(ListExporter):
         wb = SafeWorkbook(write_only=True)
         n_sheets = len(self.sheets)
         for i_sheet, (s, l) in enumerate(self.sheets):
-            ws = wb.create_sheet(str(l)[:30])
+            ws = wb.create_sheet(str(l))
             if hasattr(self, 'prepare_xlsx_sheet_' + s):
                 getattr(self, 'prepare_xlsx_sheet_' + s)(ws)
 


### PR DESCRIPTION
python3-dev is named twice in the package dependencies. I deleted it in line 68, it remains in line 67.