### PR TITLE
Fix: overwrite widget_data for existing carts (Z#23181715)

### DIFF
--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -386,6 +386,11 @@ def get_or_create_cart_id(request, create=True):
             if 'carts' in request.session:
                 request.session['carts'][current_id] = {}
         else:
+            if 'widget_data' in request.GET:
+                try:
+                    request.session['carts'][current_id]['widget_data'] = json.loads(request.GET.get('widget_data'))
+                except ValueError:
+                    pass
             return current_id
 
     cart_data = {}


### PR DESCRIPTION
Together with #4862 this fixes not overwriting cookie-consent through widget-data for existing carts/sessions.