### PR TITLE
Fix nup-badges for PDFs with cropbox (Z#23160479)

### DIFF
--- a/src/pretix/plugins/badges/exporters.py
+++ b/src/pretix/plugins/badges/exporters.py
@@ -237,7 +237,7 @@ def _render_nup_page(nup_pdf: PdfWriter, input_pages: PageObject, opt: dict) -> 
             Decimal('%.5f' % (page.mediabox.right.as_numeric() + tx)),
             Decimal('%.5f' % (page.mediabox.top.as_numeric() + ty))
         ))
-        page.trimbox = page.mediabox
+        page.trimbox = page.cropbox = page.mediabox
         nup_page.merge_page(page)
     return nup_page
 


### PR DESCRIPTION
When background-PDFs with a cropbox and a higher PDF-version than our PDF-default of 1.4 are used (which triggers a special stamp operation when using pdftk), then when placing multiple pages on one page (e.g. nup-badges), the cropbox made all pages except the first one disappear. This PR fixes it by setting the cropbox to the trimbox, which is/was set to the mediabox.