### PR TITLE
Add warning that cross-selling can't prevent unwanted combinations

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/items/category.html
+++ b/src/pretix/control/templates/pretixcontrol/items/category.html
@@ -16,8 +16,18 @@
                         {% bootstrap_field form.internal_name layout="control" %}
                     </div>
                     {% bootstrap_field form.description layout="control" %}
-                    {% bootstrap_field form.category_type layout="control" horizontal_field_class="big-radio-wrapper col-lg-9" %}
-                    {% bootstrap_field form.cross_selling_condition layout="control" horizontal_field_class="col-lg-9" %}
+                    {% bootstrap_field form.category_type layout="control" horizontal_field_class="big-radio-wrapper col-md-9" %}
+                    <div class="row" data-display-dependency="#id_category_type_2">
+                        <div class="col-md-offset-3 col-md-9">
+                            <div class="alert alert-info">
+                                {% blocktrans trimmed %}
+                                Please note that cross-selling categories are only intended as a marketing feature and are not
+                                suitable for ensuring that products are only available in certain combinations.
+                                {% endblocktrans %}
+                            </div>
+                        </div>
+                    </div>
+                    {% bootstrap_field form.cross_selling_condition layout="control" horizontal_field_class="col-md-9" %}
                     {% bootstrap_field form.cross_selling_match_products layout="control" %}
                 </fieldset>
             </div>

--- a/src/pretix/control/templates/pretixcontrol/items/category.html
+++ b/src/pretix/control/templates/pretixcontrol/items/category.html
@@ -21,8 +21,8 @@
                         <div class="col-md-offset-3 col-md-9">
                             <div class="alert alert-info">
                                 {% blocktrans trimmed %}
-                                Please note that cross-selling categories are only intended as a marketing feature and are not
-                                suitable for ensuring that products are only available in certain combinations.
+                                Please note that cross-selling categories are intended as a marketing feature and are not
+                                suitable for strictly ensuring that products are only available in certain combinations.
                                 {% endblocktrans %}
                             </div>
                         </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1fb60b09-5be5-4428-861a-083a5714edf9)

translation(de):
> Bitte beachten Sie, dass Cross-Selling-Kategorien nur als Marketing-Feature gedacht sind, und nicht geeignet sind, um sicherzustellen, dass Produkte nur in bestimmten Kombinationen erhältlich sind.