### PR TITLE
Fix copying invoice answers with special chars in label (Z#23177041)

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -387,14 +387,14 @@ $(function () {
             var $first_ticket_form = $(".questions-form").first().find("[data-addonidx=0]");
             $first_ticket_form.find("[id$=" + this.id.substring(3) + "]").val(this.value);
             if (this.placeholder) {
-                $first_ticket_form.find("[placeholder='" + this.placeholder + "']").val(this.value);
+                $first_ticket_form.find("[placeholder='" + CSS.escape(this.placeholder) + "']").val(this.value);
             }
             var label = $("label[for=" + this.id +"]").first().contents().filter(function () {
                 return this.nodeType != Node.ELEMENT_NODE || !this.classList.contains("sr-only");
             }).text().trim();
             if (label) {
                 // match to placeholder and label
-                $first_ticket_form.find("[placeholder='" + label + "']").val(this.value);
+                $first_ticket_form.find("[placeholder='" + CSS.escape(label) + "']").val(this.value);
                 var v = this.value;
                 $first_ticket_form.find("label").each(function() {
                     var text = $(this).first().contents().filter(function () {


### PR DESCRIPTION
When copying ansers from the invoice form to the first product-question, the CSS-selector failed if an apostroph `'` was used in the label/placeholder. We still need to keep the CSS-selector based on the label/placeholder, as there is no other way to match custom question in products (like for a company) to the corresponding input in the invoice-form.