### PR TITLE
Change error message for unavailable addon products

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_addons.html
@@ -13,7 +13,7 @@
         </p>
     {% elif incomplete %}
         <div class="alert alert-danger">
-            {% trans "A product in your cart is only sold in combination with add-on products that are no longer available. Please contact the event organizer." %}
+            {% trans "A product in your cart is only sold in combination with add-on products that are not available. Please contact the event organizer." %}
         </div>
     {% endif %}
     <form class="form-horizontal" method="post" data-asynctask


### PR DESCRIPTION
This can not only happen in case of sold-out addons, but also if they are e.g. not available via the current sales channel.