### PR TITLE
Order search: Proper input validation with error feedback for advanced search

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/orders/search.html
+++ b/src/pretix/control/templates/pretixcontrol/orders/search.html
@@ -7,7 +7,8 @@
 {% block title %}{% trans "Order search" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Order search" %}</h1>
-    <form class="form-horizontal" action="{% url "control:event.orders" event=request.event.slug organizer=request.event.organizer.slug %}" method="get">
+    <form class="form-horizontal" method="post">
+        {% csrf_token %}
         {% for f in forms %}
             {% bootstrap_form_errors f layout='control' %}
             {% for field in f %}

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -171,6 +171,26 @@ class OrderSearch(OrderSearchMixin, EventPermissionRequiredMixin, TemplateView):
         ctx['forms'] = self.get_forms()
         return ctx
 
+    def post(self, request, *args, **kwargs):
+        all_valid = True
+        for f in self.get_forms():
+            if not f.is_valid():
+                all_valid = False
+
+        if all_valid:
+            data = request.POST.copy()
+            data.pop('csrfmiddlewaretoken', None)
+            return redirect(reverse(
+                "control:event.orders",
+                kwargs={
+                    "event": request.event.slug,
+                    "organizer": request.event.organizer.slug,
+                }
+            ) + '?' + data.urlencode())
+        else:
+            messages.error(request, _("We could not process your input. See below for details."))
+            return self.get(request, *args, **kwargs)
+
 
 class BaseOrderBulkActionView(OrderSearchMixin, EventPermissionRequiredMixin, AsyncFormView):
     template_name = 'pretixcontrol/orders/bulk_action.html'


### PR DESCRIPTION
Previously, if input was valid, the entire search query was just ignored.