### PR TITLE
settings: also enable DEBUG for runserver_plus, not just runserver

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -96,7 +96,7 @@ else:
 
 # Adjustable settings
 
-debug_fallback = "runserver" in sys.argv
+debug_fallback = "runserver" in sys.argv or "runserver_plus" in sys.argv
 DEBUG = config.getboolean('django', 'debug', fallback=debug_fallback)
 LOG_CSP = config.getboolean('pretix', 'csp_log', fallback=False)
 CSP_ADDITIONAL_HEADER = config.get('pretix', 'csp_additional_header', fallback='')


### PR DESCRIPTION
When using runserver_plus from the django-extensions package (for serving a development instance with a TLS certificate), I noticed the DEBUG setting was not set correctly, which resulted in static files not being served correctly.