### PR TITLE
Fix log display for checkins and order splits (Z#23181229)

### DIFF
--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -286,7 +286,7 @@ class OrderChangedSplit(OrderChangeLogEntryType):
             _('Position #{posid} ({old_item}, {old_price}) split into new order: {order}'),
             old_item=escape(old_item),
             posid=data.get('positionid', '?'),
-            order=format_html(mark_safe('<a href="{}">{}</a>'),url, data['new_order']),
+            order=format_html(mark_safe('<a href="{}">{}</a>'), url, data['new_order']),
             old_price=money_filter(Decimal(data['old_price']), event.currency),
         )
 
@@ -350,7 +350,7 @@ class CheckinErrorLogEntryType(OrderLogEntryType):
 
         if 'datetime' in data:
             dt = dateutil.parser.parse(data.get('datetime'))
-            if abs((logentry.datetime - dt).total_seconds()) > 5:
+            if abs((logentry.datetime - dt).total_seconds()) > 5 or data.get('forced'):
                 tz = event.timezone
                 data['datetime'] = date_format(dt.astimezone(tz), "SHORT_DATETIME_FORMAT")
                 return str(plain_with_dt).format_map(data)
@@ -373,12 +373,8 @@ class CheckinLogEntryType(CheckinErrorLogEntryType):
             ), logentry, data)
         elif data.get('forced'):
             return self.display_plain(
-                (
-                    _('A scan for position #{posid} at {datetime} for list "{list}" has been uploaded even though it has '
-                      'been scanned already.'),
-                    _('A scan for position #{posid} for list "{list}" has been uploaded even though it has '
-                      'been scanned already.'),
-                ),
+                _('A scan for position #{posid} at {datetime} for list "{list}" has been uploaded even though it has '
+                  'been scanned already.'),
                 logentry, data
             )
         else:

--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -296,8 +296,14 @@ class OrderChangedSplitFrom(OrderLogEntryType):
     action_type = 'pretix.event.order.changed.split_from'
 
     def display(self, logentry: LogEntry, data):
-        return _('This order has been created by splitting the order {order}').format(
-            order=data['original_order'],
+        url = reverse('control:event.order', kwargs={
+            'event': logentry.event.slug,
+            'organizer': logentry.event.organizer.slug,
+            'code': data['original_order']
+        })
+        return format_html(
+            _('This order has been created by splitting the order {order}'),
+            order=format_html(mark_safe('<a href="{}">{}</a>'), url, data['original_order']),
         )
 
 

--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -350,12 +350,12 @@ class CheckinErrorLogEntryType(OrderLogEntryType):
 
         if 'datetime' in data:
             dt = dateutil.parser.parse(data.get('datetime'))
-            if abs((logentry.datetime - dt).total_seconds()) > 5 or 'forced' in data:
+            if abs((logentry.datetime - dt).total_seconds()) > 5:
                 tz = event.timezone
                 data['datetime'] = date_format(dt.astimezone(tz), "SHORT_DATETIME_FORMAT")
                 return str(plain_with_dt).format_map(data)
-            else:
-                return str(plain_without_dt).format_map(data)
+
+        return str(plain_without_dt).format_map(data)
 
 
 @log_entry_types.new('pretix.event.checkin')
@@ -373,8 +373,12 @@ class CheckinLogEntryType(CheckinErrorLogEntryType):
             ), logentry, data)
         elif data.get('forced'):
             return self.display_plain(
-                _('A scan for position #{posid} at {datetime} for list "{list}" has been uploaded even though it has '
-                  'been scanned already.'),
+                (
+                    _('A scan for position #{posid} at {datetime} for list "{list}" has been uploaded even though it has '
+                      'been scanned already.'),
+                    _('A scan for position #{posid} for list "{list}" has been uploaded even though it has '
+                      'been scanned already.'),
+                ),
                 logentry, data
             )
         else:

--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -72,7 +72,7 @@ class OrderChangeLogEntryType(OrderLogEntryType):
     prefix = _('The order has been changed:')
 
     def display(self, logentry, data):
-        return self.prefix + ' ' + self.display_prefixed(logentry.event, logentry, data)
+        return format_html('{} {}', self.prefix, self.display_prefixed(logentry.event, logentry, data))
 
     def display_prefixed(self, event: Event, logentry: LogEntry, data):
         return super().display(logentry, data)
@@ -282,12 +282,13 @@ class OrderChangedSplit(OrderChangeLogEntryType):
             'organizer': event.organizer.slug,
             'code': data['new_order']
         })
-        return mark_safe(self.prefix + ' ' + _('Position #{posid} ({old_item}, {old_price}) split into new order: {order}').format(
+        return format_html(
+            _('Position #{posid} ({old_item}, {old_price}) split into new order: {order}'),
             old_item=escape(old_item),
             posid=data.get('positionid', '?'),
-            order='<a href="{}">{}</a>'.format(url, data['new_order']),
+            order=format_html(mark_safe('<a href="{}">{}</a>'),url, data['new_order']),
             old_price=money_filter(Decimal(data['old_price']), event.currency),
-        ))
+        )
 
 
 @log_entry_types.new()

--- a/src/pretix/control/views/global_settings.py
+++ b/src/pretix/control/views/global_settings.py
@@ -110,7 +110,7 @@ class MessageView(TemplateView):
 class LogDetailView(AdministratorPermissionRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         le = get_object_or_404(LogEntry, pk=request.GET.get('pk'))
-        return JsonResponse({'data': le.parsed_data})
+        return JsonResponse({'action_type': le.action_type, 'content_type': str(le.content_type), 'object_id': le.object_id, 'data': le.parsed_data})
 
 
 class PaymentDetailView(AdministratorPermissionRequiredMixin, View):

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -1065,11 +1065,17 @@ function add_log_expand_handlers(el) {
         } else if ($a.is("[data-expandpayment]")) {
             url += 'payment/'
         }
+        function format_data(data) {
+            return Object.entries(data).map(([key, value]) =>
+                $("<div>").append(
+                    $("<b>").text(key + ': '),
+                    $("<span>").text(JSON.stringify(value, null, 2))));
+        }
         $.getJSON(url + '?pk=' + id, function (data) {
             if ($a.parent().tagName === "p") {
-                $("<pre>").text(JSON.stringify(data.data, null, 2)).insertAfter($a.parent());
+                $("<pre>").append(format_data(data)).insertAfter($a.parent());
             } else {
-                $("<pre>").text(JSON.stringify(data.data, null, 2)).appendTo($a.parent());
+                $("<pre>").append(format_data(data)).appendTo($a.parent());
             }
             $a.remove();
         });


### PR DESCRIPTION
- Fixes link in pretix.event.order.changed.split
- Adds link to existing order in pretix.event.order.changed.split_from
- Fixes display of checkin entries without datetime in data
- Adds additional info for admins (action type, linked content object):
  ![image](https://github.com/user-attachments/assets/3d169e7c-ab66-46ce-9f2e-83cbec5e6fcb)
