### PR TITLE
Fix selector for copying order/invoice answers to first ticket

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -386,22 +386,29 @@ $(function () {
         if (copy_to_first_ticket) {
             var $first_ticket_form = $(".questions-form").first().find("[data-addonidx=0]");
             $first_ticket_form.find("[id$=" + this.id.substring(3) + "]").val(this.value);
+
+            // when matching by placeholder or label, make sure to always match the tagName of the element
+            // filter any checkbox/radio inputs as copied input is either select or type=email|text, but could be
+            // matched when custom answer options have the same label, see https://github.com/pretix/pretix/issues/4860
+            var selectorPrefix = this.tagName + ":not([type='checkbox'], [type='radio'])";
             if (this.placeholder) {
-                $first_ticket_form.find("[placeholder='" + CSS.escape(this.placeholder) + "']").val(this.value);
+                $first_ticket_form.find(
+                    selectorPrefix + "[placeholder='" + CSS.escape(this.placeholder) + "']"
+                ).val(this.value);
             }
             var label = $("label[for=" + this.id +"]").first().contents().filter(function () {
                 return this.nodeType != Node.ELEMENT_NODE || !this.classList.contains("sr-only");
             }).text().trim();
             if (label) {
                 // match to placeholder and label
-                $first_ticket_form.find("[placeholder='" + CSS.escape(label) + "']").val(this.value);
+                $first_ticket_form.find(selectorPrefix + "[placeholder='" + CSS.escape(label) + "']").val(this.value);
                 var v = this.value;
                 $first_ticket_form.find("label").each(function() {
                     var text = $(this).first().contents().filter(function () {
                         return this.nodeType != Node.ELEMENT_NODE || !this.classList.contains("sr-only");
                     }).text().trim();
                     if (text == label) {
-                        $("#" + this.getAttribute("for")).val(v);
+                        $(selectorPrefix + "#" + this.getAttribute("for")).val(v);
                     }
                 });
             }

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -385,7 +385,7 @@ $(function () {
         " #id_city, #id_country, #id_state").change(function () {
         if (copy_to_first_ticket) {
             var $first_ticket_form = $(".questions-form").first().find("[data-addonidx=0]");
-            $first_ticket_form.find("[id$=" + this.id.substring(3) + "]").val(this.value);
+            $first_ticket_form.find("[id$=" + this.id.substring(3) + "]").val(this.value).trigger("change");
 
             // when matching by placeholder or label, make sure to always match the tagName of the element
             // filter any checkbox/radio inputs as copied input is either select or type=email|text, but could be
@@ -394,21 +394,21 @@ $(function () {
             if (this.placeholder) {
                 $first_ticket_form.find(
                     selectorPrefix + "[placeholder='" + CSS.escape(this.placeholder) + "']"
-                ).val(this.value);
+                ).val(this.value).trigger("change");
             }
             var label = $("label[for=" + this.id +"]").first().contents().filter(function () {
                 return this.nodeType != Node.ELEMENT_NODE || !this.classList.contains("sr-only");
             }).text().trim();
             if (label) {
                 // match to placeholder and label
-                $first_ticket_form.find(selectorPrefix + "[placeholder='" + CSS.escape(label) + "']").val(this.value);
+                $first_ticket_form.find(selectorPrefix + "[placeholder='" + CSS.escape(label) + "']").val(this.value).trigger("change");
                 var v = this.value;
                 $first_ticket_form.find("label").each(function() {
                     var text = $(this).first().contents().filter(function () {
                         return this.nodeType != Node.ELEMENT_NODE || !this.classList.contains("sr-only");
                     }).text().trim();
                     if (text == label) {
-                        $(selectorPrefix + "#" + this.getAttribute("for")).val(v);
+                        $(selectorPrefix + "#" + this.getAttribute("for")).val(v).trigger("change");
                     }
                 });
             }


### PR DESCRIPTION
This fixes #4860 

It furthermore fixes copying the selected country by triggering a change-event which refreshes the state-list as well.

Note: this ignores any checkbox/radio inputs, so if (or when) we add these type of inputs to order questions/fields, one needs to adapt this. As copying checkboxes checked states is anyway totally different to selected options/input-values, this would need to be adapted anyways then.