### PR TITLE
Display "Order status" correctly in the "Search query" line of advanced search results

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -70,6 +70,7 @@ from pretix.helpers.database import (
 )
 from pretix.helpers.dicts import move_to_end
 from pretix.helpers.i18n import get_format_without_seconds, i18ncomp
+from pretix.helpers.models import flatten_choices
 
 PAYMENT_PROVIDERS = []
 
@@ -177,10 +178,10 @@ class FilterForm(forms.Form):
             elif isinstance(v, Model):
                 val = '"' + str(v) + '"'
             elif isinstance(f, forms.MultipleChoiceField):
-                valdict = dict(f.choices)
+                valdict = dict(flatten_choices(f.choices))
                 val = ' or '.join([str(valdict.get(m)) for m in v])
             elif isinstance(f, forms.ChoiceField):
-                val = str(dict(f.choices).get(v))
+                val = str(dict(flatten_choices(f.choices)).get(v))
             elif isinstance(v, datetime):
                 val = date_format(v, 'SHORT_DATETIME_FORMAT')
             elif isinstance(v, Decimal):

--- a/src/pretix/helpers/models.py
+++ b/src/pretix/helpers/models.py
@@ -44,3 +44,13 @@ def modelcopy(obj: models.Model, **kwargs):
         else:
             setattr(n, f.name, copy.deepcopy(val))
     return n
+
+
+# django 5 contains this in django.utils.choices.flatten_choices
+def flatten_choices(choices):
+    """Flatten choices by removing nested values."""
+    for value_or_group, label_or_nested in choices or ():
+        if isinstance(label_or_nested, (list, tuple)):
+            yield from label_or_nested
+        else:
+            yield value_or_group, label_or_nested


### PR DESCRIPTION
Currently, it always says:

> Search query: Order status: None

Regardless of the order status chosen