### PR TITLE
Improve organizer/event-series calendar UI on mobile

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -26,7 +26,7 @@
                                     </a>
                                     <span aria-hidden="true" class="hidden-xs">{{ day.day }}</span>
                                 {% else %}
-                                    <span aria-hidden="true">{{ day.day }}</span>
+                                    <span aria-hidden="true" class="day-label">{{ day.day }}</span>
                                 {% endif %}
                                     <span class="sr-only">
                                         ({% blocktrans trimmed count count=day.events|length %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -20,10 +20,14 @@
                             data-date="{{ day.date|date_fast:"SHORT_DATE_FORMAT" }}">
                             <p>
                                 <time datetime="{{ day.date|date_fast:"Y-m-d" }}">
+                                {% if day.events %}
                                     <a href="#selected-day" class="day-label event hidden-sm hidden-md hidden-lg" aria-hidden="true">
                                         <b>{{ day.day }}</b>
                                     </a>
                                     <span aria-hidden="true" class="hidden-xs">{{ day.day }}</span>
+                                {% else %}
+                                    <span aria-hidden="true">{{ day.day }}</span>
+                                {% endif %}
                                     <span class="sr-only">
                                         ({% blocktrans trimmed count count=day.events|length %}
                                             {{ count }} event

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -2,7 +2,7 @@
 {% load date_fast %}
 {% load calendarhead %}
 <div class="table-responsive">
-    <table class="table table-calendar">
+    <table class="table table-calendar" role="grid">
         <caption class="sr-only">{% trans "Calendar" %}</caption>
         <thead>
         <tr>
@@ -18,7 +18,18 @@
                     {% if day %}
                         <td class="day {% if day.events %}has-events{% else %}no-events{% endif %}"
                             data-date="{{ day.date|date_fast:"SHORT_DATE_FORMAT" }}">
-                            <p><time datetime="{{ day.date|date_fast:"Y-m-d" }}">{{ day.day }}</time></p>
+                            <p>
+                                <time datetime="{{ day.date|date_fast:"Y-m-d" }}">
+                                    <span aria-hidden="true">{{ day.day }}</span>
+                                    <span class="sr-only">
+                                    {% blocktrans trimmed count count=day.events|length %}
+                                        {{ count }} event
+                                        {% plural %}
+                                        {{ count }} events
+                                    {% endblocktrans %}
+                                    </span>
+                                </time>
+                            </p>
                             <ul class="events">
                                 {% for event in day.events %}
                                     <li><a class="event {% if event.continued %}continued{% endif %} {% spaceless %}
@@ -111,9 +122,9 @@
                 {% endfor %}
             </tr>
         {% endfor %}
-        <tr class="selected-day hidden">
-            <td colspan="7"></td>
-        </tr>
         </tbody>
     </table>
+    <div class="table-calendar row">
+        <div id="selected-day" aria-live="polite" class="col-xs-12 sm-hidden"></div>
+    </div>
 </div>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -19,15 +19,12 @@
                         <td class="day {% if day.events %}has-events{% else %}no-events{% endif %}"
                             data-date="{{ day.date|date_fast:"SHORT_DATE_FORMAT" }}">
                             <p>
-                                <time datetime="{{ day.date|date_fast:"Y-m-d" }}">
-                                {% if day.events %}
-                                    <a href="#selected-day" class="day-label event hidden-sm hidden-md hidden-lg" aria-hidden="true">
-                                        <b>{{ day.day }}</b>
-                                    </a>
-                                    <span aria-hidden="true" class="hidden-xs">{{ day.day }}</span>
-                                {% else %}
-                                    <span aria-hidden="true" class="day-label">{{ day.day }}</span>
-                                {% endif %}
+                            {% if day.events %}
+                                <a href="#selected-day" class="day-label event hidden-sm hidden-md hidden-lg">
+                                    <b aria-hidden="true">{{ day.day }}</b>
+                                    <time datetime="{{ day.date|date_fast:"Y-m-d" }}" class="sr-only">
+                                        {{ day.date|date_fast:"SHORT_DATE_FORMAT" }}
+                                    </time>
                                     <span class="sr-only">
                                         ({% blocktrans trimmed count count=day.events|length %}
                                             {{ count }} event
@@ -35,7 +32,11 @@
                                             {{ count }} events
                                         {% endblocktrans %})
                                     </span>
-                                </time>
+                                </a>
+                                <time datetime="{{ day.date|date_fast:"Y-m-d" }}" class="hidden-xs">{{ day.day }}</time>
+                            {% else %}
+                                <time datetime="{{ day.date|date_fast:"Y-m-d" }}" class="day-label">{{ day.day }}</time>
+                            {% endif %}
                             </p>
                             <ul class="events">
                                 {% for event in day.events %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -131,7 +131,5 @@
         {% endfor %}
         </tbody>
     </table>
-    <div class="table-calendar clearfix hidden-sm hidden-md hidden-lg">
-        <div id="selected-day" aria-live="polite" class="col-xs-12"></div>
-    </div>
+    <div id="selected-day" aria-live="polite" class="table-calendar hidden-sm hidden-md hidden-lg"></div>
 </div>

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -20,13 +20,16 @@
                             data-date="{{ day.date|date_fast:"SHORT_DATE_FORMAT" }}">
                             <p>
                                 <time datetime="{{ day.date|date_fast:"Y-m-d" }}">
-                                    <span aria-hidden="true">{{ day.day }}</span>
+                                    <a href="#selected-day" class="day-label event hidden-sm hidden-md hidden-lg" aria-hidden="true">
+                                        <b>{{ day.day }}</b>
+                                    </a>
+                                    <span aria-hidden="true" class="hidden-xs">{{ day.day }}</span>
                                     <span class="sr-only">
-                                    {% blocktrans trimmed count count=day.events|length %}
-                                        {{ count }} event
+                                        ({% blocktrans trimmed count count=day.events|length %}
+                                            {{ count }} event
                                         {% plural %}
-                                        {{ count }} events
-                                    {% endblocktrans %}
+                                            {{ count }} events
+                                        {% endblocktrans %})
                                     </span>
                                 </time>
                             </p>
@@ -124,7 +127,7 @@
         {% endfor %}
         </tbody>
     </table>
-    <div class="table-calendar row">
-        <div id="selected-day" aria-live="polite" class="col-xs-12 sm-hidden"></div>
+    <div class="table-calendar clearfix hidden-sm hidden-md hidden-lg">
+        <div id="selected-day" aria-live="polite" class="col-xs-12"></div>
     </div>
 </div>

--- a/src/pretix/static/pretixbase/scss/_theme_variables.scss
+++ b/src/pretix/static/pretixbase/scss/_theme_variables.scss
@@ -53,7 +53,9 @@ $in-border-radius-small: 2px !default;
   --pretix-brand-primary-darken-17: #{darken($in-brand-primary, 17%)};
   --pretix-brand-primary-darken-20: #{darken($in-brand-primary, 20%)};
   --pretix-brand-primary-darken-30: #{darken($in-brand-primary, 30%)};
+  --pretix-brand-primary-tint-90: #{tint($in-brand-primary, 90%)};
   --pretix-brand-primary-shade-25: #{shade($in-brand-primary, 25%)};
+  --pretix-brand-primary-shade-42: #{shade($in-brand-primary, 42%)};
   --pretix-brand-primary-lighten-28-saturate-20: #{saturate(lighten($in-brand-primary, 28%), 20%)};
   --pretix-brand-primary-lighten-23-saturate-2: #{saturate(lighten($in-brand-primary, 23%), 2%)};
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -459,10 +459,12 @@ $(function () {
         .on("change mouseup keyup", update_cart_form);
 
     $(".table-calendar td.has-events").click(function () {
-        var $tr = $(this).closest(".table-calendar").find(".selected-day");
-        $tr.find("td").html($(this).find(".events").clone());
-        $tr.find("td").prepend($("<h3>").text($(this).attr("data-date")));
-        $tr.removeClass("hidden");
+        var $grid = $(this).closest("[aria-role='grid']");
+        $grid.find("[aria-selected]").attr("aria-selected", false);
+        $(this).attr("aria-selected", true);
+        $("#selected-day")
+            .html($(this).find(".events").clone())
+            .prepend($("<h3>").text($(this).attr("data-date")));
     });
 
     $(".print-this-page").on("click", function (e) {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -459,7 +459,7 @@ $(function () {
         .on("change mouseup keyup", update_cart_form);
 
     $(".table-calendar td.has-events").click(function () {
-        var $grid = $(this).closest("[aria-role='grid']");
+        var $grid = $(this).closest("[role='grid']");
         $grid.find("[aria-selected]").attr("aria-selected", false);
         $(this).attr("aria-selected", true);
         $("#selected-day")

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -468,6 +468,9 @@ $(function () {
     }).each(function() {
         // check all events classes and set the "winning" class for the availability of the day-label on mobile
         var $dayLabel = $('.day-label', this);
+        if ($('.available.low', this).length == $('.available', this).length) {
+            $dayLabel.addClass('low');
+        }
         var classes = ['available', 'waitinglist', 'soon', 'reserved', 'soldout', 'continued', 'over'];
         for (var c of classes) {
             if ($('.'+c, this).length) {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -475,7 +475,8 @@ $(function () {
         for (var c of classes) {
             if ($('.'+c, this).length) {
                 $dayLabel.addClass(c);
-                break;
+                // CAREFUL: „return“ as „break“ is not supported before ES2015 and breaks e.g. on iOS 15
+                return;
             }
         }
     });

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -465,6 +465,16 @@ $(function () {
         $("#selected-day")
             .html($(this).find(".events").clone())
             .prepend($("<h3>").text($(this).attr("data-date")));
+    }).each(function() {
+        // check all events classes and set the "winning" class for the availability of the day-label on mobile
+        var $dayLabel = $('.day-label', this);
+        var classes = ['available', 'waitinglist', 'soon', 'reserved', 'soldout', 'continued', 'over'];
+        for (var c of classes) {
+            if ($('.'+c, this).length) {
+                $dayLabel.addClass(c);
+                break;
+            }
+        }
     });
 
     $(".print-this-page").on("click", function (e) {

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -16,14 +16,23 @@
     --status-bg-color: var(--pretix-brand-primary-tint-90);
     --status-text-color: var(--pretix-brand-primary-shade-42);
     --status-border-color: #{$brand-primary};
+    position: relative;
     display: block;
     background: var(--status-bg-color);
     color: var(--status-text-color);
     border: 1px solid var(--status-border-color);
-    border-left-width: 12px;
     border-radius: $border-radius-base;
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 11px;
+      height: 100%;
+      background: var(--status-border-color);
+    }
 
-    padding: 3px 5px;
+    padding: 3px 5px 3px 17px;
     margin-bottom: 3px;
     font-size: 12px;
     overflow-wrap: anywhere;
@@ -49,10 +58,8 @@
       --status-text-color: #{$alert-success-text};
       --status-border-color: #{$alert-success-border};
 
-      &.low {
-        border-left-width: 8px;
-        padding-left: 9px;
-        background: linear-gradient(to right, $alert-warning-border 4px, $alert-warning-bg 4px, $alert-warning-bg 25%, $alert-success-bg 66%);
+      &.low:before {
+        background: linear-gradient(to bottom, var(--pretix-brand-warning) 1em, var(--status-border-color) 2.5em);
       }
     }
 
@@ -442,20 +449,17 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
     a.day-label, .day-label {
       --status-text-color: #{$text-muted};
       display: block;
-      padding: 3px 3px 15px 4px;
+      padding: 3px 3px 15px 12px;
       font-size: 12px;
       font-weight: bold;
       color: var(--status-text-color);
       margin-bottom: 0;
-      border-left-width: 8px;
     }
     .no-events .day-label {
       padding-left: 12px;
     }
-    a.event.available.low {
-      border-left-width: 5px;
-      padding-left: 7px;
-      background: linear-gradient(to right, $alert-warning-border 3px, $alert-warning-bg 3px, $alert-warning-bg 25%, var(--status-bg-color) 66%);
+    a.day-label:before {
+      width: 8px;
     }
   }
   #selected-day:has(*) {

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -13,14 +13,15 @@
     padding: 0;
   }
   a.event {
+    --status-bg-color: var(--pretix-brand-primary-tint-90);
+    --status-text-color: var(--pretix-brand-primary-shade-42);
+    --status-border-color: #{$brand-primary};
     display: block;
-    background: var(--pretix-brand-primary-lighten-48);
-    color: $brand-primary;
+    background: var(--status-bg-color);
+    color: var(--status-text-color);
+    border: 1px solid var(--status-border-color);
+    border-left-width: 12px;
     border-radius: $border-radius-base;
-    border-style: solid;
-    border-color: var(--pretix-brand-primary-lighten-30);
-    border-width: 1px 1px 1px 12px;
-    border-left-color: inherit;
 
     padding: 3px 5px;
     margin-bottom: 3px;
@@ -29,77 +30,42 @@
     text-decoration: none;
 
     &:hover {
-      background: var(--pretix-brand-primary-lighten-50);
-      border-color: $brand-primary;
+      outline: 1px solid var(--status-border-color);
+      outline-offset: 0;
     }
     &:focus {
-      outline-color: inherit;
+      outline: 2px solid var(--status-border-color);
+      outline-offset: 2px;
     }
 
     &.continued, &.over {
-      background: lighten($text-muted, 54%);
-      border-color: lighten($text-muted, 44%);
-      border-left-color: lighten($text-muted, 44%);
-      color: $text-muted;
-      &:hover {
-        background: lighten($text-muted, 54%);
-        border-color: lighten($text-muted, 40%);
-      }
-    }
-
-    &.soon {
-      background: var(--pretix-brand-primary-lighten-53);
-      border-color: var(--pretix-brand-primary-lighten-40);
-      border-left-color: var(--pretix-brand-primary-lighten-20);
-      color: var(--pretix-brand-primary-lighten-5);
-      &:hover {
-        background: var(--pretix-brand-primary-lighten-55);
-        border-color: var(--pretix-brand-primary-lighten-20);
-      }
+      --status-bg-color: #{$table-bg-accent};
+      --status-text-color: #{$text-muted};
+      --status-border-color: #{tint($text-muted, 50%)};
     }
 
     &.available {
-      background: var(--pretix-brand-success-lighten-48);
-      border-color: var(--pretix-brand-success-lighten-30);
-      border-left-color: $brand-success;
-      color: var(--pretix-brand-success-darken-12);
+      --status-bg-color: #{$alert-success-bg};
+      --status-text-color: #{$alert-success-text};
+      --status-border-color: #{$alert-success-border};
 
       &.low {
-        border-left-color: var(--pretix-brand-warning-lighten-12);
-      }
-
-      &:hover {
-        background: var(--pretix-brand-success-lighten-50);
-        border-color: $brand-success;
-
-        &.low {
-          border-left-color: $brand-warning;
-        }
+        border-left-width: 8px;
+        padding-left: 9px;
+        background: linear-gradient(to right, $alert-warning-border 4px, $alert-warning-bg 4px, $alert-warning-bg 25%, $alert-success-bg 66%);
       }
     }
 
     &.waitinglist {
-      background: var(--pretix-brand-warning-lighten-41);
-      border-color: var(--pretix-brand-warning-lighten-31);
-      border-left-color: var(--pretix-brand-warning-lighten-12);
-      color: #963;
-
-      &:hover {
-        background: var(--pretix-brand-warning-lighten-43);
-        border-color: $brand-warning;
-      }
+      --status-bg-color: #{$alert-warning-bg};
+      --status-text-color: #{$alert-warning-text};
+      --status-border-color: #{$alert-warning-border};
     }
 
     &.reserved, &.soldout, {
-      background: var(--pretix-brand-danger-lighten-43);
-      border-color: var(--pretix-brand-danger-lighten-30);
-      border-left-color: var(--pretix-brand-danger-lighten-30);
-      color: var(--pretix-brand-danger-darken-5);
-
-      &:hover {
-        background: var(--pretix-brand-danger-lighten-45);
-        border-color: var(--pretix-brand-danger-lighten-25);
-      }
+      --status-bg-color: #{$alert-danger-bg};
+      --status-text-color: #{$alert-danger-text};
+      --status-border-color: #{$alert-danger-border};
     }
 
     &.available > *:first-child,
@@ -474,49 +440,26 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
       display: none;
     }
     a.day-label, .day-label {
+      --status-text-color: #{$text-muted};
       display: block;
       padding: 3px 3px 15px 4px;
       font-size: 12px;
       font-weight: bold;
-      color: $text-muted;
+      color: var(--status-text-color);
       margin-bottom: 0;
       border-left-width: 8px;
     }
     .no-events .day-label {
       padding-left: 12px;
     }
+    a.event.available.low {
+      border-left-width: 5px;
+      padding-left: 7px;
+      background: linear-gradient(to right, $alert-warning-border 3px, $alert-warning-bg 3px, $alert-warning-bg 25%, var(--status-bg-color) 66%);
+    }
   }
   #selected-day:has(*) {
     padding: $table-cell-padding;
-  }
-  .day[aria-selected="true"] .event {
-    &.continued, &.over {
-      background: lighten($text-muted, 54%);
-      border-color: lighten($text-muted, 40%);
-    }
-
-    &.soon {
-      background: var(--pretix-brand-primary-lighten-55);
-      border-color: var(--pretix-brand-primary-lighten-20);
-    }
-
-    &.available {
-      background: var(--pretix-brand-success-lighten-50);
-      border-color: $brand-success;
-      &.low {
-        border-left-color: $brand-warning;
-      }
-    }
-
-    &.waitinglist {
-      background: var(--pretix-brand-warning-lighten-43);
-      border-color: $brand-warning;
-    }
-
-    &.reserved, &.soldout, {
-      background: var(--pretix-brand-danger-lighten-45);
-      border-color: var(--pretix-brand-danger-lighten-25);
-    }
   }
 }
 #monthselform .row {

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -476,6 +476,35 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
   #selected-day:has(*) {
     padding: $table-cell-padding;
   }
+  .day[aria-selected="true"] .event {
+    &.continued, &.over {
+      background: lighten($text-muted, 54%);
+      border-color: lighten($text-muted, 40%);
+    }
+
+    &.soon {
+      background: var(--pretix-brand-primary-lighten-55);
+      border-color: var(--pretix-brand-primary-lighten-20);
+    }
+
+    &.available {
+      background: var(--pretix-brand-success-lighten-50);
+      border-color: $brand-success;
+      &.low {
+        border-left-color: $brand-warning;
+      }
+    }
+
+    &.waitinglist {
+      background: var(--pretix-brand-warning-lighten-43);
+      border-color: $brand-warning;
+    }
+
+    &.reserved, &.soldout, {
+      background: var(--pretix-brand-danger-lighten-45);
+      border-color: var(--pretix-brand-danger-lighten-25);
+    }
+  }
 }
 #monthselform .row {
   margin: 0 -15px;

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -37,13 +37,13 @@
     }
 
     &.continued, &.over {
-      background: lighten(#767676, 54%);
-      border-color: lighten(#767676, 44%);
-      border-left-color: lighten(#767676, 44%);
-      color: #767676;
+      background: lighten($text-muted, 54%);
+      border-color: lighten($text-muted, 44%);
+      border-left-color: lighten($text-muted, 44%);
+      color: $text-muted;
       &:hover {
-        background: lighten(#767676, 54%);
-        border-color: lighten(#767676, 40%);
+        background: lighten($text-muted, 54%);
+        border-color: lighten($text-muted, 40%);
       }
     }
 

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -463,15 +463,27 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
   }
 }
 @media (max-width: $screen-xs-max) {
-  .table-calendar .day .events {
-    display: none;
-  }
-  .table-calendar .day-label {
-    display: block;
-    padding: 4px 6px 4px 18px;
-    font-size: 12px;
-    font-weight: bold;
-    color: $text-muted;
+  .table-calendar {
+    .day, .no-day {
+      padding: 3px 2px;
+    }
+    p {
+      margin-bottom: 0;
+    }
+    .day .events {
+      display: none;
+    }
+    time>.day-label {
+      display: block;
+      padding: 3px 3px 15px 4px;
+      font-size: 12px;
+      font-weight: bold;
+      color: $text-muted;
+      margin-bottom: 0;
+    }
+    .no-events .day-label {
+      padding-left: 16px;
+    }
   }
   #selected-day:has(*) {
     padding: $table-cell-padding;

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -480,9 +480,10 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
       font-weight: bold;
       color: $text-muted;
       margin-bottom: 0;
+      border-left-width: 8px;
     }
     .no-events .day-label {
-      padding-left: 16px;
+      padding-left: 12px;
     }
   }
   #selected-day:has(*) {

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -472,6 +472,13 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
   .table-calendar .day .events {
     display: none;
   }
+  .table-calendar .day-label {
+    display: block;
+    padding: 4px 6px 4px 18px;
+    font-size: 12px;
+    font-weight: bold;
+    color: $text-muted;
+  }
 }
 #monthselform .row {
   margin: 0 -15px;

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -433,12 +433,6 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
   margin-right: calc(var(--offset-end, 0) / var(--duration) * 100%);
 }
 
-#selected-day {
-  padding: $table-cell-padding;
-}
-
-
-
 
 @media (min-width: $screen-md-min) {
   .week-calendar {
@@ -478,6 +472,9 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
     font-size: 12px;
     font-weight: bold;
     color: $text-muted;
+  }
+  #selected-day:has(*) {
+    padding: $table-cell-padding;
   }
 }
 #monthselform .row {

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -473,7 +473,7 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
     .day .events {
       display: none;
     }
-    time>.day-label {
+    a.day-label, .day-label {
       display: block;
       padding: 3px 3px 15px 4px;
       font-size: 12px;

--- a/src/pretix/static/pretixpresale/scss/_calendar.scss
+++ b/src/pretix/static/pretixpresale/scss/_calendar.scss
@@ -433,6 +433,10 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
   margin-right: calc(var(--offset-end, 0) / var(--duration) * 100%);
 }
 
+#selected-day {
+  padding: $table-cell-padding;
+}
+
 
 
 
@@ -464,24 +468,9 @@ if concurrency is higher than 9, JavaScript (currently in pretixpresale/js/ui/ma
     }
   }
 }
-@media (min-width: $screen-sm-min) {
-  .table-calendar, .week-calendar {
-    .selected-day {
-      display: none !important;
-    }
-  }
-}
 @media (max-width: $screen-xs-max) {
   .table-calendar .day .events {
     display: none;
-  }
-  .table-calendar td.day.has-events {
-    background: $brand-primary;
-    cursor: pointer;
-    color: white;
-  }
-  .table-calendar td.day.has-events:hover {
-    background: var(--pretix-brand-primary-darken-15);
   }
 }
 #monthselform .row {


### PR DESCRIPTION
This PR improves accessibility on the mobile calendar-view as it turns the calendar-table into a role="grid" with keyboard-selectable option, info on number of events on that day and making `#selected-day` an aria-live-region.

It further improves the mobile UI by mimicking a single event box on the day-label with the most important event-availability taking precedence.

Before (just brand-primary, no hover, no selected state):
![Bildschirmfoto 2024-11-26 um 10 16 28](https://github.com/user-attachments/assets/669475c4-eef1-437a-b838-2514d51b7be9)

After:
![Bildschirmfoto 2024-11-26 um 10 26 18](https://github.com/user-attachments/assets/efb2da0d-5d99-498b-bd0d-9a8f503caf0d)