### PR TITLE
OIDC: Allow to add query parameters to Authorization URL

### DIFF
--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -140,16 +140,9 @@ def oidc_validate_and_complete_config(config):
             )
 
     if "query_parameters" in config and config["query_parameters"]:
-        for qp in config["query_parameters"].split("&"):
-            # Very rudimentary check to avoid the most common footguns:
-            # - No ? in the query parameters
-            # - Max of one = (to split key and value)
-            # - One key, one value. Not just keys with no value.
-            if not (qp.count('=') == 1 and qp.count('?') == 0 and len(list(filter(None, qp.split('=')))) == 2):
-                raise ValidationError(
-                    _(f'Query parameter {qp} is invalid.')
-                )
-
+         config["query_parameters"] = urllib.parse.urlencode(
+             urllib.parse.parse_qsl(config["query_parameters"])
+         )
     config['provider_config'] = provider_config
     return config
 
@@ -167,8 +160,7 @@ def oidc_authorize_url(provider, state, redirect_uri):
     }
 
     if "query_parameters" in provider.configuration and provider.configuration["query_parameters"]:
-        for qp in provider.configuration["query_parameters"].split("&"):
-            params[qp.split("=")[0]] = qp.split("=")[1]
+        params.update(urllib.parse.parse_qsl(provider.configuration["query_parameters"]))
 
     return endpoint + '?' + urlencode(params)
 

--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -24,7 +24,7 @@ import hashlib
 import logging
 import time
 from datetime import datetime
-from urllib.parse import urlencode, urljoin, parse_qsl
+from urllib.parse import parse_qsl, urlencode, urljoin
 
 import jwt
 import requests

--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -143,6 +143,7 @@ def oidc_validate_and_complete_config(config):
         config["query_parameters"] = urlencode(
             parse_qsl(config["query_parameters"])
         )
+
     config['provider_config'] = provider_config
     return config
 

--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -143,7 +143,7 @@ def oidc_validate_and_complete_config(config):
         config["query_parameters"] = urlencode(
             parse_qsl(config["query_parameters"])
         )
-        config['provider_config'] = provider_config
+    config['provider_config'] = provider_config
     return config
 
 

--- a/src/pretix/base/customersso/oidc.py
+++ b/src/pretix/base/customersso/oidc.py
@@ -24,7 +24,7 @@ import hashlib
 import logging
 import time
 from datetime import datetime
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, parse_qsl
 
 import jwt
 import requests
@@ -140,10 +140,10 @@ def oidc_validate_and_complete_config(config):
             )
 
     if "query_parameters" in config and config["query_parameters"]:
-         config["query_parameters"] = urllib.parse.urlencode(
-             urllib.parse.parse_qsl(config["query_parameters"])
-         )
-    config['provider_config'] = provider_config
+        config["query_parameters"] = urlencode(
+            parse_qsl(config["query_parameters"])
+        )
+        config['provider_config'] = provider_config
     return config
 
 
@@ -160,7 +160,7 @@ def oidc_authorize_url(provider, state, redirect_uri):
     }
 
     if "query_parameters" in provider.configuration and provider.configuration["query_parameters"]:
-        params.update(urllib.parse.parse_qsl(provider.configuration["query_parameters"]))
+        params.update(parse_qsl(provider.configuration["query_parameters"]))
 
     return endpoint + '?' + urlencode(params)
 

--- a/src/pretix/control/forms/organizer.py
+++ b/src/pretix/control/forms/organizer.py
@@ -1043,6 +1043,15 @@ class SSOProviderForm(I18nModelForm):
         label=pgettext_lazy('sso_oidc', 'Phone field'),
         required=False,
     )
+    config_oidc_query_parameters = forms.CharField(
+        label=pgettext_lazy('sso_oidc', 'Query parameters'),
+        help_text=pgettext_lazy('sso_oidc', 'Optional query parameters, that will be added to calls to '
+                                            'the authorization endpoint. Enter as: {example}'.format(
+                                                example='<code>param1=value1&amp;param2=value2</code>'
+                                            ),
+                                ),
+        required=False,
+    )
 
     class Meta:
         model = CustomerSSOProvider


### PR DESCRIPTION
Z#23180758

I guess, we could also just blindly append the `query_parameters` to the URL and assume that everything has already been properly urlencoded... But this seems safer...