### PR TITLE
Add min/max-imit on giftcard_expiry_years

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3291,6 +3291,8 @@ Your {organizer} team"""))  # noqa: W291
             label=_('Validity of gift card codes in years'),
             help_text=_('If you set a number here, gift cards will by default expire at the end of the year after this '
                         'many years. If you keep it empty, gift cards do not have an explicit expiry date.'),
+            min_value=0,
+            max_value=99,
         )
     },
     'cookie_consent': {


### PR DESCRIPTION
Currently it was possible to enter negative as well as very large positive numbers, which then failed calculation for validity-dates. This PR sets min 0 and max 99 years.