### PR TITLE
Improve date format heuristic for bank statement import

### DIFF
--- a/src/pretix/plugins/banktransfer/tasks.py
+++ b/src/pretix/plugins/banktransfer/tasks.py
@@ -292,11 +292,11 @@ def _handle_transaction(trans: BankTransaction, matches: tuple, event: Event = N
     trans.save()
 
 
-def parse_date(date_str):
+def parse_date(date_str, region=None):
     try:
         return dateutil.parser.parse(
             date_str,
-            dayfirst="." in date_str,
+            dayfirst="." in date_str or region in ["GB"],
         ).date()
     except (ValueError, OverflowError):
         pass
@@ -339,7 +339,7 @@ def _get_unknown_transactions(job: BankImportJob, data: list, event: Event = Non
                                 external_id=row.get('external_id'),
                                 currency=event.currency if event else job.currency)
 
-        trans.date_parsed = parse_date(trans.date)
+        trans.date_parsed = parse_date(trans.date, (event and event.settings.region) or (organizer and organizer.settings.region) or None)
 
         trans.checksum = trans.calculate_checksum()
         if trans.checksum not in known_checksums and (not trans.external_id or (trans.external_id, trans.date, trans.amount) not in known_by_external_id):

--- a/src/tests/plugins/banktransfer/test_import.py
+++ b/src/tests/plugins/banktransfer/test_import.py
@@ -790,3 +790,33 @@ def test_ignore_by_external_id(env, job):
     }])
     with scopes_disabled():
         assert BankTransaction.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_ambigious_date_without_region(env, job):
+    process_banktransfers(job, [{
+        'payer': 'Karla Kundin',
+        'reference': 'Bestellung DUMMY1Z3AS',
+        'date': '03/05/2016',
+        'amount': '23.00'
+    }])
+    env[2].refresh_from_db()
+
+    with scopes_disabled():
+        assert env[2].payments.last().info_data["date"] == "2016-03-05"
+
+
+@pytest.mark.django_db
+def test_ambigious_date_with_region(env, job):
+    env[0].settings.region = "GB"
+
+    process_banktransfers(job, [{
+        'payer': 'Karla Kundin',
+        'reference': 'Bestellung DUMMY1Z3AS',
+        'date': '03/05/2016',
+        'amount': '23.00'
+    }])
+    env[2].refresh_from_db()
+
+    with scopes_disabled():
+        assert env[2].payments.last().info_data["date"] == "2016-05-03"

--- a/src/tests/plugins/banktransfer/test_parsing.py
+++ b/src/tests/plugins/banktransfer/test_parsing.py
@@ -40,3 +40,5 @@ def test_date_formats():
 
     assert dt == parse_date("2020-07-01")
     assert dt == parse_date("2020-7-1")
+
+    assert dt == parse_date("01/07/2020", "GB")


### PR DESCRIPTION
When dates are ambiguous, use the event's locale to infer whether the day or month comes first. Since regions follow certain date format conventions, this helps make more accurate guesses.

This could probably be improved by (1) adding other countries to the check (although this can be extended later), or even better, (2) allowing the date format to be specified to avoid any wrong interpretations. However, I think this might be a reasonable stepping stone.