### PR TITLE
Clarify description for offsetting refunds

### DIFF
--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -1308,6 +1308,9 @@ class OffsettingProvider(BasePaymentProvider):
     def payment_control_render(self, request: HttpRequest, payment: OrderPayment) -> str:
         return _('Balanced against orders: %s' % ', '.join(payment.info_data['orders']))
 
+    def refund_control_render(self, request: HttpRequest, payment: OrderPayment) -> str:
+        return self.payment_control_render(request, payment)
+
 
 class GiftCardPayment(BasePaymentProvider):
     identifier = "giftcard"


### PR DESCRIPTION
The 'offsetting' payment method includes a clear description specifying which order the offsetting applies to, but the associated refund does not. This commit ensures refunds use the same message as payments, making the associated order explicit.