### PR TITLE
[A11y] Remove all autofocus in pretix-control except login/auth and dashboard (Z#23180233)

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -196,7 +196,6 @@ class OrderFilterForm(FilterForm):
         label=_('Search for…'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search for…'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -980,7 +979,6 @@ class OrderPaymentSearchFilterForm(forms.Form):
         label=_('Search for…'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search for…'),
-            'autofocus': 'autofocus'
         }),
         required=False,
     )
@@ -1242,7 +1240,6 @@ class SubEventFilterForm(FilterForm):
         label=_('Event name'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Event name'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1375,7 +1372,6 @@ class OrganizerFilterForm(FilterForm):
         label=_('Organizer name'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Organizer name'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1433,7 +1429,6 @@ class GiftCardFilterForm(FilterForm):
         label=_('Search query'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search query'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1485,7 +1480,6 @@ class CustomerFilterForm(FilterForm):
         label=_('Search query'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search query'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1558,7 +1552,6 @@ class ReusableMediaFilterForm(FilterForm):
         label=_('Search query'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search query'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1613,7 +1606,6 @@ class TeamFilterForm(FilterForm):
         label=_('Search query'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search query'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1695,7 +1687,6 @@ class EventFilterForm(FilterForm):
         label=_('Event name'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Event name'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -1878,7 +1869,6 @@ class CheckinListAttendeeFilterForm(FilterForm):
         label=_('Search attendee…'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search attendee…'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -2027,7 +2017,6 @@ class UserFilterForm(FilterForm):
         label=_('Search query'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search query'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -2119,7 +2108,6 @@ class VoucherFilterForm(FilterForm):
         label=_('Search voucher'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search voucher'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )
@@ -2597,7 +2585,6 @@ class DeviceFilterForm(FilterForm):
         label=_('Search query'),
         widget=forms.TextInput(attrs={
             'placeholder': _('Search query'),
-            'autofocus': 'autofocus'
         }),
         required=False
     )

--- a/src/pretix/control/templates/pretixcontrol/orders/index.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/index.html
@@ -44,8 +44,7 @@
             <form class="form-inline"
                   action="{% url "control:event.orders.go" event=request.event.slug organizer=request.event.organizer.slug %}">
                 <p class="input-group">
-                    <input type="text" name="code" class="form-control" placeholder="{% trans "Order code" %}"
-                           autofocus>
+                    <input type="text" name="code" class="form-control" placeholder="{% trans "Order code" %}">
                     <span class="input-group-btn">
                             <button class="btn btn-primary" type="submit">{% trans "Go!" %}</button>
                         </span>

--- a/src/pretix/control/templates/pretixcontrol/vouchers/index.html
+++ b/src/pretix/control/templates/pretixcontrol/vouchers/index.html
@@ -15,7 +15,7 @@
     <form class="form-inline"
             action="{% url "control:event.vouchers.go" event=request.event.slug organizer=request.event.organizer.slug %}">
         <p class="input-group">
-            <input type="text" name="code" class="form-control" placeholder="{% trans "Voucher code" %}" autofocus>
+            <input type="text" name="code" class="form-control" placeholder="{% trans "Voucher code" %}">
             <span class="input-group-btn">
                     <button class="btn btn-primary" type="submit">{% trans "Go!" %}</button>
                 </span>


### PR DESCRIPTION
Adding autofocus is an interuption to normal flow in keyboard access and bad for a11y. This is usually only sensible on single-purpose pages such as search (as in search-engine) and login/auth. As discussed, we keep it for the control-dashboard for now as not to interrupt workflow after login (you can just type away immediately to search). It is not ideal, but hopefully a workable compromise. I looked into alternatives like changing tab-order or manually auto-focusing through JS when the first thing one does after login is type, but that is to much magic and did not help.

In presale, there is an autofocus on the ContactForm, which is kind of in-between. One could argue it would help when you start the checkout-process and as you clicked a „button“ (actually a link), you showed the intent to start the process which begins with entering the email-address.

The other one in presale might be easy: presale.forms.customer.AuthenticationForm has an autofocus in the email-input. When used in the context of the single-purpose login page, that is a totally sensible thing to have. But the same form is used inside the checkout process and has a autofocus attribute on a initially hidden input – thanks to it being hidden, it has no effect. But technically it should not be there. Again, as it does not have a practical effect, I did not add extra code to disable it (like the checkout-info-step has for iframe-based checkouts).