### PR TITLE
Remove slimit dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dependencies = [
   "requests==2.31.*",
   "sentry-sdk==2.18.*",
   "sepaxml==2.6.*",
-  "slimit",
   "stripe==7.9.*",
   "text-unidecode==1.*",
   "tlds>=2020041600",


### PR DESCRIPTION
It doesn't work anymore on python 3.13, since
2to3 is deprecated and removed (PEP 594).

Trying to build on Fedora 41 result in:

	Downloading slimit-0.8.1.zip (88 kB)
	Installing build dependencies: started
	Installing build dependencies: finished with status 'done'
	Getting requirements to build wheel: started
	Getting requirements to build wheel: finished with status 'error'
	error: subprocess-exited-with-error
	× Getting requirements to build wheel did not run successfully.
	│ exit code: 1
	╰─> [1 lines of output]
	Python 3.X support requires the 2to3 tool.
	[end of output]

And slimit is not used in the code base nor anywhere in git (no single match)