### PR TITLE
[a11y] Remove h1 aria-label in presale

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -82,17 +82,17 @@
             {% endif %}
             {% if event_logo and event_logo_image_large %}
                 <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}"
-                   aria-label="{% trans 'Homepage' %}" title="{% trans 'Homepage' %}">
+                   title="{% trans 'Homepage' %}">
                     <img src="{{ event_logo|thumb:'1170x5000' }}" alt="{{ event.name }}" class="event-logo" />
                 </a>
             {% elif event_logo %}
                 <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}"
-                   aria-label="{% trans 'Homepage' %}" title="{% trans 'Homepage' %}">
+                   title="{% trans 'Homepage' %}">
                     <img src="{{ event_logo|thumb:'5000x120' }}" alt="{{ event.name }}" class="event-logo" />
                 </a>
             {% else %}
                 <h1>
-                    <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}" aria-label="{% trans 'Homepage' %}">{{ event.name }}</a>
+                    <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}">{{ event.name }}</a>
                     {% if request.event.settings.show_dates_on_frontpage and not event.has_subevents %}
                         <small>{{ event.get_date_range_display_as_html }}</small>
                     {% endif %}


### PR DESCRIPTION
Micro adjustment from a11y-audit – link text and label should be the same otherwise it is a „barrier“. The label does not add value to understanding what or where the link leads to, so can and should be removed.