### PR TITLE
Prevent race condition in directory creation

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -38,6 +38,7 @@ import logging
 import os
 import sys
 from json import loads
+from pathlib import Path
 from urllib.parse import urlparse
 
 import importlib_metadata as metadata
@@ -70,14 +71,10 @@ MEDIA_ROOT = os.path.join(DATA_DIR, 'media')
 PROFILE_DIR = os.path.join(DATA_DIR, 'profiles')
 CACHE_DIR = config.get('pretix', 'cachedir', fallback=os.path.join(DATA_DIR, 'cache'))
 
-if not os.path.exists(DATA_DIR):
-    os.mkdir(DATA_DIR)
-if not os.path.exists(LOG_DIR):
-    os.mkdir(LOG_DIR)
-if not os.path.exists(MEDIA_ROOT):
-    os.mkdir(MEDIA_ROOT)
-if not os.path.exists(CACHE_DIR):
-    os.mkdir(CACHE_DIR)
+Path(DATA_DIR).mkdir(parents=False, exist_ok=True)
+Path(LOG_DIR).mkdir(parents=False, exist_ok=True)
+Path(MEDIA_ROOT).mkdir(parents=False, exist_ok=True)
+Path(CACHE_DIR).mkdir(parents=False, exist_ok=True)
 
 if config.has_option('django', 'secret'):
     SECRET_KEY = config.get('django', 'secret')


### PR DESCRIPTION
Checking whether a path does not exist before trying to create it does not follow the Python paradigm of asking for forgiveness, rather than permission, and opens up a time-of-check to time-of-use race.

I did in fact hit that race condition while testing the 2024.7.0 release in a NixOS VM test, probably because we have multiple units (web and periodic) coming up in parallel, and they both import the settings.py.

```
[   23.299368] systemd[1]: Starting pretix web service...
[   23.308752] systemd[1]: Started pretix asynchronous job runner.
[   31.135238] pretix-web-pre-start[1046]: Traceback (most recent call last):
[   31.137615] pretix-web-pre-start[1046]:   File "/nix/store/iawyf9d0snhqk47yhpz83w6bgf8kvyf2-pretix-2024.7.0/bin/.pretix-manage-wrapped", line 32, in <module>
[   31.145118] pretix-web-pre-start[1046]:     execute_from_command_line(sys.argv)
[   31.146683] pretix-web-pre-start[1046]:   File "/nix/store/iq2b438xmymbh0mlp23gchp43b4aariy-python3-3.12.4-env/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
[   31.152795] pretix-web-pre-start[1046]:     utility.execute()
[   31.155274] pretix-web-pre-start[1046]:   File "/nix/store/iq2b438xmymbh0mlp23gchp43b4aariy-python3-3.12.4-env/lib/python3.12/site-packages/django/core/management/__init__.py", line 382, in execute
[   31.160274] pretix-web-pre-start[1046]:     settings.INSTALLED_APPS
[   31.162698] pretix-web-pre-start[1046]:   File "/nix/store/iq2b438xmymbh0mlp23gchp43b4aariy-python3-3.12.4-env/lib/python3.12/site-packages/django/conf/__init__.py", line 102, in __getattr__
[   31.166691] pretix-web-pre-start[1046]:     self._setup(name)
[   31.169615] pretix-web-pre-start[1046]:   File "/nix/store/iq2b438xmymbh0mlp23gchp43b4aariy-python3-3.12.4-env/lib/python3.12/site-packages/django/conf/__init__.py", line 89, in _setup
[   31.173855] pretix-web-pre-start[1046]:     self._wrapped = Settings(settings_module)
[   31.176254] pretix-web-pre-start[1046]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^
[   31.179827] pretix-web-pre-start[1046]:   File "/nix/store/iq2b438xmymbh0mlp23gchp43b4aariy-python3-3.12.4-env/lib/python3.12/site-packages/django/conf/__init__.py", line 217, in __init__
[   31.183967] pretix-web-pre-start[1046]:     mod = importlib.import_module(self.SETTINGS_MODULE)
[   31.186555] pretix-web-pre-start[1046]:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   31.190840] pretix-web-pre-start[1046]:   File "/nix/store/l014xp1qxdl6gim3zc0jv3mpxhbp346s-python3-3.12.4/lib/python3.12/importlib/__init__.py", line 90, in import_module
[   31.194723] pretix-web-pre-start[1046]:     return _bootstrap._gcd_import(name[level:], package, level)
[   31.197766] pretix-web-pre-start[1046]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   31.201293] pretix-web-pre-start[1046]:   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
[   31.204928] pretix-web-pre-start[1046]:   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
[   31.208307] pretix-web-pre-start[1046]:   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
[   31.210759] pretix-web-pre-start[1046]:   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
[   31.215095] pretix-web-pre-start[1046]:   File "<frozen importlib._bootstrap_external>", line 995, in exec_module
[   31.217231] pretix-web-pre-start[1046]:   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
[   31.220260] pretix-web-pre-start[1046]:   File "/nix/store/iq2b438xmymbh0mlp23gchp43b4aariy-python3-3.12.4-env/lib/python3.12/site-packages/pretix/settings.py", line 78, in <module>
[   31.223269] pretix-web-pre-start[1046]:     os.mkdir(MEDIA_ROOT)
[   31.225603] pretix-web-pre-start[1046]: FileExistsError: [Errno 17] File exists: '/var/lib/pretix/media'
[   31.480879] systemd[1]: pretix-web.service: Control process exited, code=exited, status=1/FAILURE
[   31.486120] systemd[1]: pretix-web.service: Failed with result 'exit-code'.
[   31.491530] systemd[1]: Failed to start pretix web service.
[   31.496979] systemd[1]: pretix-web.service: Consumed 1.830s CPU time, 33.8M memory peak.
```