### PR TITLE
[A11y] fix color-contrast for event-list status-bubbles

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -1,9 +1,11 @@
 {% extends "pretixpresale/organizers/base.html" %}
 {% load i18n %}
+{% load icon %}
 {% load rich_text %}
 {% load tz %}
 {% load eventurl %}
 {% load urlreplace %}
+{% load textbubble %}
 {% load thumb %}
 {% block title %}{% trans "Event list" %}{% endblock %}
 {% block custom_header %}
@@ -86,51 +88,73 @@
                     <td>
                 </div>
                 <div class="col-md-2 col-xs-6">
+                    <small>
                     {% if e.has_subevents %}
-                        <span class="label label-default">{% trans "Event series" %}</span>
+                        {% textbubble "info" icon="bars" %}
+                            {% trans "Event series" %}
+                        {% endtextbubble %}
                     {% elif e.presale_is_running and request.organizer.settings.event_list_availability %}
                         {% if e.best_availability_state == 100 %}
                             {% if e.best_availability_is_low %}
-                                <span class="label label-success-warning">{% trans "Few tickets left" %}</span>
+                                {% textbubble "success-warning" icon="exclamation-triangle" %}
+                                    {% trans "Few tickets left" %}
+                                {% endtextbubble %}
                             {% else %}
-                                {% if e.has_paid_item %}
-                                    <span class="label label-success">{% trans "Buy now" context "available_event_in_list" %}</span>
-                                {% else %}
-                                    <span class="label label-success">{% trans "Book now" %}</span>
-                                {% endif %}
+                                {% textbubble "success" icon="check" %}
+                                    {% if e.has_paid_item %}
+                                        {% trans "Buy now" context "available_event_in_list" %}
+                                    {% else %}
+                                        {% trans "Book now" %}
+                                    {% endif %}
+                                {% endtextbubble %}
                             {% endif %}
                         {% elif e.waiting_list_active and e.best_availability_state >= 0 %}
-                            <span class="label label-warning">{% trans "Waiting list" %}</span>
+                            {% textbubble "warning" icon="ellipsis-h" %}
+                                {% trans "Waiting list" %}
+                            {% endtextbubble %}
                         {% elif e.best_availability_state == 20 %}
-                            <span class="label label-danger">{% trans "Reserved" %}</span>
+                            {% textbubble "danger" icon="minus" %}
+                                {% trans "Reserved" %}
+                            {% endtextbubble %}
                         {% elif e.best_availability_state < 20 %}
-                            {% if e.has_paid_item %}
-                                <span class="label label-danger">{% trans "Sold out" %}</span>
-                            {% else %}
-                                <span class="label label-danger">{% trans "Fully booked" %}</span>
-                            {% endif %}
+                            {% textbubble "danger" icon="times" %}
+                                {% if e.has_paid_item %}
+                                    {% trans "Sold out" %}
+                                {% else %}
+                                    {% trans "Fully booked" %}
+                                {% endif %}
+                            {% endtextbubble %}
                         {% endif %}
                     {% elif e.presale_is_running %}
-                        <span class="label label-success">{% trans "Book now" %}</span>
+                        {% textbubble "success" icon="check" %}
+                            {% trans "Book now" %}
+                        {% endtextbubble %}
                     {% elif e.presale_has_ended %}
-                        <span class="label label-danger">{% trans "Sale over" %}</span>
+                        {% textbubble "danger" icon="times" %}
+                            {% trans "Sale over" %}
+                        {% endtextbubble %}
                     {% elif e.settings.presale_start_show_date %}
-                        <span class="label label-warning">
-                                {% blocktrans trimmed with date=e.effective_presale_start|date:"SHORT_DATE_FORMAT" %}
+                        {% textbubble "warning" icon="clock-o" %}
+                            {% with date_iso=e.effective_presale_start.isoformat date_human=e.effective_presale_start|date:"SHORT_DATE_FORMAT" %}
+                                {% blocktrans trimmed with date='<time datetime="'|add:date_iso|add:'">'|add:date_human|add:"</time>"|safe %}
                                     Sale starts {{ date }}
                                 {% endblocktrans %}
-                            </span>
+                            {% endwith %}
+                        {% endtextbubble %}
                     {% else %}
-                        <span class="label label-warning">{% trans "Not yet on sale" %}</span>
+                        {% textbubble "warning" icon="clock-o" %}
+                            {% trans "Not yet on sale" %}
+                        {% endtextbubble %}
                     {% endif %}
+                    </small>
                 </div>
                 <div class="col-md-2 col-xs-6 text-right flip">
                     <a class="btn btn-primary btn-block" href="{{ url }}{% if e.has_subevents and e.match_by_subevents %}{{ filterquery }}{% endif %}">
-                        {% if e.has_subevents %}<span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Tickets" %}
+                        {% if e.has_subevents %}{% icon "ticket" %} {% trans "Tickets" %}
                         {% elif e.presale_is_running and e.best_availability_state == 100 %}
-                            <span class="fa fa-ticket" aria-hidden="true"></span> {% trans "Tickets" %}
+                            {% icon "ticket" %} {% trans "Tickets" %}
                         {% else %}
-                            <span class="fa fa-info" aria-hidden="true"></span> {% trans "More info" %}
+                            {% icon "info" %} {% trans "More info" %}
                         {% endif %}
                     </a>
                 </div>

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -536,7 +536,7 @@ h2 .label {
 }
 
 
-.textbubble-success, .textbubble-info, .textbubble-warning, .textbubble-danger {
+.textbubble-success, .textbubble-success-warning, .textbubble-info, .textbubble-warning, .textbubble-danger {
   padding: 0 .4em;
   border-radius: $border-radius-base;
   font-weight: bold;
@@ -551,6 +551,13 @@ h2 .label {
   background: var(--pretix-brand-success-tint-85);
   .fa {
     color: var(--pretix-brand-success);
+  }
+}
+.textbubble-success-warning {
+  color: var(--pretix-brand-success-shade-42);
+  background: linear-gradient(to right, var(--pretix-brand-warning-tint-85), var(--pretix-brand-success-tint-85) 50%);
+  .fa {
+    color: var(--pretix-brand-warning);
   }
 }
 .textbubble-info {


### PR DESCRIPTION
This PR just changes from label to textbubble for better handling of color contrast. It also adds some icons, just because it looks nicer.

I am not sure about the wording though, especially „Book now“ is a call to action and not a status label and kind of asks to click the label – with textbubbles it is not that bad as they do not look so much like the button next to it, but it still kind of feels to much of a call to action. I would change the wording to „Available“ instead and maybe even change the text on the actual button from „Tickets“ to „Book now" although „Book now“ feels a little less strong/fitting IMHO.

Before 
![Bildschirmfoto 2024-12-06 um 12 11 03](https://github.com/user-attachments/assets/f34abb71-21ec-4727-8f4e-0a6fd8e14dc3)

After
![Bildschirmfoto 2024-12-06 um 12 21 19](https://github.com/user-attachments/assets/d67fa0f7-ea60-432d-b5dc-7ebe16ba4a08)

Forgot to add a screenshot of the new textbubble-success-warning:

![Bildschirmfoto 2024-12-06 um 12 29 35](https://github.com/user-attachments/assets/68e37aa3-331a-4404-838e-82b01f82206b)
