### PR TITLE
[A11y] Improve focus management + navigation in widget ajax

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1519,17 +1519,17 @@ Vue.component('pretix-widget-event-calendar', {
 
         // Calendar navigation
         + '<div class="pretix-widget-event-calendar-head">'
-        + '<a class="pretix-widget-event-calendar-previous-month" href="#" @click.prevent.stop="prevmonth" role="button">&laquo; '
+        + '<a class="pretix-widget-event-calendar-previous-month" :href="prev_href" @click.prevent.stop="prevmonth">&laquo; '
         + strings['previous_month']
         + '</a> '
         + '<strong>{{ monthname }}</strong> '
-        + '<a class="pretix-widget-event-calendar-next-month" href="#" @click.prevent.stop="nextmonth" role="button">'
+        + '<a class="pretix-widget-event-calendar-next-month" :href="next_href" @click.prevent.stop="nextmonth">'
         + strings['next_month']
         + ' &raquo;</a>'
         + '</div>'
 
         // Calendar
-        + '<table class="pretix-widget-event-calendar-table">'
+        + '<table class="pretix-widget-event-calendar-table" :id="id" tabindex="0">'
         + '<thead>'
         + '<tr>'
         + '<th>' + strings['days']['MO'] + '</th>'
@@ -1552,7 +1552,41 @@ Vue.component('pretix-widget-event-calendar', {
         },
         monthname: function () {
             return strings['months'][this.$root.date.substr(5, 2)] + ' ' + this.$root.date.substr(0, 4);
-        }
+        },
+        month: function () {
+            return parseInt(this.$root.date.substr(5, 2));
+        },
+        year: function () {
+            return parseInt(this.$root.date.substr(0, 4));
+        },
+        prev_month_date: function () {
+            var pm = this.month - 1;
+            return String(this.year - (pm ? 0 : 1)) + "-" + padNumber((pm || 12), 2);
+        },
+        next_month_date: function () {
+            var pm = this.month + 1;
+            return String(this.year + (pm > 12 ? 1 : 0)) + "-" + padNumber(pm % 12, 2);
+        },
+        id: function () {
+            return this.$root.html_id + "-event-calendar-table";
+        },
+        base_href: function () {
+            return this.$root.event?.event_url || this.$root.target_url;
+        },
+        prev_href: function () {
+            return [
+                this.base_href,
+                '?style=calendar&date=',
+                this.prev_month_date
+            ].join('');
+        },
+        next_href: function () {
+            return [
+                this.base_href,
+                '?style=calendar&date=',
+                this.next_month_date
+            ].join('');
+        },
     },
     methods: {
         back_to_list: function () {
@@ -1562,28 +1596,14 @@ Vue.component('pretix-widget-event-calendar', {
             this.$root.frontpage_text = null;
         },
         prevmonth: function () {
-            var curMonth = parseInt(this.$root.date.substr(5, 2));
-            var curYear = parseInt(this.$root.date.substr(0, 4));
-            curMonth--;
-            if (curMonth < 1) {
-                curMonth = 12;
-                curYear--;
-            }
-            this.$root.date = String(curYear) + "-" + padNumber(curMonth, 2) + "-01";
+            this.$root.date = this.prev_month_date + "-01";
             this.$root.loading++;
-            this.$root.reload();
+            this.$root.reload({focus: '#'+this.id});
         },
         nextmonth: function () {
-            var curMonth = parseInt(this.$root.date.substr(5, 2));
-            var curYear = parseInt(this.$root.date.substr(0, 4));
-            curMonth++;
-            if (curMonth > 12) {
-                curMonth = 1;
-                curYear++;
-            }
-            this.$root.date = String(curYear) + "-" + padNumber(curMonth, 2) + "-01";
+            this.$root.date = this.next_month_date + "-01";
             this.$root.loading++;
-            this.$root.reload();
+            this.$root.reload({focus: '#'+this.id});
         }
     },
 });

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1332,7 +1332,7 @@ Vue.component('pretix-widget-event-list', {
 });
 
 Vue.component('pretix-widget-event-calendar-event', {
-    template: ('<a :href="href" :class="classObject" @click.prevent.stop="select">'
+    template: ('<a :href="href" :class="classObject" @click.prevent.stop="select" v-bind:aria-describedby="describedby">'
         + '<strong class="pretix-widget-event-calendar-event-name">'
         + '{{ event.name }}'
         + '</strong>'
@@ -1340,7 +1340,8 @@ Vue.component('pretix-widget-event-calendar-event', {
         + '<div class="pretix-widget-event-calendar-event-availability" v-if="!event.continued && event.availability.text">{{ event.availability.text }}</div>'
         + '</a>'),
     props: {
-        event: Object
+        event: Object,
+        describedby: String,
     },
     computed: {
         href: function () {
@@ -1371,11 +1372,11 @@ Vue.component('pretix-widget-event-calendar-event', {
 
 Vue.component('pretix-widget-event-week-cell', {
     template: ('<div :class="classObject" @click.prevent.stop="selectDay">'
-        + '<div class="pretix-widget-event-calendar-day" v-if="day">'
+        + '<div class="pretix-widget-event-calendar-day" v-if="day" :id="id">'
         + '{{ dayhead }}'
         + '</div>'
         + '<div class="pretix-widget-event-calendar-events" v-if="day">'
-        + '<pretix-widget-event-calendar-event v-for="e in day.events" :event="e"></pretix-widget-event-calendar-event>'
+        + '<pretix-widget-event-calendar-event v-for="e in day.events" :event="e" :describedby="id"></pretix-widget-event-calendar-event>'
         + '</div>'
         + '</div>'),
     props: {
@@ -1401,6 +1402,9 @@ Vue.component('pretix-widget-event-week-cell', {
         }
     },
     computed: {
+        id: function () {
+            return this.day ? this.$root.html_id + '-' + this.day.date : '';
+        },
         dayhead: function () {
             if (!this.day) {
                 return;

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1154,6 +1154,12 @@ Vue.component('pretix-widget-event-form', {
             } else {
                 this.$root.view = "weeks";
             }
+
+            var $el = this.$root.$el;
+            this.$root.$nextTick(function() {
+                // wait for redraw, then focus content element for better a11y
+                $el.focus();
+            });
         },
         calculate_buy_disabled: function() {
             var i, j, k;
@@ -1286,6 +1292,10 @@ Vue.component('pretix-widget-event-list', {
     },
     methods: {
         back_to_calendar: function () {
+            // make sure to always focus content element
+            this.$nextTick(function () {
+                this.$root.$el.focus();
+            });
             this.$root.offset = 0;
             this.$root.append_events = false;
             if (this.$root.weeks) {
@@ -1657,7 +1667,7 @@ Vue.component('pretix-widget-event-week-calendar', {
 });
 
 Vue.component('pretix-widget', {
-    template: ('<div class="pretix-widget-wrapper" ref="wrapper">'
+    template: ('<div class="pretix-widget-wrapper" ref="wrapper" tabindex="0">'
         + '<div :class="classObject">'
         + shared_loading_fragment
         + '<div class="pretix-widget-error-message" v-if="$root.error && $root.view !== \'event\'">{{ $root.error }}</div>'
@@ -1883,6 +1893,15 @@ var shared_root_methods = {
                 // If we're on desktop and someone selects a seating-only event in a calendar, let's open it right away,
                 // but only if the person didn't close it before.
                 root.startseating()
+            } else {
+                // make sure to only move focus to content element when it had focus before the reload/click
+                // this is needed because reload is also called on initial load and we do not want to move focus on initial load
+                if (root.$el.contains(document.activeElement)) {
+                    root.$nextTick(function() {
+                        // wait for redraw, then focus content element for better a11y
+                        root.$el.focus();
+                    });
+                }
             }
         }, function (error) {
             root.categories = [];

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1532,7 +1532,7 @@ Vue.component('pretix-widget-event-calendar', {
         + '</div>'
 
         // Calendar
-        + '<table class="pretix-widget-event-calendar-table" :id="id" tabindex="0">'
+        + '<table class="pretix-widget-event-calendar-table" :id="id" tabindex="0" v-bind:aria-label="monthname">'
         + '<thead>'
         + '<tr>'
         + '<th>' + strings['days']['MO'] + '</th>'
@@ -1641,7 +1641,7 @@ Vue.component('pretix-widget-event-week-calendar', {
         + '</div>'
 
         // Actual calendar
-        + '<div class="pretix-widget-event-week-table" :id="id" tabindex="0">'
+        + '<div class="pretix-widget-event-week-table" :id="id" tabindex="0" v-bind:aria-label="weekname">'
         + '<div class="pretix-widget-event-week-col" v-for="d in $root.days">'
         + '<pretix-widget-event-week-cell :day="d">'
         + '</pretix-widget-event-week-cell>'

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1143,6 +1143,11 @@ Vue.component('pretix-widget-event-form', {
         back_to_list: function() {
             this.$root.target_url = this.$root.parent_stack.pop();
             this.$root.error = null;
+            if (!this.$root.subevent) {
+                // reset if we are not in a series
+                this.$root.name = null;
+                this.$root.frontpage_text = null;
+            }
             this.$root.subevent = null;
             this.$root.offset = 0;
             this.$root.append_events = false;

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1098,7 +1098,7 @@ Vue.component('pretix-widget-event-form', {
     },
     computed: {
         href: function () {
-            return this.$root.$weeks ? this.$root.event.event_url : this.$root.parent_stack[this.$root.parent_stack.length-1];
+            return this.$root.event?.event_url || this.$root.parent_stack[this.$root.parent_stack.length-1];
         },
         display_event_info: function () {
             return this.$root.display_event_info || (this.$root.display_event_info === null && (this.$root.events || this.$root.weeks || this.$root.days));

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1781,7 +1781,7 @@ var shared_root_methods = {
             }
         });
     },
-    reload: function () {
+    reload: function (opt) {
         var url;
         if (this.$root.is_button) {
             return;
@@ -1904,7 +1904,7 @@ var shared_root_methods = {
                 if (root.$el.contains(document.activeElement)) {
                     root.$nextTick(function() {
                         // wait for redraw, then focus content element for better a11y
-                        root.$el.focus();
+                        (opt.focus ? document.querySelector(opt.focus) : root.$el).focus();
                     });
                 }
             }

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -77,6 +77,13 @@ var strings = {
         'FR': django.gettext('Fr'),
         'SA': django.gettext('Sa'),
         'SU': django.gettext('Su'),
+        'MONDAY': django.gettext('Monday'),
+        'TUESDAY': django.gettext('Tuesday'),
+        'WEDNESDAY': django.gettext('Wednesday'),
+        'THURSDAY': django.gettext('Thursday'),
+        'FRIDAY': django.gettext('Friday'),
+        'SATURDAY': django.gettext('Saturday'),
+        'SUNDAY': django.gettext('Sunday'),
     },
     'months': {
         '01': django.gettext('January'),
@@ -1429,7 +1436,7 @@ Vue.component('pretix-widget-event-week-cell', {
 
 Vue.component('pretix-widget-event-calendar-cell', {
     template: ('<td :class="classObject" @click.prevent.stop="selectDay">'
-        + '<div class="pretix-widget-event-calendar-day" v-if="day">'
+        + '<div class="pretix-widget-event-calendar-day" v-if="day" v-bind:aria-label="date">'
         + '{{ daynum }}'
         + '</div>'
         + '<div class="pretix-widget-event-calendar-events" v-if="day">'
@@ -1464,6 +1471,9 @@ Vue.component('pretix-widget-event-calendar-cell', {
                 return;
             }
             return this.day.date.substr(8);
+        },
+        date: function () {
+            return this.day ? (new Date(this.day.date)).toLocaleDateString() : '';
         },
         classObject: function () {
             var o = {};
@@ -1535,13 +1545,13 @@ Vue.component('pretix-widget-event-calendar', {
         + '<table class="pretix-widget-event-calendar-table" :id="id" tabindex="0" v-bind:aria-label="monthname">'
         + '<thead>'
         + '<tr>'
-        + '<th>' + strings['days']['MO'] + '</th>'
-        + '<th>' + strings['days']['TU'] + '</th>'
-        + '<th>' + strings['days']['WE'] + '</th>'
-        + '<th>' + strings['days']['TH'] + '</th>'
-        + '<th>' + strings['days']['FR'] + '</th>'
-        + '<th>' + strings['days']['SA'] + '</th>'
-        + '<th>' + strings['days']['SU'] + '</th>'
+        + '<th aria-label="' + strings['days']['MONDAY'] + '">' + strings['days']['MO'] + '</th>'
+        + '<th aria-label="' + strings['days']['TUESDAY'] + '">' + strings['days']['TU'] + '</th>'
+        + '<th aria-label="' + strings['days']['WEDNESDAY'] + '">' + strings['days']['WE'] + '</th>'
+        + '<th aria-label="' + strings['days']['THURSDAY'] + '">' + strings['days']['TH'] + '</th>'
+        + '<th aria-label="' + strings['days']['FRIDAY'] + '">' + strings['days']['FR'] + '</th>'
+        + '<th aria-label="' + strings['days']['SATURDAY'] + '">' + strings['days']['SA'] + '</th>'
+        + '<th aria-label="' + strings['days']['SUNDAY'] + '">' + strings['days']['SU'] + '</th>'
         + '</tr>'
         + '</thead>'
         + '<tbody>'

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1570,12 +1570,26 @@ Vue.component('pretix-widget-event-calendar', {
             this.$root.frontpage_text = null;
         },
         prevmonth: function () {
-            this.$root.date = this.prev_month_date + "-01";
+            var curMonth = parseInt(this.$root.date.substr(5, 2));
+            var curYear = parseInt(this.$root.date.substr(0, 4));
+            curMonth--;
+            if (curMonth < 1) {
+                curMonth = 12;
+                curYear--;
+            }
+            this.$root.date = String(curYear) + "-" + padNumber(curMonth, 2) + "-01";
             this.$root.loading++;
             this.$root.reload({focus: '#'+this.id});
         },
         nextmonth: function () {
-            this.$root.date = this.next_month_date + "-01";
+            var curMonth = parseInt(this.$root.date.substr(5, 2));
+            var curYear = parseInt(this.$root.date.substr(0, 4));
+            curMonth++;
+            if (curMonth > 12) {
+                curMonth = 1;
+                curYear++;
+            }
+            this.$root.date = String(curYear) + "-" + padNumber(curMonth, 2) + "-01";
             this.$root.loading++;
             this.$root.reload({focus: '#'+this.id});
         }

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1625,14 +1625,10 @@ Vue.component('pretix-widget-event-week-calendar', {
         display_event_info: function () {
             return this.$root.display_event_info || (this.$root.display_event_info === null && this.$root.parent_stack.length > 0);
         },
-        week: function () {
-            return this.$root.week[1];
-        },
-        year: function () {
-            return this.$root.week[0];
-        },
         weekname: function () {
-            return this.week + ' / ' + this.year;
+            var curWeek = this.$root.week[1];
+            var curYear = this.$root.week[0];
+            return curWeek + ' / ' + curYear;
         },
         id: function () {
             return this.$root.html_id + "-event-week-table";
@@ -1646,12 +1642,26 @@ Vue.component('pretix-widget-event-week-calendar', {
             this.$root.view = "events";
         },
         prevweek: function () {
-            this.$root.week = this.prev_week_date.split("-W");
+            var curWeek = this.$root.week[1];
+            var curYear = this.$root.week[0];
+            curWeek--;
+            if (curWeek < 1) {
+                curYear--;
+                curWeek = getISOWeeks(curYear);
+            }
+            this.$root.week = [curYear, curWeek];
             this.$root.loading++;
             this.$root.reload({focus: '#'+this.id});
         },
         nextweek: function () {
-            this.$root.week = this.next_week_date.split("-W");
+            var curWeek = this.$root.week[1];
+            var curYear = this.$root.week[0];
+            curWeek++;
+            if (curWeek > getISOWeeks(curYear)) {
+                curWeek = 1;
+                curYear++;
+            }
+            this.$root.week = [curYear, curWeek];
             this.$root.loading++;
             this.$root.reload({focus: '#'+this.id});
         }

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1325,7 +1325,7 @@ Vue.component('pretix-widget-event-list', {
 });
 
 Vue.component('pretix-widget-event-calendar-event', {
-    template: ('<a :class="classObject" @click.prevent.stop="select">'
+    template: ('<a :href="href" :class="classObject" @click.prevent.stop="select">'
         + '<strong class="pretix-widget-event-calendar-event-name">'
         + '{{ event.name }}'
         + '</strong>'
@@ -1336,6 +1336,9 @@ Vue.component('pretix-widget-event-calendar-event', {
         event: Object
     },
     computed: {
+        href: function () {
+            return this.event.event_url + (this.event.subevent ? this.event.subevent + '/' : '');
+        },
         classObject: function () {
             var o = {
                 'pretix-widget-event-calendar-event': true

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -997,10 +997,10 @@ Vue.component('pretix-widget-event-form', {
     template: ('<div class="pretix-widget-event-form">'
         // Back navigation
         + '<div class="pretix-widget-event-list-back" v-if="$root.events || $root.weeks || $root.days">'
-        + '<a :href="href" rel="back" @click.prevent.stop="back_to_list" v-if="!$root.subevent">&lsaquo; '
+        + '<a href="#" rel="back" @click.prevent.stop="back_to_list" v-if="!$root.subevent">&lsaquo; '
         + strings['back_to_list']
         + '</a>'
-        + '<a :href="href" rel="back" @click.prevent.stop="back_to_list" v-if="$root.subevent">&lsaquo; '
+        + '<a href="#" rel="back" @click.prevent.stop="back_to_list" v-if="$root.subevent">&lsaquo; '
         + strings['back_to_dates']
         + '</a>'
         + '</div>'
@@ -1104,9 +1104,6 @@ Vue.component('pretix-widget-event-form', {
         this.$root.$off('focus_voucher_field', this.focus_voucher_field)
     },
     computed: {
-        href: function () {
-            return this.$root.event?.event_url || this.$root.parent_stack[this.$root.parent_stack.length-1];
-        },
         display_event_info: function () {
             return this.$root.display_event_info || (this.$root.display_event_info === null && (this.$root.events || this.$root.weeks || this.$root.days));
         },
@@ -1239,7 +1236,7 @@ Vue.component('pretix-widget-event-list-filter-form', {
 });
 
 Vue.component('pretix-widget-event-list-entry', {
-    template: ('<a :href="href" :class="classObject" @click.prevent.stop="select">'
+    template: ('<a href="#" :class="classObject" @click.prevent.stop="select">'
         + '<div class="pretix-widget-event-list-entry-name">{{ event.name }}</div>'
         + '<div class="pretix-widget-event-list-entry-date">{{ event.date_range }}</div>'
         + '<div class="pretix-widget-event-list-entry-location">{{ location }}</div>'  // hidden by css for now, but
@@ -1262,10 +1259,7 @@ Vue.component('pretix-widget-event-list-entry', {
         },
         location: function () {
             return this.event.location.replace(/\s*\n\s*/g, ', ');
-        },
-        href: function () {
-            return this.event.event_url + (this.event.subevent ? this.event.subevent + '/' : '');
-        },
+        }
     },
     methods: {
         select: function () {
@@ -1282,7 +1276,7 @@ Vue.component('pretix-widget-event-list-entry', {
 Vue.component('pretix-widget-event-list', {
     template: ('<div class="pretix-widget-event-list">'
         + '<div class="pretix-widget-back" v-if="$root.weeks || $root.parent_stack.length > 0">'
-        + '<a :href="href" rel="prev" @click.prevent.stop="back_to_calendar">&lsaquo; '
+        + '<a href="#" rel="prev" @click.prevent.stop="back_to_calendar">&lsaquo; '
         + strings['back']
         + '</a>'
         + '</div>'
@@ -1297,9 +1291,6 @@ Vue.component('pretix-widget-event-list', {
     computed: {
         display_event_info: function () {
             return this.$root.display_event_info || (this.$root.display_event_info === null && this.$root.parent_stack.length > 0);
-        },
-        href: function () {
-            return this.$root.$weeks ? this.$root.event.event_url : this.$root.parent_stack[this.$root.parent_stack.length-1];
         },
     },
     methods: {
@@ -1332,7 +1323,7 @@ Vue.component('pretix-widget-event-list', {
 });
 
 Vue.component('pretix-widget-event-calendar-event', {
-    template: ('<a :href="href" :class="classObject" @click.prevent.stop="select" v-bind:aria-describedby="describedby">'
+    template: ('<a href="#" :class="classObject" @click.prevent.stop="select" v-bind:aria-describedby="describedby">'
         + '<strong class="pretix-widget-event-calendar-event-name">'
         + '{{ event.name }}'
         + '</strong>'
@@ -1344,9 +1335,6 @@ Vue.component('pretix-widget-event-calendar-event', {
         describedby: String,
     },
     computed: {
-        href: function () {
-            return this.event.event_url + (this.event.subevent ? this.event.subevent + '/' : '');
-        },
         classObject: function () {
             var o = {
                 'pretix-widget-event-calendar-event': true
@@ -1536,11 +1524,11 @@ Vue.component('pretix-widget-event-calendar', {
 
         // Calendar navigation
         + '<div class="pretix-widget-event-calendar-head">'
-        + '<a class="pretix-widget-event-calendar-previous-month" :href="prev_href" @click.prevent.stop="prevmonth">&laquo; '
+        + '<a class="pretix-widget-event-calendar-previous-month" href="#" @click.prevent.stop="prevmonth">&laquo; '
         + strings['previous_month']
         + '</a> '
         + '<strong>{{ monthname }}</strong> '
-        + '<a class="pretix-widget-event-calendar-next-month" :href="next_href" @click.prevent.stop="nextmonth">'
+        + '<a class="pretix-widget-event-calendar-next-month" href="#" @click.prevent.stop="nextmonth">'
         + strings['next_month']
         + ' &raquo;</a>'
         + '</div>'
@@ -1570,39 +1558,8 @@ Vue.component('pretix-widget-event-calendar', {
         monthname: function () {
             return strings['months'][this.$root.date.substr(5, 2)] + ' ' + this.$root.date.substr(0, 4);
         },
-        month: function () {
-            return parseInt(this.$root.date.substr(5, 2));
-        },
-        year: function () {
-            return parseInt(this.$root.date.substr(0, 4));
-        },
-        prev_month_date: function () {
-            var pm = this.month - 1;
-            return String(this.year - (pm ? 0 : 1)) + "-" + padNumber((pm || 12), 2);
-        },
-        next_month_date: function () {
-            var pm = this.month + 1;
-            return String(this.year + (pm > 12 ? 1 : 0)) + "-" + padNumber(pm % 12, 2);
-        },
         id: function () {
             return this.$root.html_id + "-event-calendar-table";
-        },
-        base_href: function () {
-            return this.$root.event?.event_url || this.$root.target_url;
-        },
-        prev_href: function () {
-            return [
-                this.base_href,
-                '?style=calendar&date=',
-                this.prev_month_date
-            ].join('');
-        },
-        next_href: function () {
-            return [
-                this.base_href,
-                '?style=calendar&date=',
-                this.next_month_date
-            ].join('');
         },
     },
     methods: {
@@ -1645,11 +1602,11 @@ Vue.component('pretix-widget-event-week-calendar', {
         // Calendar navigation
         + '<div class="pretix-widget-event-description" v-if="$root.frontpage_text && display_event_info" v-html="$root.frontpage_text"></div>'
         + '<div class="pretix-widget-event-calendar-head">'
-        + '<a class="pretix-widget-event-calendar-previous-month" :href="prev_href" @click.prevent.stop="prevweek" role="button">&laquo; '
+        + '<a class="pretix-widget-event-calendar-previous-month" href="#" @click.prevent.stop="prevweek" role="button">&laquo; '
         + strings['previous_week']
         + '</a> '
         + '<strong>{{ weekname }}</strong> '
-        + '<a class="pretix-widget-event-calendar-next-month" :href="next_href" @click.prevent.stop="nextweek" role="button">'
+        + '<a class="pretix-widget-event-calendar-next-month" href="#" @click.prevent.stop="nextweek" role="button">'
         + strings['next_week']
         + ' &raquo;</a>'
         + '</div>'
@@ -1677,39 +1634,8 @@ Vue.component('pretix-widget-event-week-calendar', {
         weekname: function () {
             return this.week + ' / ' + this.year;
         },
-        prev_week_date: function () {
-            var w = this.week - 1;
-            if (!w) {
-                return (this.year - 1) + "-W" + getISOWeeks(this.year - 1);
-            }
-            return this.year + "-W" + w;
-        },
-        next_week_date: function () {
-            var w = this.week + 1;
-            if (w > getISOWeeks(this.year)) {
-                return String(this.year + 1) + "-W1";
-            }
-            return String(this.year) + "-W" + w;
-        },
         id: function () {
             return this.$root.html_id + "-event-week-table";
-        },
-        base_href: function () {
-            return this.$root.event?.event_url || this.$root.target_url;
-        },
-        prev_href: function () {
-            return [
-                this.base_href,
-                '?style=week&date=',
-                this.prev_week_date
-            ].join('');
-        },
-        next_href: function () {
-            return [
-                this.base_href,
-                '?style=week&date=',
-                this.next_week_date
-            ].join('');
         },
     },
     methods: {

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -990,10 +990,10 @@ Vue.component('pretix-widget-event-form', {
     template: ('<div class="pretix-widget-event-form">'
         // Back navigation
         + '<div class="pretix-widget-event-list-back" v-if="$root.events || $root.weeks || $root.days">'
-        + '<a href="#" @click.prevent.stop="back_to_list" v-if="!$root.subevent">&lsaquo; '
+        + '<a :href="href" rel="back" @click.prevent.stop="back_to_list" v-if="!$root.subevent">&lsaquo; '
         + strings['back_to_list']
         + '</a>'
-        + '<a href="#" @click.prevent.stop="back_to_list" v-if="$root.subevent">&lsaquo; '
+        + '<a :href="href" rel="back" @click.prevent.stop="back_to_list" v-if="$root.subevent">&lsaquo; '
         + strings['back_to_dates']
         + '</a>'
         + '</div>'
@@ -1097,6 +1097,9 @@ Vue.component('pretix-widget-event-form', {
         this.$root.$off('focus_voucher_field', this.focus_voucher_field)
     },
     computed: {
+        href: function () {
+            return this.$root.$weeks ? this.$root.event.event_url : this.$root.parent_stack[this.$root.parent_stack.length-1];
+        },
         display_event_info: function () {
             return this.$root.display_event_info || (this.$root.display_event_info === null && (this.$root.events || this.$root.weeks || this.$root.days));
         },
@@ -1261,7 +1264,7 @@ Vue.component('pretix-widget-event-list-entry', {
 Vue.component('pretix-widget-event-list', {
     template: ('<div class="pretix-widget-event-list">'
         + '<div class="pretix-widget-back" v-if="$root.weeks || $root.parent_stack.length > 0">'
-        + '<a href="#" @click.prevent.stop="back_to_calendar" role="button">&lsaquo; '
+        + '<a :href="href" rel="prev" @click.prevent.stop="back_to_calendar">&lsaquo; '
         + strings['back']
         + '</a>'
         + '</div>'
@@ -1276,6 +1279,9 @@ Vue.component('pretix-widget-event-list', {
     computed: {
         display_event_info: function () {
             return this.$root.display_event_info || (this.$root.display_event_info === null && this.$root.parent_stack.length > 0);
+        },
+        href: function () {
+            return this.$root.$weeks ? this.$root.event.event_url : this.$root.parent_stack[this.$root.parent_stack.length-1];
         },
     },
     methods: {

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1218,7 +1218,7 @@ Vue.component('pretix-widget-event-list-filter-form', {
 });
 
 Vue.component('pretix-widget-event-list-entry', {
-    template: ('<a :class="classObject" @click.prevent.stop="select">'
+    template: ('<a :href="href" :class="classObject" @click.prevent.stop="select">'
         + '<div class="pretix-widget-event-list-entry-name">{{ event.name }}</div>'
         + '<div class="pretix-widget-event-list-entry-date">{{ event.date_range }}</div>'
         + '<div class="pretix-widget-event-list-entry-location">{{ location }}</div>'  // hidden by css for now, but
@@ -1241,7 +1241,10 @@ Vue.component('pretix-widget-event-list-entry', {
         },
         location: function () {
             return this.event.location.replace(/\s*\n\s*/g, ', ');
-        }
+        },
+        href: function () {
+            return this.event.event_url + (this.event.subevent ? this.event.subevent + '/' : '');
+        },
     },
     methods: {
         select: function () {

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1672,7 +1672,7 @@ Vue.component('pretix-widget-event-week-calendar', {
 });
 
 Vue.component('pretix-widget', {
-    template: ('<div class="pretix-widget-wrapper" ref="wrapper" tabindex="0">'
+    template: ('<div class="pretix-widget-wrapper" ref="wrapper" tabindex="0" role="article" v-bind:aria-label="$root.name">'
         + '<div :class="classObject">'
         + shared_loading_fragment
         + '<div class="pretix-widget-error-message" v-if="$root.error && $root.view !== \'event\'">{{ $root.error }}</div>'

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1804,7 +1804,7 @@ var shared_root_methods = {
             }
         });
     },
-    reload: function (opt) {
+    reload: function (opt = {}) {
         var url;
         if (this.$root.is_button) {
             return;


### PR DESCRIPTION
This PRs improves focus management in the widget when using any navigation methods other than opening the iframe-overlay – this usually only happens on event-series or when the widget is included on a organizer-level. To make screen-readers recognize new content loaded dynamically and not lose focus-order, focus is moved to the widgets container and the screen-reader reads the aria-label, which is the event’s name (empty for organizer level, could be improved if a subevent is selected).

Making the whole container aria-live is not helping here, as aria-live will read the whole container once it is loaded.

Usually only interactive elements are focusable (depending on browser). To make the container focusable (at least in Safari with VoicerOver), we need to add a `tabindex` to it. This makes it a focusable object, which ideally should have an aria-label. I initially thought of only adding the aria-label and the tabindex once the widget is navigated inside, as the organizer-view does not necessarily provide any useful label for the whole widget. The widget-container still needs to be focusable though (e.g. when navigating back from an event to the organizer overview), so this PR adds tabindex with a potentially empty aria-label (only empty in organizer-level widget). Not ideal, but IMHO the best option.

Furthermore for best experience when navigating inside the widget’s calendar, it adds an optional focus-parameter to reload to focus the current calendar element instead of the whole widget. It also adds some aria-labels to improve understanding when navigating the calendar.

All navigation links are made actual links (rel=button does not make a link with no href a tab-target with Safari/VoiceOver). Also in the best interest of a11y, all calendar navigation links are now the correct links to the actual pretix-shop so there is a static-html-page fallback instead of loading content via ajax. So e.g. an open-link-in-new-window/tab now works as expected.