### PR TITLE
[A11y] Test for autofocus tabindex UX

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/dashboard.html
+++ b/src/pretix/control/templates/pretixcontrol/dashboard.html
@@ -7,7 +7,7 @@
     <div class="dropdown-container">
         <input type="text" class="form-control" id="dashboard_query"
                 placeholder="{% trans "Go to event" %}"
-                data-typeahead-query autofocus>
+                data-typeahead-query tabindex="1" autofocus>
         <ul data-event-typeahead data-source="{% url "control:nav.typeahead" %}" data-typeahead-field="#dashboard_query"
                 class="event-dropdown dropdown-menu">
         </ul>


### PR DESCRIPTION
We currently use autofocus quite extensively on search-inputs inside pretix-control. This has some UX-impliciations especially regarding accessibility and is most of the time not recommended as the autofocused input usually lies after the main navigation and by that skips important content for e.g. screen-reader users.

Removing autofocus would be the right thing to do, but this adds a layer of friction for users that are used to it – e.g. on the dashboard after login you can just start typing to search for your events.

This PR gives an easy way to test keeping the autofocus, but moving the autofocused input to the start of the tab-queue by using tabindex.

I am personally unsure, whether that is the right thing to do as it messes the tab-order with the visual hierarchy/order of items.

A different and probably way to over-engineered way would be, that – until a click or tab-key happened – we listen to keystrokes and move focus to the e.g. search-input, so that kind of mimicks autofocus? But this feels like so much magic, I am not sure it is worth it.