### PR TITLE
Hide empty panels

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -136,6 +136,10 @@ article.item-with-variations .product-row:last-child:after {
     display: none;
 }
 
+.panel-body:not(:has(*)) {
+  padding: 0;
+}
+
 .panel-body > *:last-child,
 .panel-body address:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
This PR removes padding from .panel-body when it does not have any childnodes – due to excessive white-space the :empty-selector does not work. The implication of this is, that .panel-body with plain-text will have no padding. I have never come across a panel-body with plan-text though.

Before
![Bildschirmfoto 2024-12-04 um 21 12 22](https://github.com/user-attachments/assets/d1751a3e-5eb0-4003-be6a-396c61f95023)

After:
![Bildschirmfoto 2024-12-04 um 21 12 38](https://github.com/user-attachments/assets/8065f77d-84dc-4c52-bb86-77e59a49b139)
