### PR TITLE
Show proper error message in case of add-ons that are required, sold-out and hidden

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -645,6 +645,7 @@ class AddOnsStep(CartMixin, AsyncAction, TemplateFlowStep):
         ctx['forms'] = self.forms
         ctx['cart'] = self.get_cart()
         ctx['cross_selling_data'] = self.cross_selling_data
+        ctx['incomplete'] = not self.is_completed(self.request)
         return ctx
 
     def get_success_message(self, value):
@@ -660,7 +661,7 @@ class AddOnsStep(CartMixin, AsyncAction, TemplateFlowStep):
         self.request = request
         if 'async_id' in request.GET and settings.HAS_CELERY:
             return self.get_result(request)
-        if len(self.forms) == 0 and len(self.cross_selling_data) == 0:
+        if len(self.forms) == 0 and len(self.cross_selling_data) == 0 and self.is_completed(request):
             return redirect(self.get_next_url(request))
         return TemplateFlowStep.get(self, request)
 

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
@@ -11,6 +11,10 @@
         <p>
             {% trans "For some of the products in your cart, you can choose additional options before you continue." %}
         </p>
+    {% elif incomplete %}
+        <div class="alert alert-danger">
+            {% trans "A product in your cart is only sold in combination with add-on products that are no longer available. Please contact the event organizer." %}
+        </div>
     {% endif %}
     <form class="form-horizontal" method="post" data-asynctask
             data-asynctask-headline="{% trans "We're now trying to book these add-ons for you!" %}">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/83dbda3b-7af2-4a1f-9967-7ef0bc58192d)
