### PR TITLE
[A11y] Improve number inputs for screen-readers

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -6,13 +6,14 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% for c in form.categories %}
+    {% with category_idx=forloop.counter %}
     <fieldset data-addon-max-count="{{ c.max_count }}"{% if c.multi_allowed %} data-addon-multi-allowed{% endif %}>
         <legend>{{ c.category.name }}</legend>
         {% if c.category.description %}
             {{ c.category.description|rich_text }}
         {% endif %}
         {% if c.min_count == c.max_count %}
-            <p class="addon-count-desc">
+            <p class="addon-count-desc" id="addon-count-desc-{{ category_idx }}">
                 {% blocktrans trimmed count min_count=c.min_count %}
                     You need to choose exactly one option from this category.
                 {% plural %}
@@ -21,7 +22,7 @@
             </p>
         {% elif c.min_count == 0 and c.max_count >= c.items|length and not c.multi_allowed %}
         {% elif c.min_count == 0 %}
-            <p class="addon-count-desc">
+            <p class="addon-count-desc" id="addon-count-desc-{{ category_idx }}">
                 {% blocktrans trimmed count max_count=c.max_count %}
                     You can choose {{ max_count }} option from this category.
                 {% plural %}
@@ -29,7 +30,7 @@
                 {% endblocktrans %}
             </p>
         {% else %}
-            <p class="addon-count-desc">
+            <p class="addon-count-desc" id="addon-count-desc-{{ category_idx }}">
                 {% blocktrans trimmed with min_count=c.min_count max_count=c.max_count %}
                     You can choose between {{ min_count }} and {{ max_count }} options from
                     this category.
@@ -58,7 +59,7 @@
                                     </div>
                                 {% endif %}
                                 {% if item.min_per_order and item.min_per_order > 1 %}
-                                    <p>
+                                    <p id="cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
                                         <small>
                                             {% blocktrans trimmed with num=item.min_per_order %}
                                                 minimum amount to order: {{ num }}
@@ -196,12 +197,14 @@
                                                         {% endif %}
                                                         id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
-                                                        aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}">
+                                                        aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
+                                                        aria-describedby="addon-count-desc-{{ category_idx }}">
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" context "checkbox" %}
                                             </label>
                                         {% else %}
-                                            <div class="input-item-count-group">
+                                            <fieldset class="input-item-count-group" aria-describedby="addon-count-desc-{{ category_idx }} cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
+                                                <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}</legend>
                                                 <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
                                                     {% if var.initial %}value="{{ var.initial }}"{% endif %}
@@ -211,9 +214,9 @@
                                                     max="{{ c.max_count }}"
                                                     id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                     name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
-                                                    aria-label="{% blocktrans with item=item.name var=var %}Quantity of {{ item }}, {{ var }} to order{% endblocktrans %}">
+                                                    aria-label="{% trans "Quantity" %}">
                                                 <button type="button" data-step="1" data-controls="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}">+</button>
-                                            </div>
+                                            </fieldset>
                                         {% endif %}
                                     </div>
                                 {% else %}
@@ -250,7 +253,7 @@
                                 {% include "pretixpresale/event/fragment_quota_left.html" with avail=item.cached_availability %}
                             {% endif %}
                             {% if item.min_per_order and item.min_per_order > 1 %}
-                                <p>
+                                <p id="cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
                                     <small>
                                         {% blocktrans trimmed with num=item.min_per_order %}
                                             minimum amount to order: {{ num }}
@@ -341,12 +344,13 @@
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
-                                            {% if item.description %} aria-describedby="cp-{{ form.pos.pk }}-item-{{ item.id }}-description"{% endif %}>
+                                            aria-describedby="addon-count-desc-{{ category_idx }}">
                                             <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                             {% trans "Select" context "checkbox" %}
                                 </label>
                             {% else %}
-                                <div class="input-item-count-group">
+                                <fieldset class="input-item-count-group" aria-describedby="addon-count-desc-{{ category_idx }} cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
+                                    <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}</legend>
                                     <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
                                         {% if item.free_price %}
@@ -356,10 +360,9 @@
                                         {% if item.initial %}value="{{ item.initial }}"{% endif %}
                                         name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                         id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
-                                        aria-label="{% blocktrans with item=item.name %}Quantity of {{ item }} to order{% endblocktrans %}"
-                                        {% if item.description %} aria-describedby="cp-{{ form.pos.pk }}-item-{{ item.id }}-description"{% endif %}>
+                                        aria-label="{% trans "Quantity" %}">
                                     <button type="button" data-step="1" data-controls="cp_{{ form.pos.pk }}_item_{{ item.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}">+</button>
-                                </div>
+                                </fieldset>
                             {% endif %}
                         </div>
                     {% else %}
@@ -370,6 +373,7 @@
             {% endif %}
         {% endfor %}
     </fieldset>
+    {% endwith %}
 {% empty %}
     <em>
         {% trans "There are no add-ons available for this product." %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -13,7 +13,7 @@
             {{ c.category.description|rich_text }}
         {% endif %}
         {% if c.min_count == c.max_count %}
-            <p class="addon-count-desc" id="addon-count-desc-{{ category_idx }}">
+            <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
                 {% blocktrans trimmed count min_count=c.min_count %}
                     You need to choose exactly one option from this category.
                 {% plural %}
@@ -22,7 +22,7 @@
             </p>
         {% elif c.min_count == 0 and c.max_count >= c.items|length and not c.multi_allowed %}
         {% elif c.min_count == 0 %}
-            <p class="addon-count-desc" id="addon-count-desc-{{ category_idx }}">
+            <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
                 {% blocktrans trimmed count max_count=c.max_count %}
                     You can choose {{ max_count }} option from this category.
                 {% plural %}
@@ -30,7 +30,7 @@
                 {% endblocktrans %}
             </p>
         {% else %}
-            <p class="addon-count-desc" id="addon-count-desc-{{ category_idx }}">
+            <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
                 {% blocktrans trimmed with min_count=c.min_count max_count=c.max_count %}
                     You can choose between {{ min_count }} and {{ max_count }} options from
                     this category.
@@ -198,12 +198,12 @@
                                                         id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
-                                                        aria-describedby="addon-count-desc-{{ category_idx }}">
+                                                        aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" context "checkbox" %}
                                             </label>
                                         {% else %}
-                                            <fieldset class="input-item-count-group" aria-describedby="addon-count-desc-{{ category_idx }} cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
+                                            <fieldset class="input-item-count-group" aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
                                                 <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}</legend>
                                                 <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
@@ -344,12 +344,12 @@
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-label="{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}"
-                                            aria-describedby="addon-count-desc-{{ category_idx }}">
+                                            aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
                                             <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                             {% trans "Select" context "checkbox" %}
                                 </label>
                             {% else %}
-                                <fieldset class="input-item-count-group" aria-describedby="addon-count-desc-{{ category_idx }} cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
+                                <fieldset class="input-item-count-group" aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
                                     <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}</legend>
                                     <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -219,7 +219,8 @@
                                                 {% trans "Select" context "checkbox" %}
                                             </label>
                                         {% else %}
-                                            <div class="input-item-count-group">
+                                            <fieldset class="input-item-count-group">
+                                                <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}</legend>
                                                 <button type="button" data-step="-1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
                                                     {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
@@ -230,10 +231,10 @@
                                                        max="{{ var.order_max }}"
                                                        id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
                                                        name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       aria-label="{% blocktrans with item=item.name var=var.name %}Quantity of {{ item }}, {{ var }} to order{% endblocktrans %}">
+                                                       aria-label="{% trans "Quantity" %}">
                                                 <button type="button" data-step="1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}"
                                                     {% if not ev.presale_is_running %}disabled{% endif %}>+</button>
-                                            </div>
+                                            </fieldset>
                                         {% endif %}
                                     </div>
                                 {% else %}
@@ -370,7 +371,8 @@
                                         {% trans "Select" context "checkbox" %}
                                 </label>
                             {% else %}
-                                <div class="input-item-count-group">
+                                <fieldset class="input-item-count-group">
+                                    <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}</legend>
                                     <button type="button" data-step="-1" data-controls="{{ form_prefix }}item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
                                         {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
@@ -382,11 +384,10 @@
                                            max="{{ item.order_max }}"
                                            name="{{ form_prefix }}item_{{ item.id }}"
                                            id="{{ form_prefix }}item_{{ item.id }}"
-                                           aria-label="{% blocktrans with item=item.name %}Quantity of {{ item }} to order{% endblocktrans %}"
-                                           {% if item.description %} aria-describedby="{{ form_prefix }}item-{{ item.id }}-description"{% endif %}>
+                                           aria-label="{% trans "Quantity" %}">
                                     <button type="button" data-step="1" data-controls="{{ form_prefix }}item_{{ item.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}"
                                         {% if not ev.presale_is_running %}disabled{% endif %}>+</button>
-                                </div>
+                                </fieldset>
                             {% endif %}
                         </div>
                     {% else %}

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -231,16 +231,17 @@
                                                                 {% trans "Select" context "checkbox" %}
                                                             </label>
                                                         {% else %}
-                                                            <div class="input-item-count-group">
+                                                            <fieldset class="input-item-count-group">
+                                                                <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}</legend>
                                                                 <button type="button" data-step="-1" data-controls="variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
                                                                     max="{{ var.order_max }}"
                                                                     id="variation_{{ item.id }}_{{ var.id }}"
                                                                     name="variation_{{ item.id }}_{{ var.id }}"
                                                                     {% if options == 1 %}value="1"{% endif %}
-                                                                    aria-label="{% blocktrans with item=item.name var=var.name %}Quantity of {{ item }}, {{ var }} to order{% endblocktrans %}">
+                                                                    aria-label="{% trans "Quantity" %}">
                                                                 <button type="button" data-step="1" data-controls="variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}">+</button>
-                                                            </div>
+                                                            </fieldset>
                                                         {% endif %}
                                                     {% else %}
                                                         <label>
@@ -385,7 +386,8 @@
                                                     {% trans "Select" context "checkbox" %}
                                                 </label>
                                             {% else %}
-                                                <div class="input-item-count-group">
+                                                <fieldset class="input-item-count-group">
+                                                    <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }} to cart{% endblocktrans %}</legend>
                                                     <button type="button" data-step="-1" data-controls="item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}">-</button>
                                                     <input type="number" class="form-control input-item-count"
                                                        placeholder="0" min="0"
@@ -393,10 +395,9 @@
                                                        id="item_{{ item.id }}"
                                                        name="item_{{ item.id }}"
                                                        {% if options == 1 %}value="1"{% endif %}
-                                                       aria-label="{% blocktrans with item=item.name %}Quantity of {{ item }} to order{% endblocktrans %}"
-                                                       {% if item.description %} aria-describedby="item-{{ item.id }}-description"{% endif %}>
+                                                       aria-label="{% trans "Quantity" %}">
                                                     <button type="button" data-step="1" data-controls="item_{{ item.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}">+</button>
-                                                </div>
+                                                </fieldset>
                                             {% endif %}
                                         {% else %}
                                             <label>


### PR DESCRIPTION
This PR groups the number inputs and its rocker-buttons into a fieldset with a legend, which improves the screenreader experience by reading that legend as well when focusing the +/- rocker buttons.