### PR TITLE
Fix auto-linking error-inputs self-referencing (Z#23159088)

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -769,6 +769,9 @@ function setup_basics(el) {
         var $this = $(this);
         var $panel = $this.closest("div.panel-collapse").collapse("show");
         var alert = el.find(".alert-danger").get(0);
+        if (alert === this) {
+            return;
+        }
         var label = "";
         var description = "";
         var scrollTarget = null;


### PR DESCRIPTION
In a special case when setting up a custom email adress, only one warning-box was present – but this box was inside a .panel, which sometime happens to be an error-message to a group of inputs, which needs to be converted to a link as well. This PR fixes the auto-linker when it tries to add an error-message to itself.