### PR TITLE
Search engines: Do not index event lists for specific dates (#23185037)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -15,6 +15,8 @@
 {% block custom_header %}
     {% if event.settings.meta_noindex %}
         <meta name="robots" content="noindex, nofollow">
+    {% elif "date" in request.GET or "old" in request.GET %}
+        <meta name="robots" content="noindex, follow">
     {% endif %}
     <meta property="og:type" content="website" />
     {% if social_image %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/base.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/base.html
@@ -11,6 +11,8 @@
 {% block custom_header %}
     {% if organizer.settings.meta_noindex %}
         <meta name="robots" content="noindex, nofollow">
+    {% elif "date" in request.GET or "old" in request.GET %}
+        <meta name="robots" content="noindex, follow">
     {% endif %}
     <meta property="og:type" content="website" />
 


### PR DESCRIPTION
Users usually do not want to have the list of old events or the list of events in a specific month as a search result. However, these are still interesting pages for search engines to crawl and discover events. So let's set them to noindex but follow.