### PR TITLE
adds an `order_info_top` signal for the control component

### DIFF
--- a/src/pretix/control/signals.py
+++ b/src/pretix/control/signals.py
@@ -255,6 +255,15 @@ As with all plugin signals, the ``sender`` keyword argument will contain the eve
 Additionally, the argument ``order`` and ``request`` are available.
 """
 
+order_info_top = EventPluginSignal()
+"""
+Arguments: ``order``, ``request``
+
+This signal is sent out to display additional information on top of the order detail page ("Order details" section)
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+"""
+
 order_position_buttons = EventPluginSignal()
 """
 Arguments: ``order``, ``position``, ``request``

--- a/src/pretix/control/templates/pretixcontrol/order/index.html
+++ b/src/pretix/control/templates/pretixcontrol/order/index.html
@@ -177,6 +177,7 @@
                 </div>
                 <div class="panel-body">
                     <dl class="dl-horizontal">
+                        {% eventsignal event "pretix.control.signals.order_info_top" order=order request=request %}
                         <dt>{% trans "Order code" %}</dt>
                         <dd>{{ order.code }}</dd>
                         <dt>{% trans "Order date" %}</dt>


### PR DESCRIPTION
I'm working on a plugin to capture additional customer details and display them on the order summary page of the `control` component. The only currently suitable signal is `control.signals.order_info` which allows injection considerable far down the page.

`order_details_top` will permit plugins to insert relevant content to the top-level "Order details" section as needed.

Ideally, I think the Order Details section could be rewritten to move the logic outside of the template and instead have the signal collect a list of dictionaries with property titles and values to display. 

I'm very new to this project, django & python in general, so I don't know if that is advisable or not. I'm willing to take a look at it if that would be worthwhile.