### PR TITLE
A11y: improve/unify html-source for uncategorized products

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -6,22 +6,16 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for tup in items_by_category %}
-    <section
-        {% if tup.0 %}
-            aria-labelledby="category-{{ tup.0.id }}"
-            {% if tup.0.description %} aria-describedby="category-info-{{ tup.0.id }}"{% endif %}
-        {% else %}
-            aria-labelledby="category-none"
-        {% endif %}
-    >
-        {% if tup.0 %}
+    {% if tup.0 %}
+        <section aria-labelledby="category-{{ tup.0.id }}"{% if tup.0.description %} aria-describedby="category-info-{{ tup.0.id }}"{% endif %}>
             <h3 id="category-{{ tup.0.id }}">{{ tup.0.name }}</h3>
             {% if tup.0.description %}
                 <div id="category-info-{{ tup.0.id }}">{{ tup.0.description|localize|rich_text }}</div>
             {% endif %}
-        {% else %}
+    {% else %}
+        <section aria-labelledby="category-none">
             <h3 id="category-none" class="sr-only">{% trans "Uncategorized items" %}</h3>
-        {% endif %}
+    {% endif %}
         {% for item in tup.1 %}
             {% if item.has_variations %}
                 <article aria-labelledby="item-{{ item.pk }}-legend"{% if item.description %} aria-describedby="item-{{ item.pk }}-description"{% endif %} class="item-with-variations{% if event.settings.show_variations_expanded %} details-open{% endif %}" id="item-{{ item.pk }}">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -6,12 +6,21 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for tup in items_by_category %}
-    <section aria-labelledby="category-{{ tup.0.id|default:0 }}"{% if tup.0.description %} aria-describedby="category-info-{{ tup.0.id }}"{% endif %}>
-        <h3 id="category-{{ tup.0.id|default:0 }}"{% if not tup.0 %} class="sr-only"{% endif %}>
-            {% if tup.0 %}{{ tup.0.name }}{% else %}{% trans "Uncategorized items" %}{% endif %}
-        </h3>
-        {% if tup.0.description %}
-            <div id="category-info-{{ tup.0.id }}">{{ tup.0.description|localize|rich_text }}</div>
+    <section
+        {% if tup.0 %}
+            aria-labelledby="category-{{ tup.0.id }}"
+            {% if tup.0.description %} aria-describedby="category-info-{{ tup.0.id }}"{% endif %}
+        {% else %}
+            aria-labelledby="category-none"
+        {% endif %}
+    >
+        {% if tup.0 %}
+            <h3 id="category-{{ tup.0.id }}">{{ tup.0.name }}</h3>
+            {% if tup.0.description %}
+                <div id="category-info-{{ tup.0.id }}">{{ tup.0.description|localize|rich_text }}</div>
+            {% endif %}
+        {% else %}
+            <h3 id="category-none" class="sr-only">{% trans "Uncategorized items" %}</h3>
         {% endif %}
         {% for item in tup.1 %}
             {% if item.has_variations %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -6,12 +6,12 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for tup in items_by_category %}
-    <section {% if tup.0 %}aria-labelledby="category-{{ tup.0.id }}"{% else %}aria-label="{% trans "Uncategorized items" %}"{% endif %}{% if tup.0.description %} aria-describedby="category-info-{{ tup.0.id }}"{% endif %}>
-        {% if tup.0 %}
-            <h3 id="category-{{ tup.0.id }}">{{ tup.0.name }}</h3>
-            {% if tup.0.description %}
-                <div id="category-info-{{ tup.0.id }}">{{ tup.0.description|localize|rich_text }}</div>
-            {% endif %}
+    <section aria-labelledby="category-{{ tup.0.id|default:0 }}"{% if tup.0.description %} aria-describedby="category-info-{{ tup.0.id }}"{% endif %}>
+        <h3 id="category-{{ tup.0.id|default:0 }}"{% if not tup.0 %} class="sr-only"{% endif %}>
+            {% if tup.0 %}{{ tup.0.name }}{% else %}{% trans "Uncategorized items" %}{% endif %}
+        </h3>
+        {% if tup.0.description %}
+            <div id="category-info-{{ tup.0.id }}">{{ tup.0.description|localize|rich_text }}</div>
         {% endif %}
         {% for item in tup.1 %}
             {% if item.has_variations %}


### PR DESCRIPTION
I stumbled upon a divergent html source when having uncategorized products listed. Especially combined with a waitinglist on seating this could create a valid, but somewhat strange page-structure for a11y. This PR unifies the handling of h3s for grouping products into categories.