### PR TITLE
Fix organizer event list status overflow

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -53,7 +53,7 @@
         </div>
         {% for e in events %}{% eventurl e "presale:event.index" as url %}
             <div class="row">
-                <div class="col-md-5 col-xs-12">
+                <div class="col-md-4 col-xs-12">
                     <a href="{{ url }}">
                         <strong>
                             {{ e.name }}
@@ -87,7 +87,7 @@
                     {% endif %}
                     <td>
                 </div>
-                <div class="col-md-2 col-xs-6">
+                <div class="col-md-3 col-xs-6">
                     <small>
                     {% if e.has_subevents %}
                         {% textbubble "info" icon="bars" %}
@@ -133,18 +133,19 @@
                         {% textbubble "danger" icon="times" %}
                             {% trans "Sale over" %}
                         {% endtextbubble %}
-                    {% elif e.settings.presale_start_show_date %}
+                    {% else %}
                         {% textbubble "warning" icon="clock-o" %}
+                            {% trans "Not yet on sale" %}
+                        {% endtextbubble %}
+                        {% if e.settings.presale_start_show_date %}
+                            <br><span class="text-muted">
                             {% with date_iso=e.effective_presale_start.isoformat date_human=e.effective_presale_start|date:"SHORT_DATE_FORMAT" %}
                                 {% blocktrans trimmed with date='<time datetime="'|add:date_iso|add:'">'|add:date_human|add:"</time>"|safe %}
                                     Sale starts {{ date }}
                                 {% endblocktrans %}
                             {% endwith %}
-                        {% endtextbubble %}
-                    {% else %}
-                        {% textbubble "warning" icon="clock-o" %}
-                            {% trans "Not yet on sale" %}
-                        {% endtextbubble %}
+                            </span>
+                        {% endif %}
                     {% endif %}
                     </small>
                 </div>


### PR DESCRIPTION
When an event is planned to go on sale, the status-bubble is a very long text including the date, which causes overflow issues on smaller screens. This PR makes the column for the status-bubble a little wider and also moves the availability date in a new line that allows white-space to wrap. This now works down to about 360px width (so e.g. iPhone 6 upwards should  be fine – at least in german).

Before:
![Bildschirmfoto 2024-12-11 um 09 27 23](https://github.com/user-attachments/assets/34307ebf-1ee0-4ce5-9c70-8049a3db7c8e)
![Bildschirmfoto 2024-12-11 um 09 29 30](https://github.com/user-attachments/assets/d7f38187-1d0e-44b6-ba70-10d0b2cf762c)

After:
![Bildschirmfoto 2024-12-11 um 09 47 37](https://github.com/user-attachments/assets/555b14ef-c2ac-41c5-9a1f-5bedf6bbe664)
![Bildschirmfoto 2024-12-11 um 09 47 00](https://github.com/user-attachments/assets/519e778c-473f-48b3-bee4-6ad6d8609592)


 If we need to go lower to e.g. 320px, then we would need to dump the bootstrap-cols and do a combination of pull-left/pull-right and put the status-bubble and the btn-link in the same col-element. Actually works like a charm on very small screens, but we lose styling the button as btn-block so every button has the same width. Not sure it is worth it for these very very narrow screens. 

With pull-left/pull-right:

![Bildschirmfoto 2024-12-11 um 09 59 22](https://github.com/user-attachments/assets/112f174d-a1e3-460d-a46f-f6455b2dcfe6)
![Bildschirmfoto 2024-12-11 um 09 57 50](https://github.com/user-attachments/assets/59ad6719-0f4b-4ded-912f-384c92db6a85)

Currently the changes in this PR on 320px width cause a very small overflow (in german):
![Bildschirmfoto 2024-12-11 um 10 00 17](https://github.com/user-attachments/assets/4bb5b1ee-c3dc-4943-9409-0f71e1b22355)