### PR TITLE
Update address field logic (Z#23163120)

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -78,7 +78,7 @@ from pretix.base.i18n import (
     get_babel_locale, get_language_without_region, language,
 )
 from pretix.base.models import InvoiceAddress, Item, Question, QuestionOption
-from pretix.base.models.tax import VAT_ID_COUNTRIES, ask_for_vat_id
+from pretix.base.models.tax import ask_for_vat_id
 from pretix.base.services.tax import (
     VATIDFinalError, VATIDTemporaryError, validate_vat_id,
 )

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -951,7 +951,7 @@ class BaseQuestionsForm(forms.Form):
         if self.address_validation:
             self.cleaned_data = d = validate_address(d, all_optional=not self.attendee_addresses_required)
 
-        if d.get('city') and d.get('country') and str(d['country']) in COUNTRIES_WITH_STATE_IN_ADDRESS:
+        if d.get('street') and d.get('country') and str(d['country']) in COUNTRIES_WITH_STATE_IN_ADDRESS:
             if not d.get('state'):
                 self.add_error('state', _('This field is required.'))
 

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -54,6 +54,7 @@ from django.core.validators import (
 from django.db.models import QuerySet
 from django.forms import Select, widgets
 from django.forms.widgets import FILE_INPUT_CONTRADICTION
+from django.urls import reverse
 from django.utils.formats import date_format
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
@@ -712,6 +713,7 @@ class BaseQuestionsForm(forms.Form):
                 initial=country,
                 widget=forms.Select(attrs={
                     'autocomplete': 'country',
+                    'data-country-information-url': reverse('js_helpers.states'),
                 }),
             )
             c = [('', pgettext_lazy('address', 'Select state'))]
@@ -1005,7 +1007,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
             'street': forms.Textarea(attrs={
                 'rows': 2,
                 'placeholder': _('Street and Number'),
-                'autocomplete': 'street-address'
+                'autocomplete': 'street-address',
             }),
             'beneficiary': forms.Textarea(attrs={'rows': 3}),
             'country': forms.Select(attrs={
@@ -1021,7 +1023,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
                 'data-display-dependency': '#id_is_business_1',
                 'autocomplete': 'organization',
             }),
-            'vat_id': forms.TextInput(attrs={'data-display-dependency': '#id_is_business_1', 'data-countries-with-vat-id': ','.join(VAT_ID_COUNTRIES)}),
+            'vat_id': forms.TextInput(attrs={'data-display-dependency': '#id_is_business_1'}),
             'internal_reference': forms.TextInput,
         }
         labels = {
@@ -1055,6 +1057,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
             ])
 
         self.fields['country'].choices = CachedCountries()
+        self.fields['country'].widget.attrs['data-country-information-url'] = reverse('js_helpers.states')
 
         c = [('', pgettext_lazy('address', 'Select state'))]
         fprefix = self.prefix + '-' if self.prefix else ''
@@ -1082,6 +1085,10 @@ class BaseInvoiceAddressForm(forms.ModelForm):
             }),
         )
         self.fields['state'].widget.is_required = True
+
+        self.fields['street'].required = False
+        self.fields['zipcode'].required = False
+        self.fields['city'].required = False
 
         # Without JavaScript the VAT ID field is not hidden, so we empty the field if a country outside the EU is selected.
         if cc and not ask_for_vat_id(cc) and fprefix + 'vat_id' in self.data:

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -1150,7 +1150,7 @@ class BaseInvoiceAddressForm(forms.ModelForm):
             data['vat_id'] = ''
         if self.event.settings.invoice_address_required:
             if data.get('is_business') and not data.get('company'):
-                raise ValidationError(_('You need to provide a company name.'))
+                raise ValidationError({"company": _('You need to provide a company name.')})
             if not data.get('is_business') and not data.get('name_parts'):
                 raise ValidationError(_('You need to provide your name.'))
 

--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -1153,6 +1153,8 @@ class BaseInvoiceAddressForm(forms.ModelForm):
                 raise ValidationError({"company": _('You need to provide a company name.')})
             if not data.get('is_business') and not data.get('name_parts'):
                 raise ValidationError(_('You need to provide your name.'))
+            if not data.get('street') and not data.get('zipcode') and not data.get('city'):
+                raise ValidationError({"street": _('This field is required.')})
 
         if 'vat_id' in self.changed_data or not data.get('vat_id'):
             self.instance.vat_id_validated = False

--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -3204,9 +3204,9 @@ class InvoiceAddress(models.Model):
     company = models.CharField(max_length=255, blank=True, verbose_name=_('Company name'))
     name_cached = models.CharField(max_length=255, verbose_name=_('Full name'), blank=True)
     name_parts = models.JSONField(default=dict)
-    street = models.TextField(verbose_name=_('Address'), blank=False)
-    zipcode = models.CharField(max_length=30, verbose_name=_('ZIP code'), blank=False)
-    city = models.CharField(max_length=255, verbose_name=_('City'), blank=False)
+    street = models.TextField(verbose_name=_('Address'), blank=True)
+    zipcode = models.CharField(max_length=30, verbose_name=_('ZIP code'), blank=True)
+    city = models.CharField(max_length=255, verbose_name=_('City'), blank=True)
     country_old = models.CharField(max_length=255, verbose_name=_('Country'), blank=False)
     country = FastCountryField(verbose_name=_('Country'), blank=False, blank_label=_('Select country'),
                                countries=CachedCountries)

--- a/src/pretix/base/views/js_helpers.py
+++ b/src/pretix/base/views/js_helpers.py
@@ -22,7 +22,9 @@
 import pycountry
 from django.http import JsonResponse
 
-from pretix.base.addressvalidation import COUNTRIES_WITH_STREET_ZIPCODE_AND_CITY_REQUIRED
+from pretix.base.addressvalidation import (
+    COUNTRIES_WITH_STREET_ZIPCODE_AND_CITY_REQUIRED,
+)
 from pretix.base.models.tax import VAT_ID_COUNTRIES
 from pretix.base.settings import COUNTRIES_WITH_STATE_IN_ADDRESS
 
@@ -37,7 +39,7 @@ def states(request):
         'vat_id': {'visible': cc in VAT_ID_COUNTRIES, 'required': False},
     }
     if cc not in COUNTRIES_WITH_STATE_IN_ADDRESS:
-        return JsonResponse({'data': [], **info,})
+        return JsonResponse({'data': [], **info, })
     types, form = COUNTRIES_WITH_STATE_IN_ADDRESS[cc]
     statelist = [s for s in pycountry.subdivisions.get(country_code=cc) if s.type in types]
     return JsonResponse({

--- a/src/pretix/base/views/js_helpers.py
+++ b/src/pretix/base/views/js_helpers.py
@@ -30,7 +30,7 @@ from pretix.base.settings import COUNTRIES_WITH_STATE_IN_ADDRESS
 def states(request):
     cc = request.GET.get("country", "DE")
     info = {
-        'street': {'required': cc in COUNTRIES_WITH_STREET_ZIPCODE_AND_CITY_REQUIRED},
+        'street': {'required': True},
         'zipcode': {'required': cc in COUNTRIES_WITH_STREET_ZIPCODE_AND_CITY_REQUIRED},
         'city': {'required': cc in COUNTRIES_WITH_STREET_ZIPCODE_AND_CITY_REQUIRED},
         'state': {'visible': cc in COUNTRIES_WITH_STATE_IN_ADDRESS, 'required': cc in COUNTRIES_WITH_STATE_IN_ADDRESS},

--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -61,6 +61,7 @@
             <script type="text/javascript" src="{% static "fileupload/jquery.fileupload.js" %}"></script>
             <script type="text/javascript" src="{% static "lightbox/js/lightbox.js" %}"></script>
             <script type="text/javascript" src="{% static "are-you-sure/jquery.are-you-sure.js" %}"></script>
+            <script type="text/javascript" src="{% static "pretixbase/js/addressform.js" %}"></script>
 		{% endcompress %}
         {{ html_head|safe }}
 

--- a/src/pretix/control/templates/pretixcontrol/order/change_questions.html
+++ b/src/pretix/control/templates/pretixcontrol/order/change_questions.html
@@ -46,11 +46,13 @@
                     <div id="cp{{ pos.id }}">
                         <div class="panel-body">
                             {% for form in forms %}
-                                {% if form.pos.item != pos.item %}
-                                    {# Add-Ons #}
-                                    <legend>+ {{ form.pos.item }}</legend>
-                                {% endif %}
-                                {% bootstrap_form form layout="control" %}
+                                <div class="profile-scope">
+                                    {% if form.pos.item != pos.item %}
+                                        {# Add-Ons #}
+                                        <legend>+ {{ form.pos.item }}</legend>
+                                    {% endif %}
+                                    {% bootstrap_form form layout="control" %}
+                                </div>
                             {% endfor %}
                         </div>
                     </div>

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1076,8 +1076,8 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                     if warn:
                         messages.warning(request, _('Please fill in answers to all required questions.'))
                     return False
-                if cp.item.ask_attendee_data and self.request.event.settings.get('attendee_attendees_required', as_type=bool) \
-                        and (cp.street is None or cp.city is None or cp.country is None):
+                if cp.item.ask_attendee_data and self.request.event.settings.get('attendee_addresses_required', as_type=bool) \
+                        and (cp.street is None and cp.city is None and cp.country is None):
                     if warn:
                         messages.warning(request, _('Please fill in answers to all required questions.'))
                     return False

--- a/src/pretix/presale/templates/pretixpresale/fragment_js.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_js.html
@@ -20,4 +20,5 @@
     <script type="text/javascript" src="{% static "pretixpresale/js/ui/cart.js" %}"></script>
     <script type="text/javascript" src="{% static "lightbox/js/lightbox.js" %}"></script>
     <script type="text/javascript" src="{% static "pretixpresale/js/ui/iframe.js" %}"></script>
+    <script type="text/javascript" src="{% static "pretixbase/js/addressform.js" %}"></script>
 {% endcompress %}

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -24,6 +24,7 @@ $(function () {
                         return;  // Lost race
                     }
                     var selected_value = dependents.state.prop("data-selected-value");
+                    if (selected_value) dependents.state.prop("data-selected-value", "");
                     dependents.state.find("option").filter(function (t) {return !!$(this).attr("value")}).remove();
                     if (data.data.length > 0) {
                         $.each(data.data, function (k, s) {
@@ -35,7 +36,7 @@ $(function () {
                         });
                     }
                     for(var k in dependents) {
-                        const options = data[k], dependent = dependents[k]; console.log(options, dependent)
+                        const options = data[k], dependent = dependents[k];
                         if ('visible' in options) {
                             if (options.visible) {
                                 dependent.closest(".form-group").show().toggleClass('required', isRequired);
@@ -54,6 +55,7 @@ $(function () {
                     dependency.closest(".form-group").find("label .fa-spin").remove();
                 });
             };
+        dependents.state.prop("data-selected-value", dependents.state.val());
         update();
         dependency.on("change", update);
     });

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -1,0 +1,44 @@
+$(function () {
+    "use strict";
+
+    $("select[name$=state]:not([data-static])").each(function () {
+        var dependent = $(this),
+            counter = 0,
+            dependency = $(this).closest(".panel-body, form").find('select[name$=country]'),
+            update = function (ev) {
+                counter++;
+                var curCounter = counter;
+                dependent.prop("disabled", true);
+                dependency.closest(".form-group").find("label").prepend("<span class='fa fa-cog fa-spin'></span> ");
+                $.getJSON('/js_helpers/states/?country=' + dependency.val(), function (data) {
+                    if (counter > curCounter) {
+                        return;  // Lost race
+                    }
+                    var selected_value = dependent.prop("data-selected-value");
+                    dependent.find("option").filter(function (t) {return !!$(this).attr("value")}).remove();
+                    if (data.data.length > 0) {
+                        $.each(data.data, function (k, s) {
+                            var o = $("<option>").attr("value", s.code).text(s.name);
+                            if (s.code == selected_value || (selected_value && selected_value.indexOf && selected_value.indexOf(s.code) > -1)) {
+                                o.prop("selected", true);
+                            }
+                            dependent.append(o);
+                        });
+                        dependent.closest(".form-group").show();
+                        dependent.prop('required', dependency.prop("required"));
+                    } else {
+                        dependent.closest(".form-group").hide();
+                        dependent.prop("required", false);
+                    }
+                    dependent.prop("disabled", false);
+                    dependency.closest(".form-group").find("label .fa-spin").remove();
+                });
+            };
+        if (dependent.find("option").length === 1) {
+            dependent.closest(".form-group").hide();
+        } else {
+            dependent.prop('required', dependency.prop("required"));
+        }
+        dependency.on("change", update);
+    });
+});

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -5,6 +5,7 @@ $(function () {
         var dependent = $(this),
             counter = 0,
             dependency = $(this).closest(".panel-body, form").find('select[name$=country]'),
+            depRequired = dependency.closest(".form-group").is(".required"),
             update = function (ev) {
                 counter++;
                 var curCounter = counter;
@@ -24,8 +25,8 @@ $(function () {
                             }
                             dependent.append(o);
                         });
-                        dependent.closest(".form-group").show();
-                        dependent.prop('required', dependency.prop("required"));
+                        dependent.closest(".form-group").show().toggleClass('required', depRequired);
+                        dependent.prop('required', depRequired);
                     } else {
                         dependent.closest(".form-group").hide();
                         dependent.prop("required", false);
@@ -37,7 +38,8 @@ $(function () {
         if (dependent.find("option").length === 1) {
             dependent.closest(".form-group").hide();
         } else {
-            dependent.prop('required', dependency.prop("required"));
+            dependent.closest(".form-group").toggleClass('required', depRequired);
+            dependent.prop('required', depRequired);
         }
         dependency.on("change", update);
     });

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -1,65 +1,61 @@
 $(function () {
     "use strict";
 
-    $("select[name$=state]:not([data-static])").each(function () {
-        var dependent = $(this),
-            counter = 0,
-            dependency = $(this).closest(".panel-body, form").find('select[name$=country]'),
-            depRequired = dependency.closest(".form-group").is(".required"),
+    $("select[data-country-information-url]").each(function () {
+        let counter = 0;
+        const dependency = $(this),
+            url = this.getAttribute('data-country-information-url'),
+            form = $(this).closest(".panel-body, form"),
+            isRequired = dependency.closest(".form-group").is(".required"),
+            dependents =  {
+                'city': form.find("input[name$=city]"),
+                'zipcode': form.find("input[name$=zipcode]"),
+                'street': form.find("textarea[name$=street]"),
+                'state': form.find("select[name$=state]"),
+                'vat_id': form.find("input[name$=vat_id]"),
+            },
             update = function (ev) {
                 counter++;
-                var curCounter = counter;
-                dependent.prop("disabled", true);
+                const curCounter = counter;
+                for (var k in dependents) dependents[k].prop("disabled", true);
                 dependency.closest(".form-group").find("label").prepend("<span class='fa fa-cog fa-spin'></span> ");
-                $.getJSON('/js_helpers/states/?country=' + dependency.val(), function (data) {
+                $.getJSON(url + '?country=' + dependency.val(), function (data) {
                     if (counter > curCounter) {
                         return;  // Lost race
                     }
-                    var selected_value = dependent.prop("data-selected-value");
-                    dependent.find("option").filter(function (t) {return !!$(this).attr("value")}).remove();
+                    var selected_value = dependents.state.prop("data-selected-value");
+                    dependents.state.find("option").filter(function (t) {return !!$(this).attr("value")}).remove();
                     if (data.data.length > 0) {
                         $.each(data.data, function (k, s) {
                             var o = $("<option>").attr("value", s.code).text(s.name);
                             if (s.code == selected_value || (selected_value && selected_value.indexOf && selected_value.indexOf(s.code) > -1)) {
                                 o.prop("selected", true);
                             }
-                            dependent.append(o);
+                            dependents.state.append(o);
                         });
-                        dependent.closest(".form-group").show().toggleClass('required', depRequired);
-                        dependent.prop('required', depRequired);
-                    } else {
-                        dependent.closest(".form-group").hide();
-                        dependent.prop("required", false);
                     }
-                    dependent.prop("disabled", false);
+                    for(var k in dependents) {
+                        const options = data[k], dependent = dependents[k]; console.log(options, dependent)
+                        if ('visible' in options) {
+                            if (options.visible) {
+                                dependent.closest(".form-group").show().toggleClass('required', isRequired);
+                                dependent.prop('required', isRequired);
+                            } else {
+                                dependent.closest(".form-group").hide();
+                                dependent.prop("required", false);
+                            }
+                        }
+                        if ('required' in options) {
+                            dependent.closest(".form-group").toggleClass('required', options.required && isRequired);
+                            dependent.prop('required', options.required && isRequired);
+                        }
+                    }
+                    for (var k in dependents) dependents[k].prop("disabled", false);
                     dependency.closest(".form-group").find("label .fa-spin").remove();
                 });
             };
-        if (dependent.find("option").length === 1) {
-            dependent.closest(".form-group").hide();
-        } else {
-            dependent.closest(".form-group").toggleClass('required', depRequired);
-            dependent.prop('required', depRequired);
-        }
-        dependency.on("change", update);
-    });
-
-    $("input[name$=vat_id][data-countries-with-vat-id]").each(function () {
-        var dependent = $(this),
-            dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
-            dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),
-            update = function (ev) {
-                if (dependency_id_is_business_1.length && !dependency_id_is_business_1.prop("checked")) {
-                    dependent.closest(".form-group").hide();
-                } else if (dependent.attr('data-countries-with-vat-id').split(',').includes(dependency_country.val())) {
-                    dependent.closest(".form-group").show();
-                } else {
-                    dependent.closest(".form-group").hide();
-                }
-            };
         update();
-        dependency_country.on("change", update);
-        dependency_id_is_business_1.on("change", update);
+        dependency.on("change", update);
     });
 
 });

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -28,9 +28,7 @@ $(function () {
                     if (data.data.length > 0) {
                         $.each(data.data, function (k, s) {
                             var o = $("<option>").attr("value", s.code).text(s.name);
-                            if (s.code == selected_value || (selected_value && selected_value.indexOf && selected_value.indexOf(s.code) > -1)) {
-                                o.prop("selected", true);
-                            }
+                            if (selected_value == s.code) o.prop("selected", true);
                             dependents.state.append(o);
                         });
                     }

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -43,4 +43,23 @@ $(function () {
         }
         dependency.on("change", update);
     });
+
+    $("input[name$=vat_id][data-countries-with-vat-id]").each(function () {
+        var dependent = $(this),
+            dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
+            dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),
+            update = function (ev) {
+                if (dependency_id_is_business_1.length && !dependency_id_is_business_1.prop("checked")) {
+                    dependent.closest(".form-group").hide();
+                } else if (dependent.attr('data-countries-with-vat-id').split(',').includes(dependency_country.val())) {
+                    dependent.closest(".form-group").show();
+                } else {
+                    dependent.closest(".form-group").hide();
+                }
+            };
+        update();
+        dependency_country.on("change", update);
+        dependency_id_is_business_1.on("change", update);
+    });
+
 });

--- a/src/pretix/static/pretixbase/js/addressform.js
+++ b/src/pretix/static/pretixbase/js/addressform.js
@@ -5,7 +5,7 @@ $(function () {
         let counter = 0;
         const dependency = $(this),
             url = this.getAttribute('data-country-information-url'),
-            form = $(this).closest(".panel-body, form"),
+            form = $(this).closest(".panel-body, form, .profile-scope"),
             isRequired = dependency.closest(".form-group").is(".required"),
             dependents =  {
                 'city': form.find("input[name$=city]"),

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -434,24 +434,6 @@ var form_handlers = function (el) {
         dependency.closest('.form-group').find('input[name=' + dependency.attr("name") + ']').on("dp.change", update);
     });
 
-    $("input[name$=vat_id][data-countries-with-vat-id]").each(function () {
-        var dependent = $(this),
-            dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
-            dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),
-            update = function (ev) {
-                if (dependency_id_is_business_1.length && !dependency_id_is_business_1.prop("checked")) {
-                    dependent.closest(".form-group").hide();
-                } else if (dependent.attr('data-countries-with-vat-id').split(',').includes(dependency_country.val())) {
-                    dependent.closest(".form-group").show();
-                } else {
-                    dependent.closest(".form-group").hide();
-                }
-            };
-        update();
-        dependency_country.on("change", update);
-        dependency_id_is_business_1.on("change", update);
-    });
-
     el.find("div.scrolling-choice:not(.no-search)").each(function () {
         if ($(this).find("input[type=text]").length > 0) {
             return;

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -452,42 +452,6 @@ var form_handlers = function (el) {
         dependency_id_is_business_1.on("change", update);
     });
 
-    $("select[name$=state]:not([data-static])").each(function () {
-        var dependent = $(this),
-            counter = 0,
-            dependency = $(this).closest(".panel-body, form").find('select[name$=country]'),
-            update = function (ev) {
-                counter++;
-                var curCounter = counter;
-                dependent.prop("disabled", true);
-                dependency.closest(".form-group").find("label").prepend("<span class='fa fa-cog fa-spin'></span> ");
-                $.getJSON('/js_helpers/states/?country=' + dependency.val(), function (data) {
-                    if (counter > curCounter) {
-                        return;  // Lost race
-                    }
-                    dependent.find("option").filter(function (t) {return !!$(this).attr("value")}).remove();
-                    if (data.data.length > 0) {
-                        $.each(data.data, function (k, s) {
-                            dependent.append($("<option>").attr("value", s.code).text(s.name));
-                        });
-                        dependent.closest(".form-group").show();
-                        dependent.prop('required', dependency.prop("required"));
-                    } else {
-                        dependent.closest(".form-group").hide();
-                        dependent.prop("required", false);
-                    }
-                    dependent.prop("disabled", false);
-                    dependency.closest(".form-group").find("label .fa-spin").remove();
-                });
-            };
-        if (dependent.find("option").length === 1) {
-            dependent.closest(".form-group").hide();
-        } else {
-            dependent.prop('required', dependency.prop("required"));
-        }
-        dependency.on("change", update);
-    });
-
     el.find("div.scrolling-choice:not(.no-search)").each(function () {
         if ($(this).find("input[type=text]").length > 0) {
             return;

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -535,47 +535,6 @@ $(function () {
         dependency_id_is_business_1.on("change", update);
     });
 
-    $("select[name$=state]").each(function () {
-        var dependent = $(this),
-            counter = 0,
-            dependency = $(this).closest(".panel-body, form").find('select[name$=country]'),
-            update = function (ev) {
-                counter++;
-                var curCounter = counter;
-                dependent.prop("disabled", true);
-                dependency.closest(".form-group").find("label").prepend("<span class='fa fa-cog fa-spin'></span> ");
-                $.getJSON('/js_helpers/states/?country=' + dependency.val(), function (data) {
-                    if (counter > curCounter) {
-                        return;  // Lost race
-                    }
-                    var selected_value = dependent.prop("data-selected-value");
-                    dependent.find("option").filter(function (t) {return !!$(this).attr("value")}).remove();
-                    if (data.data.length > 0) {
-                        $.each(data.data, function (k, s) {
-                            var o = $("<option>").attr("value", s.code).text(s.name);
-                            if (s.code == selected_value || (selected_value && selected_value.indexOf && selected_value.indexOf(s.code) > -1)) {
-                                o.prop("selected", true);
-                            }
-                            dependent.append(o);
-                        });
-                        dependent.closest(".form-group").show();
-                        dependent.prop('required', dependency.prop("required"));
-                    } else {
-                        dependent.closest(".form-group").hide();
-                        dependent.prop("required", false);
-                    }
-                    dependent.prop("disabled", false);
-                    dependency.closest(".form-group").find("label .fa-spin").remove();
-                });
-            };
-        if (dependent.find("option").length === 1) {
-            dependent.closest(".form-group").hide();
-        } else {
-            dependent.prop('required', dependency.prop("required"));
-        }
-        dependency.on("change", update);
-    });
-
     form_handlers($("body"));
 
     var local_tz = moment.tz.guess()

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -517,24 +517,6 @@ $(function () {
         dependency.closest('.form-group, form').find('input[name=' + dependency.attr("name") + ']').on("dp.change", update);
     });
 
-    $("input[name$=vat_id][data-countries-with-vat-id]").each(function () {
-        var dependent = $(this),
-            dependency_country = $(this).closest(".panel-body, form").find('select[name$=country]'),
-            dependency_id_is_business_1 = $(this).closest(".panel-body, form").find('input[id$=id_is_business_1]'),
-            update = function (ev) {
-                if (dependency_id_is_business_1.length && !dependency_id_is_business_1.prop("checked")) {
-                    dependent.closest(".form-group").hide();
-                } else if (dependent.attr('data-countries-with-vat-id').split(',').includes(dependency_country.val())) {
-                    dependent.closest(".form-group").show();
-                } else {
-                    dependent.closest(".form-group").hide();
-                }
-            };
-        update();
-        dependency_country.on("change", update);
-        dependency_id_is_business_1.on("change", update);
-    });
-
     form_handlers($("body"));
 
     var local_tz = moment.tz.guess()

--- a/src/tests/presale/test_checkout.py
+++ b/src/tests/presale/test_checkout.py
@@ -1207,6 +1207,67 @@ class CheckoutTestCase(BaseCheckoutTestCase, TimemachineTestMixin, TestCase):
         }
         assert ia.name_cached == 'Mr John Kennedy'
 
+    def test_invoice_address_required_no_zipcode_country(self):
+        self.event.settings.invoice_address_asked = True
+        self.event.settings.invoice_address_required = True
+        self.event.settings.invoice_address_not_asked_free = True
+        self.event.settings.set('name_scheme', 'title_given_middle_family')
+
+        with scopes_disabled():
+            CartPosition.objects.create(
+                event=self.event, cart_id=self.session_key, item=self.ticket,
+                price=23, expires=now() + timedelta(minutes=10)
+            )
+        response = self.client.get('/%s/%s/checkout/questions/' % (self.orga.slug, self.event.slug), follow=True)
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        self.assertEqual(len(doc.select('input[name="city"]')), 1)
+
+        # Not all required fields filled out, expect failure
+        response = self.client.post('/%s/%s/checkout/questions/' % (self.orga.slug, self.event.slug), {
+            'is_business': 'business',
+            'company': 'Foo',
+            'name_parts_0': 'Mr',
+            'name_parts_1': 'John',
+            'name_parts_2': '',
+            'name_parts_3': 'Kennedy',
+            'street': '',
+            'zipcode': '',
+            'city': 'Bar',
+            'country': 'BI',
+            'vat_id': 'DE123456',
+            'email': 'admin@localhost'
+        }, follow=True)
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        self.assertGreaterEqual(len(doc.select('.has-error')), 1)
+
+        # Correct request for a country where zip code is not required in address
+        response = self.client.post('/%s/%s/checkout/questions/' % (self.orga.slug, self.event.slug), {
+            'is_business': 'business',
+            'company': 'Foo',
+            'name_parts_0': 'Mr',
+            'name_parts_1': 'John',
+            'name_parts_2': '',
+            'name_parts_3': 'Kennedy',
+            'street': 'Baz',
+            'zipcode': '',
+            'city': 'Bar',
+            'country': 'DE',
+            'vat_id': 'DE123456',
+            'email': 'admin@localhost'
+        }, follow=True)
+        self.assertRedirects(response, '/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug),
+                             target_status_code=200)
+        with scopes_disabled():
+            ia = InvoiceAddress.objects.last()
+        assert ia.name_parts == {
+            'title': 'Mr',
+            'given_name': 'John',
+            'middle_name': '',
+            'family_name': 'Kennedy',
+            "_scheme": "title_given_middle_family"
+        }
+        assert ia.name_cached == 'Mr John Kennedy'
+
     def test_invoice_address_validated(self):
         self.event.settings.invoice_address_asked = True
         self.event.settings.invoice_address_required = True

--- a/src/tests/presale/test_checkout.py
+++ b/src/tests/presale/test_checkout.py
@@ -1232,9 +1232,8 @@ class CheckoutTestCase(BaseCheckoutTestCase, TimemachineTestMixin, TestCase):
             'name_parts_3': 'Kennedy',
             'street': '',
             'zipcode': '',
-            'city': 'Bar',
+            'city': '',
             'country': 'BI',
-            'vat_id': 'DE123456',
             'email': 'admin@localhost'
         }, follow=True)
         doc = BeautifulSoup(response.content.decode(), "lxml")
@@ -1248,11 +1247,10 @@ class CheckoutTestCase(BaseCheckoutTestCase, TimemachineTestMixin, TestCase):
             'name_parts_1': 'John',
             'name_parts_2': '',
             'name_parts_3': 'Kennedy',
-            'street': 'Baz',
+            'street': 'BP 12345',
             'zipcode': '',
-            'city': 'Bar',
-            'country': 'DE',
-            'vat_id': 'DE123456',
+            'city': 'Bujumbura',
+            'country': 'BI',
             'email': 'admin@localhost'
         }, follow=True)
         self.assertRedirects(response, '/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug),


### PR DESCRIPTION
This PR consolidates the front-end (javascript) code to show/hide and mark as required/optional certain address components depending on the selected country. Information on the required fields is loaded on demand. It's loaded in the same request as the list of (federal) states of a country, so no additional request is required.

Example response for Germany:
![image](https://github.com/user-attachments/assets/aaf014a1-f182-49c0-a0a0-149bc5220ac6)

this resolves the following problems:
- the state select box was always marked as optional, even if it was required because the whole address was required and a country with "state in address" was selected - this is now handled correctly
- even for countries where we don't know about the correct address fields, we always required street, zipcode and city, if the whole address form was obligatory (but only street address if the whole address form was optional) - now we always only require a street address, which is a multi line field, allowing customers to enter their address in free form.
