### PR TITLE
Fix color differences for panel-heading in accordion-panel

### DIFF
--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -544,8 +544,6 @@ table td > .checkbox input[type="checkbox"] {
   margin: 0;
 }
 .panel-default>.accordion-radio>.panel-heading, fieldset.accordion-panel>legend>.panel-heading {
-  color: #333;
-  background-color: #f5f5f5;
   padding: 12px 15px;
 
   input[type=checkbox] {

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -136,8 +136,6 @@ a.btn, button.btn {
 }
 .panel-default>.accordion-radio>.panel-heading, fieldset.accordion-panel>legend>.panel-heading {
   display: block;
-  color: #333;
-  background-color: #f5f5f5;
   padding: 8px 15px;
   margin: 0;
   line-height: 1.428571429;


### PR DESCRIPTION
Somehow accordion-panels got lighter panel-headings than all other panel-default panel-headings.

Instead of setting the colors again, use the cascade on panel-default. I double checked, any `div.accordion-panel` also is `.panel.panel-default`, so no need to define colors in CSS twice.