### PR TITLE
Show percentage of discount in cart (Z#23176955)

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -3219,6 +3219,12 @@ class CartPosition(AbstractPosition):
             self.save(update_fields=['line_price_gross', 'tax_rate'])
 
     @property
+    def discount_percentage(self):
+        if not self.line_price_gross:
+            return 0
+        return (self.line_price_gross - self.price) / self.line_price_gross * 100
+
+    @property
     def addons_without_bundled(self):
         addons = [op for op in self.addons.all() if not op.is_bundled]
         return sorted(addons, key=lambda cp: cp.sort_key)

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -268,8 +268,15 @@
                         {% if line.discount and line.line_price_gross != line.price %}
                             <span class="text-success discounted" data-toggle="tooltip" title="{% trans "The price of this product was reduced because of an automatic discount." %}">
                                 <br>
-                                <span class="fa fa-percent fa-fw" aria-hidden="true"></span>
-                                {% trans "Discounted" %}
+                                <span class="fa fa-star fa-fw" aria-hidden="true"></span>
+                                {% if line.price < line.line_price_gross %}
+                                    {% widthratio line.price line.line_price_gross 100 as percent %}
+                                    {% blocktranslate trimmed with percent=percent %}
+                                        {{ percent }} % Discount
+                                    {% endblocktranslate %}
+                                {% else %}
+                                    {% trans "Discounted" %}
+                                {% endif %}
                             </span>
                         {% endif %}
                     </div>
@@ -335,8 +342,15 @@
                         {% if line.discount and line.line_price_gross != line.price %}
                             <span class="text-success discounted" data-toggle="tooltip" title="{% trans "The price of this product was reduced because of an automatic discount." %}">
                                 <br>
-                                <span class="fa fa-percent fa-fw" aria-hidden="true"></span>
-                                {% trans "Discounted" %}
+                                <span class="fa fa-star fa-fw" aria-hidden="true"></span>
+                                {% if line.price < line.line_price_gross %}
+                                    {% widthratio line.price line.line_price_gross 100 as percent %}
+                                    {% blocktranslate trimmed with percent=percent %}
+                                        {{ percent }} % Discount
+                                    {% endblocktranslate %}
+                                {% else %}
+                                    {% trans "Discounted" %}
+                                {% endif %}
                             </span>
                         {% endif %}
                     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -270,8 +270,7 @@
                                 <br>
                                 <span class="fa fa-star fa-fw" aria-hidden="true"></span>
                                 {% if line.price < line.line_price_gross %}
-                                    {% widthratio line.price line.line_price_gross 100 as percent %}
-                                    {% blocktranslate trimmed with percent=percent %}
+                                    {% blocktranslate trimmed with percent=line.discount_percentage|floatformat:0 %}
                                         {{ percent }} % Discount
                                     {% endblocktranslate %}
                                 {% else %}
@@ -344,8 +343,7 @@
                                 <br>
                                 <span class="fa fa-star fa-fw" aria-hidden="true"></span>
                                 {% if line.price < line.line_price_gross %}
-                                    {% widthratio line.price line.line_price_gross 100 as percent %}
-                                    {% blocktranslate trimmed with percent=percent %}
+                                    {% blocktranslate trimmed with percent=line.discount_percentage|floatformat:0 %}
                                         {{ percent }} % Discount
                                     {% endblocktranslate %}
                                 {% else %}


### PR DESCRIPTION
Simple approach to reassure customers they got the expected discount.

- I decided against showing the original price, since then we'll get into discussions about `listed_price` vs `original_price` and pre-voucher vs post-voucher. This way, it's showing the percentage given by the discount rule and hopefully no-one will care about these details.
- I switched the icons because it looked weird otherwise: "% 50 % discount".