### PR TITLE
MetricsMiddleware: Do not record pretix_view_duration_seconds for urls with no url.url_name

### DIFF
--- a/src/pretix/helpers/metrics/middleware.py
+++ b/src/pretix/helpers/metrics/middleware.py
@@ -62,7 +62,8 @@ class MetricsMiddleware(object):
         t0 = time.perf_counter()
         resp = self.get_response(request)
         tdiff = time.perf_counter() - t0
-        pretix_view_duration_seconds.observe(tdiff, status_code=resp.status_code, method=request.method,
-                                             url_name=url.namespace + ':' + url.url_name)
+        if url.url_name:
+            pretix_view_duration_seconds.observe(tdiff, status_code=resp.status_code, method=request.method,
+                                                 url_name=url.namespace + ':' + url.url_name)
 
         return resp


### PR DESCRIPTION
For some time now, I was able to observe on my local dev instance, that uploaded files (such as header graphics, background-PDFs, etc.) were not accessible and the server instead returned a `TypeError` like this:

> TypeError at /media/pub/thumbs/2dc3b4bbad87f9fea81f2d60919157ea.5000x120_iUpmgGG.jpeg
> can only concatenate str (not "NoneType") to str

This is caused when `url.url_name` is none - in those cases, the `url.namespace` will probably be empty too and thus I am not sure how much the logging makes sense...

This fixes the issue for me, but I am not sure this is the best way to handle this.

I would also assume that this bug is only an issue in Dev-environments, since we normally serve the `/media/`-folder through a reverse proxy where the requests would never touch the server-runner...
