### PR TITLE
Fix voucher application on "free price" items (Z#23183254)

### DIFF
--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -623,6 +623,9 @@ class CartManager:
 
             if p.is_bundled:
                 continue
+                
+            if p.custom_price_input and p.custom_price_input != p.listed_price:
+                continue
 
             if p.listed_price is None:
                 if p.addon_to_id and is_included_for_free(p.item, p.addon_to):

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -1349,8 +1349,10 @@ class CartManager:
 
                 op.position.price_after_voucher = op.price_after_voucher
                 op.position.voucher = op.voucher
+                if op.position.custom_price_input and op.position.custom_price_input == op.position.listed_price:
+                    op.position.custom_price_input = op.price_after_voucher
                 # op.position.price will be set in recompute_final_prices_and_taxes
-                op.position.save(update_fields=['price_after_voucher', 'voucher'])
+                op.position.save(update_fields=['price_after_voucher', 'voucher', 'custom_price_input'])
                 vouchers_ok[op.voucher] -= 1
 
                 if op.voucher.all_bundles_included or op.voucher.all_addons_included:

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -623,7 +623,7 @@ class CartManager:
 
             if p.is_bundled:
                 continue
-                
+
             if p.custom_price_input and p.custom_price_input != p.listed_price:
                 continue
 

--- a/src/tests/presale/test_cart.py
+++ b/src/tests/presale/test_cart.py
@@ -1727,8 +1727,8 @@ class CartTest(CartTestMixin, TestCase):
         self.assertEqual(objs[0].price_after_voucher, Decimal('23.00'))
 
         response = self.client.post('/%s/%s/cart/voucher' % (self.orga.slug, self.event.slug),
-                                   {'voucher': v.code},
-                                   follow=True)
+                                    {'voucher': v.code},
+                                    follow=True)
 
         self.assertRedirects(response, '/%s/%s/?require_cookie=true' % (self.orga.slug, self.event.slug),
                              target_status_code=200)
@@ -1758,8 +1758,8 @@ class CartTest(CartTestMixin, TestCase):
         }, follow=True)
 
         response = self.client.post('/%s/%s/cart/voucher' % (self.orga.slug, self.event.slug),
-                                   {'voucher': v.code},
-                                   follow=True)
+                                    {'voucher': v.code},
+                                    follow=True)
         doc = BeautifulSoup(response.rendered_content, "lxml")
         self.assertIn('We did not find any position in your cart that we could use this voucher for', doc.select('.alert-danger')[0].text)
 


### PR DESCRIPTION
For items with "Free price input" (user-selectable price), vouchers redeemed on existing cart should apply if and only if the chosen price equals minimum price.

Old behavior is that the voucher is marked as applied but the price doesn't change.