### PR TITLE
Add delete button to voucher details page

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/vouchers/detail.html
+++ b/src/pretix/control/templates/pretixcontrol/vouchers/detail.html
@@ -125,6 +125,15 @@
                 <button type="submit" class="btn btn-primary btn-save">
                     {% trans "Save" %}
                 </button>
+                {% if voucher.pk %}
+                    <div class="pull-left">
+                        <a href="{% url "control:event.voucher.delete" organizer=request.organizer.slug event=request.event.slug voucher=voucher.pk %}"
+                           class="btn btn-danger btn-lg">
+                            <span class="fa fa-trash"></span>
+                            {% trans "Delete voucher" %}
+                        </a>
+                    </div>
+                {% endif %}
             </div>
         {% endif %}
     </form>


### PR DESCRIPTION
A common workflow is to search for a voucher by code, which navigates directly to the voucher details page. Previously, the delete button was only available in the formset list view, but in many cases, vouchers are never accessed via this view, especially when a large number of vouchers are active. This meant users often had no visible way to delete a voucher.

This commit adds a delete button to the voucher details page, allowing users to remove vouchers directly from this interface.