### PR TITLE
Fix fieldset accordion css

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -135,9 +135,13 @@ a.btn, button.btn {
   margin: 0;
 }
 .panel-default>.accordion-radio>.panel-heading, fieldset.accordion-panel>legend>.panel-heading {
+  display: block;
   color: #333;
   background-color: #f5f5f5;
   padding: 8px 15px;
+  margin: 0;
+  line-height: 1;
+  font-size: 16px;
 
   input[type=radio] {
     margin-top: 0;

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -140,7 +140,7 @@ a.btn, button.btn {
   background-color: #f5f5f5;
   padding: 8px 15px;
   margin: 0;
-  line-height: 1;
+  line-height: 1.428571429;
   font-size: 16px;
 
   input[type=radio] {

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -335,6 +335,11 @@ body.loading .container {
     }
 }
 
+.font-normal {
+    font-style: normal;
+    font-weight: normal;
+}
+
 .blank-after {
     margin-bottom: 1em;
 }


### PR DESCRIPTION
The new fieldset-accordion markup was worng by using p and div inside legend-elements. This PR fixes the CSS when changing them to correctly label and span.