### PR TITLE
Control: fix initial sidebar display for mobile

### DIFF
--- a/src/pretix/static/pretixcontrol/js/sb-admin-2.js
+++ b/src/pretix/static/pretixcontrol/js/sb-admin-2.js
@@ -8,26 +8,26 @@
 //Loads the correct sidebar on window load,
 //collapses the sidebar on window resize.
 // Sets the min-height of #page-wrapper to window size
+$(window).bind("load resize", function () {
+    'use strict';
+    var topOffset = 50,
+        width = (this.window.innerWidth > 0) ? this.window.innerWidth : this.screen.width;
+    if (width < 768) {
+        $('div.navbar-collapse').addClass('collapse');
+        topOffset = 100; // 2-row-menu
+    } else {
+        $('div.navbar-collapse').removeClass('collapse');
+    }
+
+    var height = ((this.window.innerHeight > 0) ? this.window.innerHeight : this.screen.height) - 1;
+    height = height - topOffset;
+    if (height < 1) height = 1;
+    if (height > topOffset) {
+        $("#page-wrapper").css("min-height", (height) + "px");
+    }
+});
 $(function () {
     'use strict';
-    $(window).bind("load resize", function () {
-        var topOffset = 50,
-            width = (this.window.innerWidth > 0) ? this.window.innerWidth : this.screen.width;
-        if (width < 768) {
-            $('div.navbar-collapse').addClass('collapse');
-            topOffset = 100; // 2-row-menu
-        } else {
-            $('div.navbar-collapse').removeClass('collapse');
-        }
-
-        var height = ((this.window.innerHeight > 0) ? this.window.innerHeight : this.screen.height) - 1;
-        height = height - topOffset;
-        if (height < 1) height = 1;
-        if (height > topOffset) {
-            $("#page-wrapper").css("min-height", (height) + "px");
-        }
-    });
-
     $('ul.nav ul.nav-second-level a.active').parent().parent().addClass('in').parent().addClass('active');
     $('#side-menu').metisMenu({
         'toggle': false,


### PR DESCRIPTION
Originally window.load was bound to inside a jquery-ready call, which sometimes does not work as the window.load event was already fired.

The diff looks a bit weird, but I basically just moved the binding to window.load/resize outside the jquery-ready call.