### PR TITLE
OIDC: Respect token_endpoint_auth_methods_supported (Z#2164777)

### DIFF
--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -46,6 +46,8 @@ This module contains utilities for implementing OpenID Connect for customer auth
 as well as an OpenID Provider (OP).
 """
 
+pretix_token_endpoint_auth_methods = ['client_secret_basic', 'client_secret_post']
+
 
 def _urljoin(base, path):
     if not base.endswith("/"):
@@ -127,6 +129,16 @@ def oidc_validate_and_complete_config(config):
                         fields=", ".join(provider_config.get("claims_supported", []))
                     ))
 
+    if "token_endpoint_auth_methods_supported" in provider_config:
+        token_endpoint_auth_methods_supported = provider_config.get("token_endpoint_auth_methods_supported",
+                                                                    ["client_secret_basic"])
+        if not any(x in pretix_token_endpoint_auth_methods for x in token_endpoint_auth_methods_supported):
+            raise ValidationError(
+                _(f'No supported Token Endpoint Auth Methods supported: {token_endpoint_auth_methods_supported}').format(
+                    token_endpoint_auth_methods_supported=", ".join(token_endpoint_auth_methods_supported)
+                )
+            )
+
     config['provider_config'] = provider_config
     return config
 
@@ -147,15 +159,30 @@ def oidc_authorize_url(provider, state, redirect_uri):
 
 def oidc_validate_authorization(provider, code, redirect_uri):
     endpoint = provider.configuration['provider_config']['token_endpoint']
+
+    # Wall of shame and RFC ignorant IDPs
+    if endpoint == 'https://www.linkedin.com/oauth/v2/accessToken':
+        token_endpoint_auth_method = 'client_secret_post'
+    else:
+        token_endpoint_auth_methods = provider.configuration['provider_config'].get(
+            'token_endpoint_auth_methods_supported', ['client_secret_basic']
+        )
+        token_endpoint_auth_method = [
+            x for x in pretix_token_endpoint_auth_methods if x in token_endpoint_auth_methods
+        ][0]
+
     params = {
         # https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
         # https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
         'grant_type': 'authorization_code',
         'code': code,
         'redirect_uri': redirect_uri,
-        'client_id': provider.configuration['client_id'],
-        'client_secret': provider.configuration['client_secret'],
     }
+
+    if token_endpoint_auth_method == 'client_secret_post':
+        params['client_id'] = provider.configuration['client_id']
+        params['client_secret'] = provider.configuration['client_secret']
+
     try:
         resp = requests.post(
             endpoint,
@@ -163,7 +190,10 @@ def oidc_validate_authorization(provider, code, redirect_uri):
             headers={
                 'Accept': 'application/json',
             },
-            auth=(provider.configuration['client_id'], provider.configuration['client_secret']),
+            auth=(
+                provider.configuration['client_id'],
+                provider.configuration['client_secret']
+            ) if token_endpoint_auth_method == 'client_secret_basic' else None,
         )
         resp.raise_for_status()
         data = resp.json()

--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -153,6 +153,8 @@ def oidc_validate_authorization(provider, code, redirect_uri):
         'grant_type': 'authorization_code',
         'code': code,
         'redirect_uri': redirect_uri,
+        'client_id': provider.configuration['client_id'],
+        'client_secret': provider.configuration['client_secret'],
     }
     try:
         resp = requests.post(


### PR DESCRIPTION
This fixes OIDC-Logins for LinkedIn, which - as outlined [here](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?tabs=HTTPS1#step-3-exchange-authorization-code-for-an-access-token) require the client_id and client_secret to be present in calls to the token endpoint.

Well - that's what LinkedIn is saying - in reality the client_id is not really, really required...

I am torn to just merge this change, as I am not sure how other OIDC-providers will handle this addition. In an ideal world, they would just ignore the extra fields - but will they?