### PR TITLE
Fix testutils redis mock

### DIFF
--- a/src/pretix/testutils/mock.py
+++ b/src/pretix/testutils/mock.py
@@ -40,7 +40,7 @@ def mocker_context():
 
 def get_redis_connection(alias="default", write=True):
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
-    if worker_id.startswith("gw"):
+    if worker_id and worker_id.startswith("gw"):
         redis_port = 1000 + int(worker_id.replace("gw", ""))
     else:
         redis_port = 1000


### PR DESCRIPTION
In my dev setup, `PYTEST_XDIST_WORKER` returns `None`. Not sure this is a config error on my part though.