### PR TITLE
API: fix event creation sales-channel-migration

### DIFF
--- a/src/pretix/api/serializers/__init__.py
+++ b/src/pretix/api/serializers/__init__.py
@@ -80,7 +80,14 @@ class SalesChannelMigrationMixin:
             raise ValueError("organizer not in context")
 
     def to_internal_value(self, data):
-        if data.get("sales_channels") is not None:
+        if "sales_channels" in data:
+            if data["sales_channels"] is None:
+                raise ValidationError({
+                    "sales_channels": [
+                        "The legacy attribute 'sales_channels' cannot be set to None, it must be a list."
+                    ]
+                })
+
             prefetch_related_objects([self.organizer], "sales_channels")
             all_channels = {
                 s.identifier for s in
@@ -110,7 +117,6 @@ class SalesChannelMigrationMixin:
                 data["all_sales_channels"] = False
                 data["limit_sales_channels"] = data["sales_channels"]
 
-        if "sales_channels" in data:
             del data["sales_channels"]
 
         if data.get("all_sales_channels"):

--- a/src/pretix/api/serializers/__init__.py
+++ b/src/pretix/api/serializers/__init__.py
@@ -96,7 +96,7 @@ class SalesChannelMigrationMixin:
 
             if data.get("all_sales_channels") and set(data["sales_channels"]) != all_channels:
                 raise ValidationError({
-                    "limit_sales_channels": [
+                    "all_sales_channels": [
                         "If 'all_sales_channels' is set, the legacy attribute 'sales_channels' must not be set or set to "
                         "the list of all sales channels."
                     ]

--- a/src/pretix/api/serializers/__init__.py
+++ b/src/pretix/api/serializers/__init__.py
@@ -80,7 +80,7 @@ class SalesChannelMigrationMixin:
             raise ValueError("organizer not in context")
 
     def to_internal_value(self, data):
-        if "sales_channels" in data:
+        if data.get("sales_channels") is not None:
             prefetch_related_objects([self.organizer], "sales_channels")
             all_channels = {
                 s.identifier for s in
@@ -109,6 +109,8 @@ class SalesChannelMigrationMixin:
             else:
                 data["all_sales_channels"] = False
                 data["limit_sales_channels"] = data["sales_channels"]
+
+        if "sales_channels" in data:
             del data["sales_channels"]
 
         if data.get("all_sales_channels"):


### PR DESCRIPTION
We stumbled over an issue where copying an event through the API had a `data["sales_channels"]` being `None`, which caused the serialization to fail. This PR only migrates legacy sales_channels if there are any.