### PR TITLE
Cross-selling: Use different label if there are no add-on products

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
@@ -16,7 +16,7 @@
             {% trans "A product in your cart is only sold in combination with add-on products that are no longer available. Please contact the event organizer." %}
         </div>
     {% endif %}
-    <form class="form-horizontal" method="post" data-asynctask
+    <div class="form-horizontal" method="post" data-asynctask
             data-asynctask-headline="{% trans "We're now trying to book these add-ons for you!" %}">
         {% csrf_token %}
         <div class="panel-group addons" id="questions_group">
@@ -57,16 +57,28 @@
         </div>
 
         {% if cross_selling_data %}
-            <details class="panel panel-default cross-selling" open>
+            {% if forms %}
+                <details class="panel panel-default cross-selling" open>
+            {% else %}
+                <div class="panel panel-default cross-selling">
+            {% endif %}
                 <summary class="panel-heading">
                     <h3 class="panel-title">
-                        {% trans "More recommendations" %}
+                        {% if forms %}
+                            {% trans "More recommendations" %}
+                        {% else %}
+                            {% trans "Our recommendations" %}
+                        {% endif %}
                     </h3>
                 </summary>
                 <div class="panel-body">
                     {% include "pretixpresale/event/fragment_product_list.html" with items_by_category=cross_selling_data ev=event %}
                 </div>
-            </details>
+            {% if forms %}
+                </details>
+            {% else %}
+                </div>
+            {% endif %}
         {% endif %}
 
         <div class="row checkout-button-row">

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
@@ -16,7 +16,7 @@
             {% trans "A product in your cart is only sold in combination with add-on products that are no longer available. Please contact the event organizer." %}
         </div>
     {% endif %}
-    <div class="form-horizontal" method="post" data-asynctask
+    <form class="form-horizontal" method="post" data-asynctask
             data-asynctask-headline="{% trans "We're now trying to book these add-ons for you!" %}">
         {% csrf_token %}
         <div class="panel-group addons" id="questions_group">

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
@@ -59,18 +59,19 @@
         {% if cross_selling_data %}
             {% if forms %}
                 <details class="panel panel-default cross-selling" open>
+                    <summary class="panel-heading">
+                        <h3 class="panel-title">
+                            {% trans "More recommendations" %}
+                        </h3>
+                    </summary>
             {% else %}
                 <div class="panel panel-default cross-selling">
-            {% endif %}
-                <summary class="panel-heading">
-                    <h3 class="panel-title">
-                        {% if forms %}
-                            {% trans "More recommendations" %}
-                        {% else %}
+                    <div class="panel-heading">
+                        <h3 class="panel-title">
                             {% trans "Our recommendations" %}
-                        {% endif %}
-                    </h3>
-                </summary>
+                        </h3>
+                    </div>
+            {% endif %}
                 <div class="panel-body">
                     {% include "pretixpresale/event/fragment_product_list.html" with items_by_category=cross_selling_data ev=event %}
                 </div>

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
@@ -73,7 +73,7 @@
                     </div>
             {% endif %}
                 <div class="panel-body">
-                    {% include "pretixpresale/event/fragment_product_list.html" with items_by_category=cross_selling_data ev=event %}
+                    {% include "pretixpresale/event/fragment_product_list.html" with items_by_category=cross_selling_data ev=event headline_level=4 %}
                 </div>
             {% if forms %}
                 </details>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -8,7 +8,7 @@
 {% for tup in items_by_category %}{% with category=tup.0 items=tup.1 form_prefix=tup.2 %}
     {% if category %}
         <section aria-labelledby="{{ form_prefix }}category-{{ category.id }}"{% if category.description %} aria-describedby="{{ form_prefix }}category-info-{{ category.id }}"{% endif %}>
-            <h3 id="{{ form_prefix }}category-{{ category.id }}">{{ category.name }}
+            <h{{ headline_level|default:3 }} class="h3" id="{{ form_prefix }}category-{{ category.id }}">{{ category.name }}
                 {% if category.subevent_name %}
                     <small class="text-muted"><i class="fa fa-calendar"></i> {{ category.subevent_name }}</small>
                 {% endif %}
@@ -19,13 +19,13 @@
                         {% trans "Your order qualifies for a discount" %}
                     </small>
                 {% endif %}
-            </h3>
+            </h{{ headline_level|default:3 }}>
             {% if category.description %}
                 <div id="{{ form_prefix }}category-info-{{ category.id }}">{{ category.description|localize|rich_text }}</div>
             {% endif %}
     {% else %}
         <section aria-labelledby="{{ form_prefix }}category-none">
-            <h3 id="{{ form_prefix }}category-none" class="sr-only">{% trans "Uncategorized items" %}</h3>
+            <h{{ headline_level|default:"3" }} id="{{ form_prefix }}category-none" class="h3 sr-only">{% trans "Uncategorized items" %}</h{{ headline_level|default:3 }}>
     {% endif %}
         {% for item in items %}
             {% if item.has_variations %}
@@ -43,7 +43,7 @@
                                 </a>
                             {% endif %}
                             <div class="product-description {% if item.picture %}with-picture{% endif %}">
-                                <h4 id="{{ form_prefix }}item-{{ item.pk }}-legend">{{ item.name }}</h4>
+                                <h{{ headline_level|default:3|add:1 }} class="h4" id="{{ form_prefix }}item-{{ item.pk }}-legend">{{ item.name }}</h{{ headline_level|default:3|add:1 }}>
                                 {% if item.description %}
                                     <div id="{{ form_prefix }}item-{{ item.pk }}-description" class="product-description">
                                         {{ item.description|localize|rich_text }}
@@ -117,7 +117,7 @@
                                 data-price="{% if event.settings.display_net_prices %}{{ var.display_price.net|unlocalize }}{% else %}{{ var.display_price.gross|unlocalize }}{% endif %}"
                             {% endif %}>
                                 <div class="col-md-8 col-sm-6 col-xs-12">
-                                    <h5 id="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-legend">{{ var }}</h5>
+                                    <h{{ headline_level|default:3|add:2 }} class="h5" id="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-legend">{{ var }}</h{{ headline_level|default:3|add:2 }}>
                                     {% if var.description %}
                                         <div id="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-description" class="variation-description">
                                             {{ var.description|localize|rich_text }}
@@ -261,7 +261,7 @@
                             </a>
                         {% endif %}
                         <div class="product-description {% if item.picture %}with-picture{% endif %}">
-                            <h4 id="{{ form_prefix }}item-{{ item.pk }}-legend">{{ item.name }}</h4>
+                            <h{{ headline_level|default:3|add:1 }} class="h4" id="{{ form_prefix }}item-{{ item.pk }}-legend">{{ item.name }}</h{{ headline_level|default:3 }}>
                             {% if item.description %}
                                 <div id="{{ form_prefix }}item-{{ item.pk }}-description" class="product-description">
                                     {{ item.description|localize|rich_text }}

--- a/src/pretix/static/pretixpresale/scss/_checkout.scss
+++ b/src/pretix/static/pretixpresale/scss/_checkout.scss
@@ -102,15 +102,16 @@
     }
   }
 }
-.cross-selling .panel-body h3 {
+.cross-selling .panel-body h3, .cross-selling .panel-body .h3 {
   font-size: 21px;
   line-height: inherit;
   margin-top: 20px;
 }
-.cross-selling .panel-body > *:first-child > h3:first-child {
+.cross-selling .panel-body > *:first-child > h3:first-child,
+.cross-selling .panel-body > *:first-child > .h3:first-child {
   margin-top: 0;
 }
-.cross-selling .panel-body h3 small {
+.cross-selling .panel-body h3 small, .cross-selling .panel-body .h3 small {
   padding-left: 20px;
 }
 

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -53,7 +53,7 @@
     &.variation label {
         font-weight: normal;
     }
-    h4 {
+    h4, .h4 {
         font-size: inherit;
         margin: 0;
         line-height: inherit;
@@ -62,7 +62,7 @@
             font-weight: bold;
         }
     }
-    h5 {
+    h5, .h5 {
         font-size: inherit;
         font-weight: inherit;
         margin: 0;


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/7c70c6ed-78e5-473b-9e46-cb213dccfaf7)

After:

![Screenshot 2024-10-28 at 12-13-22 Step 1 of 5 Add-on products – Checkout Cross-selling test shop](https://github.com/user-attachments/assets/c5d77d29-dbfa-4328-a5fa-0010ca67300c)
