### PR TITLE
Remove git dir and work tree config from pre-commit hook

### DIFF
--- a/doc/development/setup.rst
+++ b/doc/development/setup.rst
@@ -136,9 +136,7 @@ It is a good idea to put this command into your git hook ``.git/hooks/pre-commit
 for example, to check for any errors in any staged files when committing::
 
     #!/bin/bash
-    cd $GIT_DIR/../src
-    export GIT_WORK_TREE=../
-    export GIT_DIR=../.git
+
     source ../env/bin/activate  # Adjust to however you activate your virtual environment
     for file in $(git diff --cached --name-only | grep -E '\.py$' | grep -Ev "migrations|mt940\.py|pretix/settings\.py|make_testdata\.py|testutils/settings\.py|tests/settings\.py|pretix/base/models/__init__\.py|.*_pb2\.py")
     do


### PR DESCRIPTION
These variables effectively hardcode the location from which the script is run.  We shouldn't need these since git should know it is inside a repo when run.

GIT_DIR isn't set by default, at least for me.  If we still need to get the root path for the repo, we can use `git rev-parse --show-toplevel`.