### PR TITLE
Widget: Prefill email_repeat with data-email attribute (Z#23181657)

### DIFF
--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -787,6 +787,10 @@ class QuestionsStep(QuestionsViewMixin, CartMixin, TemplateFlowStep):
                 self.cart_session.get('email', '') or
                 wd.get('email', '')
             ),
+            'email_repeat': (
+                self.cart_session.get('email_repeat', '') or
+                wd.get('email', '')
+            ),
             'phone': self.cart_session.get('phone', '') or wd.get('phone', None)
         }
         initial.update(self.cart_session.get('contact_form_data', {}))


### PR DESCRIPTION
Z#23181657

Especially when the fields are locked, we need to copy the information over - or the customer is stuck in a dead-end.