### PR TITLE
Add device_info_updated signal

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -14,7 +14,7 @@ Core
    :members: periodic_task, event_live_issues, event_copy_data, email_filter, register_notification_types, notification,
       item_copy_data, register_sales_channel_types, register_global_settings, quota_availability, global_email_filter,
       register_ticket_secret_generators, gift_card_transaction_display,
-      register_text_placeholders, register_mail_placeholders
+      register_text_placeholders, register_mail_placeholders, device_info_updated
 
 Order events
 """"""""""""

--- a/src/pretix/api/views/device.py
+++ b/src/pretix/api/views/device.py
@@ -200,6 +200,11 @@ class UpdateView(APIView):
         device.save()
         device.log_action('pretix.device.updated', data=serializer.validated_data, auth=device)
 
+        from ...base.signals import device_info_updated
+        device_info_updated.send(
+            sender=Device, old_device=request.auth, new_device=device
+        )
+
         serializer = DeviceSerializer(device)
         return Response(serializer.data)
 

--- a/src/pretix/base/signals.py
+++ b/src/pretix/base/signals.py
@@ -838,3 +838,12 @@ is given as the first argument.
 
 The ``sender`` keyword argument will contain the organizer.
 """
+
+device_info_updated = django.dispatch.Signal()
+"""
+Arguments: ``old_device``, ``new_device``
+
+This signal is sent out each time the information for a Device is modified.
+Both the original and updated versions of the Device are included to allow
+receivers to see what has been updated.
+"""


### PR DESCRIPTION
This provides both the original and updated version of the Device so subscribers can see the changes.