### PR TITLE
fix: xff/xfh header name in 400_hostname template

### DIFF
--- a/src/pretix/base/templates/400_hostname.html
+++ b/src/pretix/base/templates/400_hostname.html
@@ -28,7 +28,7 @@
             <code>Host: {{ request.headers.Host }}</code>
             {% if xfh %}
             <br>
-            <code>X-Forwarded-For: {{ xfh }}</code>
+            <code>X-Forwarded-Host: {{ xfh }}</code>
             {% if not settings.USE_X_FORWARDED_HOST %}({% trans "ignored" %}){% endif %}
             {% endif %}
         </dd>


### PR DESCRIPTION
Currently, the "unknown host" 400 error page erroneously presents the `X-Forwarded-Host` header as `X-Forwarded-For`.

This PR fixes this mixup.