### PR TITLE
Date picker: Guess default time 23:59 for end dates (Z#23182900)

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -205,7 +205,7 @@ var form_handlers = function (el) {
                     return;
                 }
                 if ($timepicker.val() === "") {
-                    if ($(this).attr("name").includes("_until") || $(this).attr("name").includes("_end")) {
+                    if (/_(until|end|to)(_|$)/.test($(this).attr("name"))) {
                         date.set({'hour': 23, 'minute': 59, 'second': 59});
                     } else {
                         date.set({'hour': 0, 'minute': 0, 'second': 0});

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -205,7 +205,11 @@ var form_handlers = function (el) {
                     return;
                 }
                 if ($timepicker.val() === "") {
-                    date.set({'hour': 0, 'minute': 0, 'second': 0});
+                    if ($(this).attr("name").includes("_until") || $(this).attr("name").includes("_end")) {
+                        date.set({'hour': 23, 'minute': 59, 'second': 59});
+                    } else {
+                        date.set({'hour': 0, 'minute': 0, 'second': 0});
+                    }
                     $timepicker.data('DateTimePicker').date(date);
                 }
             });

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -91,7 +91,7 @@ var form_handlers = function (el) {
                     return;
                 }
                 if ($timepicker.val() === "") {
-                    if ($(this).attr("name").includes("_until") || $(this).attr("name").includes("_end")) {
+                    if (/_(until|end|to)(_|$)/.test($(this).attr("name"))) {
                         date.set({'hour': 23, 'minute': 59, 'second': 59});
                     } else {
                         date.set({'hour': 0, 'minute': 0, 'second': 0});

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -91,7 +91,11 @@ var form_handlers = function (el) {
                     return;
                 }
                 if ($timepicker.val() === "") {
-                    date.set({'hour': 0, 'minute': 0, 'second': 0});
+                    if ($(this).attr("name").includes("_until") || $(this).attr("name").includes("_end")) {
+                        date.set({'hour': 23, 'minute': 59, 'second': 59});
+                    } else {
+                        date.set({'hour': 0, 'minute': 0, 'second': 0});
+                    }
                     $timepicker.data('DateTimePicker').date(date);
                 }
             });


### PR DESCRIPTION
When a filter form asks users to select a datetime range, it is a common scenario that users want to filter just by date. However, this will easily lead to off-by-one-errors, as "Feb 1st, 00:00 to Feb 28th, 00:00" is missing the last day of February. This PR tries to detect these fields and use a different initial value for the time field.