### PR TITLE
Fix label matching when copying answers (Z#23186844)

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -388,13 +388,13 @@ $(function () {
         var source_label = get_label_text_for_id(source.id);
 
         var $first_ticket_form = $(".questions-form").first().find("[data-addonidx=0]");
-        var $candidates = $first_ticket_form.find(source.tagName + ":not([type='checkbox'], [type='radio'])");
+        var $candidates = $first_ticket_form.find(source.tagName + ":not([type='checkbox'], [type='radio'], [type='hidden'])");
         var $match = $candidates.filter(function() {
             return (
                 this.id.endsWith(source.id.substring(3))
                 || (this.placeholder && this.placeholder === source.placeholder)
                 || (this.placeholder && this.placeholder === source_label)
-                || (source_label && get_label_text_for_id(this.id) === source_label)
+                || (source_label && this.id && get_label_text_for_id(this.id) === source_label)
             );
         }).first();
         $match.val(this.value).trigger("change");


### PR DESCRIPTION
When there is an image-question for the product, a hidden input for cropdata is created, which the copy-to-first-form fails on as that hidden input does not have an id and also not a label. This PR does two things to prevent this: 1. it only tries to match labels if input has an id (because otherwise the get-label-through-id-selector fails) and 2. do not even select inputs with type=hidden as possible matches.