### PR TITLE
make "Show in backend" button on ticket pages available on custom domains

### DIFF
--- a/src/pretix/base/auth.py
+++ b/src/pretix/base/auth.py
@@ -222,3 +222,14 @@ class HistoryPasswordValidator:
         user.historic_passwords.filter(
             pk__in=user.historic_passwords.order_by("-created")[self.history_length:].values_list("pk", flat=True),
         ).delete()
+
+def has_event_access_permission(request, permission = 'can_change_event_settings'):
+    return (
+        request.user.is_authenticated and
+        request.user.has_event_permission(request.organizer, request.event, permission, request=request)
+    ) or (
+        getattr(request, 'event_access_user', None) and
+        request.event_access_user.is_authenticated and
+        request.event_access_user.has_event_permission(request.organizer, request.event, permission,
+                                                       session_key=request.event_access_parent_session_key)
+    )

--- a/src/pretix/base/auth.py
+++ b/src/pretix/base/auth.py
@@ -223,7 +223,8 @@ class HistoryPasswordValidator:
             pk__in=user.historic_passwords.order_by("-created")[self.history_length:].values_list("pk", flat=True),
         ).delete()
 
-def has_event_access_permission(request, permission = 'can_change_event_settings'):
+
+def has_event_access_permission(request, permission='can_change_event_settings'):
     return (
         request.user.is_authenticated and
         request.user.has_event_permission(request.organizer, request.event, permission, request=request)

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -63,6 +63,7 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 
+from pretix.base.auth import has_event_access_permission
 from pretix.base.forms.widgets import SplitDateTimePickerWidget
 from pretix.base.models import (
     ItemVariation, Quota, SalesChannel, SeatCategoryMapping, Voucher,
@@ -87,7 +88,6 @@ from pretix.presale.views.organizer import (
     filter_qs_by_attr, has_before_after, weeks_for_template,
 )
 
-from pretix.base.auth import has_event_access_permission
 from . import (
     CartMixin, EventViewMixin, allow_frame_if_namespaced, get_cart,
     iframe_entry_view_wrapper,

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -73,9 +73,7 @@ from pretix.base.models.items import (
 )
 from pretix.base.services.placeholders import PlaceholderContext
 from pretix.base.services.quotas import QuotaAvailability
-from pretix.base.timemachine import (
-    has_time_machine_permission, time_machine_now,
-)
+from pretix.base.timemachine import time_machine_now
 from pretix.helpers.compat import date_fromisocalendar
 from pretix.helpers.formats.en.formats import (
     SHORT_MONTH_DAY_FORMAT, WEEK_FORMAT,
@@ -89,6 +87,7 @@ from pretix.presale.views.organizer import (
     filter_qs_by_attr, has_before_after, weeks_for_template,
 )
 
+from pretix.base.auth import has_event_access_permission
 from . import (
     CartMixin, EventViewMixin, allow_frame_if_namespaced, get_cart,
     iframe_entry_view_wrapper,
@@ -963,7 +962,7 @@ class EventTimeMachine(EventViewMixin, TemplateView):
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
-        if not has_time_machine_permission(request, request.event):
+        if not has_event_access_permission(request):
             raise PermissionDenied(_('You are not allowed to access time machine mode.'))
         if not request.event.testmode:
             raise PermissionDenied(_('This feature is only available in test mode.'))

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -70,6 +70,7 @@ from pretix.base.models.orders import (
 )
 from pretix.base.models.tax import TaxedPrice
 from pretix.base.payment import PaymentException
+from pretix.base.auth import has_event_access_permission
 from pretix.base.services.invoices import (
     generate_cancellation, generate_invoice, invoice_pdf, invoice_pdf_task,
     invoice_qualified,
@@ -205,10 +206,8 @@ class TicketPageMixin:
 
         ctx['download_buttons'] = self.download_buttons
 
-        ctx['backend_user'] = (
-            self.request.user.is_authenticated
-            and self.request.user.has_event_permission(self.request.organizer, self.request.event, 'can_view_orders', request=self.request)
-        )
+        ctx['backend_user'] = has_event_access_permission(self.request, 'can_view_orders')
+
         return ctx
 
     @cached_property

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -60,6 +60,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import ListView, TemplateView, View
 
+from pretix.base.auth import has_event_access_permission
 from pretix.base.models import (
     CachedTicket, Checkin, GiftCard, Invoice, Order, OrderPosition, Quota,
     TaxRule,
@@ -70,7 +71,6 @@ from pretix.base.models.orders import (
 )
 from pretix.base.models.tax import TaxedPrice
 from pretix.base.payment import PaymentException
-from pretix.base.auth import has_event_access_permission
 from pretix.base.services.invoices import (
     generate_cancellation, generate_invoice, invoice_pdf, invoice_pdf_task,
     invoice_qualified,


### PR DESCRIPTION
This button is currently missing on custom domains:

![image](https://github.com/user-attachments/assets/af3038be-edbf-470c-964f-081cdb64c9bc)

With this PR, we use the `pretix_event_access` cross-domain session, if available, to determine whether the user is logged into a backend session with `can_view_orders` permission  to show th button if appropriate.