### PR TITLE
Dev: add support for asyncio_default_fixture_loop_scope in pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dev = [
   "isort==5.13.*",
   "pep8-naming==0.14.*",
   "potypo",
-  "pytest-asyncio",
+  "pytest-asyncio==0.24.*",
   "pytest-cache",
   "pytest-cov",
   "pytest-django==4.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dev = [
   "isort==5.13.*",
   "pep8-naming==0.14.*",
   "potypo",
-  "pytest-asyncio==0.24.*",
+  "pytest-asyncio>=0.24",
   "pytest-cache",
   "pytest-cov",
   "pytest-django==4.*",


### PR DESCRIPTION
asyncio_default_fixture_loop_scope requires at least 0.24