### PR TITLE
Add missing question mark to delete check-ins confirmation form

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/checkin/bulk_revert_confirm.html
+++ b/src/pretix/control/templates/pretixcontrol/checkin/bulk_revert_confirm.html
@@ -13,7 +13,7 @@
         {% endfor %}
 		<p>
             {% blocktrans trimmed count count=cnt %}
-                Are you sure you want to permanently delete the check-ins of <strong>one ticket</strong>.
+                Are you sure you want to permanently delete the check-ins of <strong>one ticket</strong>?
             {% plural %}
                 Are you sure you want to permanently delete the check-ins of <strong>{{ count }} tickets</strong>?
             {% endblocktrans %}


### PR DESCRIPTION
It is a question, so it needs to end with a question mark.