### PR TITLE
Move cursor fix for disabled fieldsets from bootstrap to presale

### DIFF
--- a/src/pretix/static/bootstrap/scss/bootstrap/_forms.scss
+++ b/src/pretix/static/bootstrap/scss/bootstrap/_forms.scss
@@ -70,7 +70,7 @@ input[type="checkbox"] {
   // Note: Neither radios nor checkboxes can be readonly.
   &[disabled],
   &.disabled,
-  fieldset[disabled] &:not(fieldset[disabled] > legend &) {
+  fieldset[disabled] & {
     cursor: $cursor-disabled;
   }
 }

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -329,10 +329,6 @@ $(function () {
         var $input = $("input", this);
         if (!$input.prop("checked")) $input.prop('checked', true).trigger("change");
     });
-    $(".accordion-radio input").on("change", function() {
-        $(this).closest("fieldset").find(".panel-body").slideDown();
-        $(this).closest(".panel-group").find(".accordion-panel:has(.accordion-radio input:not(:checked)) .panel-body").slideUp();
-    });
 
     setup_basics($("body"));
     $(".overlay-remove").on("click", function() {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -329,6 +329,10 @@ $(function () {
         var $input = $("input", this);
         if (!$input.prop("checked")) $input.prop('checked', true).trigger("change");
     });
+    $(".accordion-radio input").on("change", function() {
+        $(this).closest("fieldset").find(".panel-body").slideDown();
+        $(this).closest(".panel-group").find(".accordion-panel:has(.accordion-radio input:not(:checked)) .panel-body").slideUp();
+    });
 
     setup_basics($("body"));
     $(".overlay-remove").on("click", function() {

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -153,6 +153,10 @@ fieldset.accordion-panel > legend {
 fieldset.accordion-panel[disabled] > .panel-body {
   display: none;
 }
+fieldset[disabled] legend input[type="radio"],
+fieldset[disabled] legend input[type="checkbox"] {
+  cursor: default;
+}
 
 .nav-tabs {
   border-bottom: 0px solid #ddd;


### PR DESCRIPTION
This PR undoes commit a747ab1, which changed a bootstrap css – although we probably never receive an update to bootstrap 3, I guess we should not change it if possible. Furthermore it adds slideUp/Down-animation through Javascript to the panels as using transform with plain CSS does not properly due to auto-height and padding issues.