### PR TITLE
Invoice rendering: Remove transparency from logos (Z#23179391)

### DIFF
--- a/src/pretix/base/invoice.py
+++ b/src/pretix/base/invoice.py
@@ -389,6 +389,10 @@ class ClassicInvoiceRenderer(BaseReportlabInvoiceRenderer):
                 logger.exception("Can not resize image")
                 pass
             try:
+                # Valid ZUGFeRD invoices must be compliant with PDF/A-3. pretix-zugferd ensures this by passing them
+                # through ghost script. Unfortunately, if the logo contains transparency, this will still fail.
+                # I was unable to figure out a way to fix this in GhostScript, so the easy fix is to remove the
+                # transparency, as our invoices always have a white background anyways.
                 ir.remove_transparency()
             except:
                 logger.exception("Can not remove transparency from logo")

--- a/src/pretix/base/invoice.py
+++ b/src/pretix/base/invoice.py
@@ -388,6 +388,11 @@ class ClassicInvoiceRenderer(BaseReportlabInvoiceRenderer):
             except:
                 logger.exception("Can not resize image")
                 pass
+            try:
+                ir.remove_transparency()
+            except:
+                logger.exception("Can not remove transparency from logo")
+                pass
             canvas.drawImage(ir,
                              self.logo_left,
                              self.pagesize[1] - self.logo_height - self.logo_top,

--- a/src/pretix/helpers/reportlab.py
+++ b/src/pretix/helpers/reportlab.py
@@ -39,6 +39,12 @@ class ThumbnailingImageReader(ImageReader):
         self._data = None
         return width, height
 
+    def remove_transparency(self, background_color="WHITE"):
+        if "A" in self._image.mode:
+            new_image = Image.new("RGBA", self._image.size, background_color)
+            new_image.paste(self._image, mask=self._image)
+            self._image = new_image.convert("RGB")
+
     def _jpeg_fh(self):
         # Bypass a reportlab-internal optimization that falls back to the original
         # file handle if the file is a JPEG, and therefore does not respect the


### PR DESCRIPTION
Valid ZUGFeRD invoices must be compliant with PDF/A-3. pretix-zugferd ensures this by passing them through ghost script. Unfortunately, if the logo contains transparency, this will still fail with:

```
      <validationReport jobEndStatus="normal" profileName="PDF/A-3B validation profile" statement="PDF file is not compliant with Validation Profile requirements." isCompliant="false">
        <details passedRules="144" failedRules="1" passedChecks="4239" failedChecks="1">
          <rule specification="ISO 19005-3:2012" clause="6.2.10" testNumber="2" status="failed" failedChecks="1">
            <description>If the document does not contain a PDF/A OutputIntent, then all Page objects that contain transparency shall include the Group key, and the attribute dictionary that forms the value of that Group key shall include a CS entry whose value shall be used as the default blending colour space</description>
            <object>PDPage</object>
            <test>gOutputCS != null || containsGroupCS == true || containsTransparency == false</test>
            <check status="failed">
              <context>root/document[0]/pages[0](4 0 obj PDPage)</context>
              <errorMessage>The page contains transparent objects with no blending colour space defined</errorMessage>
            </check>
          </rule>
        </details>
      </validationReport>
```

I was unable to figure out a way to fix this in GhostScript, so the easy fix is to remove the transparency, as our invoices always have a white background anyways.