### PR TITLE
Fix creating to many ScheduledMails on subevent creation

### DIFF
--- a/src/pretix/plugins/sendmail/signals.py
+++ b/src/pretix/plugins/sendmail/signals.py
@@ -65,11 +65,10 @@ def scheduled_mail_create(sender, **kwargs):
     with scope(organizer=event.organizer):
         existing_rules = ScheduledMail.objects.filter(subevent=subevent).values_list('rule_id', flat=True)
         to_create = []
-        for rule in event.sendmail_rules.all():
-            if rule.pk not in existing_rules and subevent:
-                sm = ScheduledMail(rule=rule, event=event, subevent=subevent)
-                sm.recompute()
-                to_create.append(sm)
+        for rule in event.sendmail_rules.filter(subevent=None).exclude(id__in=existing_rules):
+            sm = ScheduledMail(rule=rule, event=event, subevent=subevent)
+            sm.recompute()
+            to_create.append(sm)
         ScheduledMail.objects.bulk_create(to_create)
 
 


### PR DESCRIPTION
When havin a event series with a ScheduledMail-rule, that is bound to a single subevent, when creating a new subevent, the subevent filter for that rule was ignored and a ScheduledMail was created for the newly created subevent.

This PR basically adds a `.filter(subevent=None)` when looping over `event.sendmail_rules`. It furthermore adds some minor optimizations such as checking for subevent in the for-loop (subevent will always be set as the signal will only be run on subevent-creation) and filtering for existing_rules on db-level, not in the for-loop.