### PR TITLE
Fix undefined currency in paypal2

### DIFF
--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -564,7 +564,7 @@ class PaypalMethod(BasePaymentProvider):
             )
             request.session['payment_paypal_payment'] = None
         else:
-            pass
+            return None
 
         try:
             paymentreq = OrdersCreateRequest()


### PR DESCRIPTION
This fixes a bug, where `currency` and `value` can be undefined even if they should not.

Should we add an logger.error as well? Not sure the else-case should ever be expected valid in the first place?