### PR TITLE
Seating: visually remove waitinglist headline for soldout seating

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -185,7 +185,7 @@
 
                 {% if waitinglist_seated %}
                     <aside class="front-page" aria-labelledby="waiting-list">
-                        <h3 id="waiting-list">{% trans "Waiting list" %}</h3>
+                        <h3 id="waiting-list" class="sr-only">{% trans "Waiting list" %}</h3>
                         <div class="row">
                             <div class="col-md-8 col-sm-6 col-xs-12">
                                 <p>


### PR DESCRIPTION
to improve UI and make additional non-seated products (especially uncategorized products) look more connected.