### PR TITLE
Render progress info on non-javascript fallback page for celery tasks

### DIFF
--- a/src/pretix/base/views/tasks.py
+++ b/src/pretix/base/views/tasks.py
@@ -140,7 +140,12 @@ class AsyncMixin:
                     return self.success(res.info)
                 else:
                     return self.error(res.info)
-            return render(request, 'pretixpresale/waiting.html')
+            state, info = res.state, res.info
+            return render(request, 'pretixpresale/waiting.html', {
+                'started': state in ('PROGRESS', 'STARTED'),
+                'percentage': info.get('value', 0) if isinstance(info, dict) else 0,
+                'steps': info.get('steps', []) if isinstance(info, dict) else None,
+            })
 
     def success(self, value):
         smes = self.get_success_message(value)

--- a/src/pretix/presale/templates/pretixpresale/waiting.html
+++ b/src/pretix/presale/templates/pretixpresale/waiting.html
@@ -27,12 +27,14 @@
                 </div>
             </div>
             {% if steps %}
-                <p class="steps">
+                <ol class="steps">
                     {% for step in steps %}
-                        <span class="fa fa-fw {% if step.done %}fa-check text-success{% else %}fa-cog fa-spin text-muted{% endif %}"></span>
-                        {{ step.label }}<br>
+                        <li>
+                            <span class="fa fa-fw {% if step.done %}fa-check text-success{% else %}fa-cog fa-spin text-muted{% endif %}"></span>
+                            {{ step.label }}
+                        </li>
                     {% endfor %}
-                </p>
+                </ol>
             {% endif %}
         {% endif %}
 

--- a/src/pretix/presale/templates/pretixpresale/waiting.html
+++ b/src/pretix/presale/templates/pretixpresale/waiting.html
@@ -21,6 +21,21 @@
 
         <h1>{% trans "We are processing your request …" %}</h1>
 
+        {% if percentage %}
+            <div class="progress">
+                <div class="progress-bar progress-bar-success progress-bar-{{ percentage|floatformat:0 }}">
+                </div>
+            </div>
+            {% if steps %}
+                <p class="steps">
+                    {% for step in steps %}
+                        <span class="fa fa-fw {% if step.done %}fa-check text-success{% else %}fa-cog fa-spin text-muted{% endif %}"></span>
+                        {{ step.label }}<br>
+                    {% endfor %}
+                </p>
+            {% endif %}
+        {% endif %}
+
         <p>
             {% trans "If this takes longer than a few minutes, please contact us." %}
         </p>

--- a/src/pretix/static/pretixpresale/scss/waiting.scss
+++ b/src/pretix/static/pretixpresale/scss/waiting.scss
@@ -27,6 +27,8 @@ body {
     max-width: 450px;
     text-align: left;
     margin: 0 auto 20px;
+    list-style-type: none;
+    padding: 0;
 }
 @for $i from 0 through 100 {
     .progress-bar-#{$i} { width: 1% * $i; }

--- a/src/pretix/static/pretixpresale/scss/waiting.scss
+++ b/src/pretix/static/pretixpresale/scss/waiting.scss
@@ -18,3 +18,16 @@ body {
     font-size: 200px;
     color: $brand-primary;
 }
+
+.progress {
+    max-width: 450px;
+    margin: 0 auto 20px;
+}
+.steps {
+    max-width: 450px;
+    text-align: left;
+    margin: 0 auto 20px;
+}
+@for $i from 0 through 100 {
+    .progress-bar-#{$i} { width: 1% * $i; }
+}


### PR DESCRIPTION
Looks like this:
![image](https://github.com/user-attachments/assets/5dee17bd-58ed-4efc-90ae-7999df238f22)
