### PR TITLE
CI: Do not fail if codecov upload fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,5 +80,5 @@ jobs:
         with:
           file: src/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
         if: matrix.database == 'postgres' && matrix.python-version == '3.11'


### PR DESCRIPTION
This happens all the time with external PRs until https://github.com/codecov/engineering-team/issues/1574 is solved and is doing more harm than good. We still see if there is no coverage attached.