### PR TITLE
Fix performance issue in filtering checkin list (Z#23170917)

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -1967,7 +1967,7 @@ class CheckinListAttendeeFilterForm(FilterForm):
             if s == '1':
                 qs = qs.filter(last_entry__isnull=False)
             elif s == '2':
-                qs = qs.filter(pk__in=self.list.positions_inside.values_list('pk'))
+                qs = self.list._filter_positions_inside(qs)
             elif s == '3':
                 qs = qs.filter(last_entry__isnull=False).filter(
                     Q(last_exit__isnull=False) & Q(last_exit__gte=F('last_entry'))

--- a/src/tests/control/test_checkins.py
+++ b/src/tests/control/test_checkins.py
@@ -265,7 +265,6 @@ def test_checkins_list_ordering(client, checkin_list_env, order_key, expected):
     ('status=1&item=&user=', ['A1Ticket', 'A3Ticket']),
     ('status=2&item=&user=', ['A1Ticket']),
     ('status=3&item=&user=', ['A3Ticket']),
-    ('status=0&item=&user=', ['A1Mascot', 'A2Ticket']),
     ('status=&item=&user=a3dummy', ['A3Ticket']),  # match order email
     ('status=&item=&user=a3dummy', ['A3Ticket']),  # match order email,
     ('status=&item=&user=a4', ['A3Ticket']),  # match attendee name

--- a/src/tests/control/test_checkins.py
+++ b/src/tests/control/test_checkins.py
@@ -228,6 +228,7 @@ def checkin_list_env():
     # checkin
     Checkin.objects.create(position=op_a1_ticket, datetime=now() + timedelta(minutes=1), list=cl)
     Checkin.objects.create(position=op_a3_ticket, list=cl)
+    Checkin.objects.create(position=op_a3_ticket, list=cl, type="exit")
 
     return event, user, orga, [item_ticket, item_mascot], [order_pending, order_a1, order_a2, order_a3], \
         [op_pending_ticket, op_a1_ticket, op_a1_mascot, op_a2_ticket, op_a3_ticket], cl
@@ -260,7 +261,10 @@ def test_checkins_list_ordering(client, checkin_list_env, order_key, expected):
 @pytest.mark.django_db
 @pytest.mark.parametrize("query, expected", [
     ('status=&item=&user=', ['A1Ticket', 'A1Mascot', 'A2Ticket', 'A3Ticket']),
+    ('status=0&item=&user=', ['A1Mascot', 'A2Ticket']),
     ('status=1&item=&user=', ['A1Ticket', 'A3Ticket']),
+    ('status=2&item=&user=', ['A1Ticket']),
+    ('status=3&item=&user=', ['A3Ticket']),
     ('status=0&item=&user=', ['A1Mascot', 'A2Ticket']),
     ('status=&item=&user=a3dummy', ['A3Ticket']),  # match order email
     ('status=&item=&user=a3dummy', ['A3Ticket']),  # match order email,


### PR DESCRIPTION
On pretix.eu production, we have an event with ~14k tickets where filtering the check-in list for people currently present takes a mindblowing **7 minutes**. Looking at the query plan, PostgreSQL executes the subquery with the window function 14082 times – once for every order position. This is a complete waste of resources, as the subquery is not dependent on the order position it is executed one. This feels like an optimizer bug in PostgreSQL to me.

While looking at the query for hours, I noticed there is a pointless layer of subqueries in there. And luckily, removing this pointless layer seems to resolve the issue. So here's my proposed change.

Query plan excerpt (before):
```
                     ->  Group  (cost=2983.73..2983.75 rows=5 width=8) (actual time=27.584..27.584 rows=0 loops=14082)
                           Group Key: s.position_id
                           ->  Sort  (cost=2983.73..2983.74 rows=5 width=8) (actual time=27.584..27.584 rows=0 loops=14082)
                                 Sort Key: s.position_id
                                 Sort Method: quicksort  Memory: 25kB
                                 ->  Subquery Scan on s  (cost=2959.06..2983.67 rows=5 width=8) (actual time=27.582..27.582 rows=0 loops=14082)
                                       Filter: (((s.type)::text = 'entry'::text) AND (s.cnt_exists_after = 0))
                                       Rows Removed by Filter: 39371
                                       ->  Sort  (cost=2959.06..2962.58 rows=1406 width=37) (actual time=24.716..25.999 rows=39371 loops=14082)
                                             Sort Key: pretixbase_checkin.datetime DESC
                                             Sort Method: quicksort  Memory: 4612kB
                                             ->  WindowAgg  (cost=2850.40..2885.55 rows=1406 width=37) (actual time=10.151..20.386 rows=39371 loops=14082)
                                                   ->  Sort  (cost=2850.40..2853.91 rows=1406 width=29) (actual time=10.149..11.239 rows=39371 loops=14082)
                                                         Sort Key: pretixbase_checkin.position_id, pretixbase_checkin.datetime
                                                         Sort Method: quicksort  Memory: 4305kB
                                                         ->  Index Scan using pretixbase_checkin_list_id_edd48d9f on pretixbase_checkin  (cost=0.44..2776.88 rows=1406 width=29) (actual time=0.005..5.301 rows=39371 loops=14082)
                                                               Index Cond: (list_id = 347131)
                                                               Filter: successful
                                                               Rows Removed by Filter: 1128

```