### PR TITLE
Formally deprecate eu_reverse_charge

### DIFF
--- a/doc/api/resources/taxrules.rst
+++ b/doc/api/resources/taxrules.rst
@@ -20,8 +20,9 @@ internal_name                         string                     An optional nam
 rate                                  decimal (string)           Tax rate in percent
 price_includes_tax                    boolean                    If ``true`` (default), tax is assumed to be included in
                                                                  the specified product price
-eu_reverse_charge                     boolean                    If ``true``, EU reverse charge rules are applied. Will
-                                                                 be ignored if custom rules are set.
+eu_reverse_charge                     boolean                    **DEPRECATED**. If ``true``, EU reverse charge rules
+                                                                 are applied. Will be ignored if custom rules are set.
+                                                                 Use custom rules instead.
 home_country                          string                     Merchant country (required for reverse charge), can be
                                                                  ``null`` or empty string
 keep_gross_if_rate_changes            boolean                    If ``true``, changes of the tax rate based on custom

--- a/src/pretix/base/models/tax.py
+++ b/src/pretix/base/models/tax.py
@@ -29,6 +29,8 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.deconstruct import deconstructible
 from django.utils.formats import localize
+from django.utils.functional import lazy
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _, pgettext
 from i18nfield.fields import I18nCharField
 from i18nfield.strings import LazyI18nString
@@ -120,6 +122,8 @@ EU_CURRENCIES = {
 }
 VAT_ID_COUNTRIES = EU_COUNTRIES | {'CH', 'NO'}
 
+format_html_lazy = lazy(format_html, str)
+
 
 def is_eu_country(cc):
     cc = str(cc)
@@ -193,11 +197,17 @@ class TaxRule(LoggedModel):
     eu_reverse_charge = models.BooleanField(
         verbose_name=_("Use EU reverse charge taxation rules"),
         default=False,
-        help_text=_("Not recommended. Most events will NOT be qualified for reverse charge since the place of "
-                    "taxation is the location of the event. This option disables charging VAT for all customers "
-                    "outside the EU and for business customers in different EU countries who entered a valid EU VAT "
-                    "ID. Only enable this option after consulting a tax counsel. No warranty given for correct tax "
-                    "calculation. USE AT YOUR OWN RISK.")
+        help_text=format_html_lazy(
+            '<span class="label label-warning" data-toggle="tooltip" title="{}">{}</span> {}',
+            _('This feature will be removed in the future as it does not handle VAT for non-business customers in '
+              'other EU countries in a way that works for all organizers. Use custom rules instead.'),
+            _('DEPRECATED'),
+            _("Not recommended. Most events will NOT be qualified for reverse charge since the place of "
+              "taxation is the location of the event. This option disables charging VAT for all customers "
+              "outside the EU and for business customers in different EU countries who entered a valid EU VAT "
+              "ID. Only enable this option after consulting a tax counsel. No warranty given for correct tax "
+              "calculation. USE AT YOUR OWN RISK.")
+        ),
     )
     home_country = FastCountryField(
         verbose_name=_('Merchant country'),


### PR DESCRIPTION
I have not been at ease with our eu_reverse_charge flag for a while (see #1837 for first attempt to remove it). For now, I'd like to formally deprecate it.

The reason is that the case of a non-business customer in a different EU country is handled in a way that is only correct for companies with <10k€ in sales of this type. Larger companies need to use the One-Stop-Shop mechanism that requires a more complex setup. We cannot properly take on the responsibility of handling this for clients.