### PR TITLE
Name order and Examples Defined in PERSON_NAME_SCHEMES, Adaption to Japanese addressing system

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3609,8 +3609,8 @@ PERSON_NAME_SCHEMES = OrderedDict([
         'concatenation': lambda d: str(d.get('full_name', '')),
         'concatenation_all_components': lambda d: str(d.get('full_name', '')) + " (" + d.get('latin_transcription', '') + ")",
         'sample': {
-            'full_name': '明仁',
-            'latin_transcription': 'Akihito',
+            'full_name': 'Aye',
+            'latin_transcription': 'Aye',
             '_scheme': 'full_transcription',
         },
     }),

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3557,8 +3557,8 @@ PERSON_NAME_SCHEMES = OrderedDict([
             str(p) for p in [d.get('family_name', ''), d.get('given_name', '')] if p
         ),
         'sample': {
-            'given_name': '泽东',
-            'family_name': '毛',
+            'family_name': '孫',
+            'given_name': '文',
             '_scheme': 'family_nospace_given',
         },
     }),
@@ -3609,8 +3609,8 @@ PERSON_NAME_SCHEMES = OrderedDict([
         'concatenation': lambda d: str(d.get('full_name', '')),
         'concatenation_all_components': lambda d: str(d.get('full_name', '')) + " (" + d.get('latin_transcription', '') + ")",
         'sample': {
-            'full_name': '庄司',
-            'latin_transcription': 'Shōji',
+            'full_name': '明仁',
+            'latin_transcription': 'Akihito',
             '_scheme': 'full_transcription',
         },
     }),

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3609,8 +3609,8 @@ PERSON_NAME_SCHEMES = OrderedDict([
         'concatenation': lambda d: str(d.get('full_name', '')),
         'concatenation_all_components': lambda d: str(d.get('full_name', '')) + " (" + d.get('latin_transcription', '') + ")",
         'sample': {
-            'full_name': 'Aye',
-            'latin_transcription': 'Aye',
+            'full_name': '山田花子',
+            'latin_transcription': 'Yamada Hanako',
             '_scheme': 'full_transcription',
         },
     }),

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3701,6 +3701,7 @@ COUNTRIES_WITH_STATE_IN_ADDRESS = {
     'BR': (['State'], 'short'),
     'CA': (['Province', 'Territory'], 'short'),
     # 'CN': (['Province', 'Autonomous region', 'Munincipality'], 'long'),
+    'JP': (['Prefecture'], 'long'),
     'MY': (['State', 'Federal territory'], 'long'),
     'MX': (['State', 'Federal district'], 'short'),
     'US': (['State', 'Outlying area', 'District'], 'short'),


### PR DESCRIPTION
The reasons for the corrections are as follows:

### "family_nospace_given" is incorrectly defined as having the order of “given name, family name,” with the example of “毛泽东” (Mao Zedong) written in simplified Chinese characters.

This results in names being displayed as “泽东毛” (phonetically "ZedongMao"), which is inconsistent with the example and opposite to the name order in cultural contexts where Chinese characters are used.

Furthermore, using the simplified Chinese version of “毛泽东” may be difficult to understand in regions that do not use simplified characters. (Simplified Chinese is used primarily in Mainland China and Singapore.)  Additionally, the name of a leader of the Chinese Communist Party may be considered inappropriate in some regions.

I propose replacing this example with “孫文” (Sun Wen, the official name of “Sun Yat-sen”).

The characters in this name are identical in both simplified and traditional Chinese, and they also match the character style used in Hong Kong, Macao, Japan (Kanji) and Korea (Hanja). Moreover, Sun Yat-sen is regarded as the “Father of the Nation” in both mainland China and Taiwan and is generally recognized as a politically neutral figure.

### "full_transcription" currently lists “庄司” (Shoji) as an example of a full name, but this is clearly incorrect.

“庄司” is the kanji representation of a Japanese surname "Shoji" and is not a full name. According to Japanese law, a full name must include both a family name and a given name. The only exception to this rule applies to members of the Imperial Family.

Therefore, I suggest revising the example to “明仁” (Akihito, Emperor Emeritus of Japan).

It should also be noted that in some regions of Asia, legal names consist only of given names without surnames. If pretix plans to support languages from such regions in the future, it would be more appropriate to use examples of full names from those languages in this section. (e.g., Burmese, traditional Mongolian, Javanese, etc.)

![スクリーンショット 2025-01-01 3 16 45](https://github.com/user-attachments/assets/a9ff8145-b1ce-4b6c-9806-9272dc038ece)
![スクリーンショット 2025-01-01 3 17 50](https://github.com/user-attachments/assets/8c39687b-0bdb-4cfb-94cd-d0a715235193)
