### PR TITLE
Fix datepicker date display when using min/max (Z#23185544)

### DIFF
--- a/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
+++ b/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
@@ -947,7 +947,7 @@
 
                 input.blur();
 
-                viewDate = date.clone();
+                //viewDate = date.clone();
 
                 return picker;
             },

--- a/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
+++ b/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
@@ -947,7 +947,6 @@
 
                 input.blur();
 
-                // custom edit: do not date.clone() as this breaks when minDate/maxDate is outside of date's month
                 //viewDate = date.clone();
 
                 return picker;

--- a/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
+++ b/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
@@ -947,6 +947,7 @@
 
                 input.blur();
 
+                // custom edit: do not date.clone() as this breaks when minDate/maxDate is outside of date's month
                 //viewDate = date.clone();
 
                 return picker;

--- a/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
+++ b/src/pretix/static/datetimepicker/bootstrap-datetimepicker.js
@@ -947,7 +947,7 @@
 
                 input.blur();
 
-                //viewDate = date.clone();
+                viewDate = date.clone();
 
                 return picker;
             },

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -196,7 +196,15 @@ var form_handlers = function (el) {
         }
         if ($(this).is('[data-is-payment-date]'))
             opts["daysOfWeekDisabled"] = JSON.parse($("body").attr("data-payment-weekdays-disabled"));
-        $(this).datetimepicker(opts);
+        $(this).datetimepicker(opts).on("dp.hide", function() {
+            // when min/max is used in datetimepicker, closing and re-opening the picker opens at the wrong date
+            // therefore keep the current viewDate and re-set it after datetimepicker is done hiding
+            var $dtp = $(this).data("DateTimePicker");
+            var currentViewDate = $dtp.viewDate();
+            window.setTimeout(function () {
+                $dtp.viewDate(currentViewDate);
+            }, 50);
+        });
         if ($(this).parent().is('.splitdatetimerow')) {
             $(this).on("dp.change", function (ev) {
                 var $timepicker = $(this).closest(".splitdatetimerow").find(".timepickerfield");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -82,7 +82,13 @@ var form_handlers = function (el) {
                     Math.abs(+new Date(opts.minDate) - new Date()) < Math.abs(+new Date(opts.maxDate) - new Date())
             ) ? opts.minDate : opts.maxDate;
         }
-        $(this).datetimepicker(opts);
+        $(this).datetimepicker(opts).on("dp.hide", function() {
+            var $dtp = $(this).data("DateTimePicker");
+            var currentViewDate = $dtp.viewDate();
+            window.setTimeout(function () {
+                $dtp.viewDate(currentViewDate);
+            }, 500);
+        });
         if ($(this).parent().is('.splitdatetimerow')) {
             $(this).on("dp.change", function (ev) {
                 var $timepicker = $(this).closest(".splitdatetimerow").find(".timepickerfield");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -83,11 +83,13 @@ var form_handlers = function (el) {
             ) ? opts.minDate : opts.maxDate;
         }
         $(this).datetimepicker(opts).on("dp.hide", function() {
+            // when min/max is used in datetimepicker, closing and re-opening the picker opens at the wrong date
+            // therefore keep the current viewDate and re-set it after datetimepicker is done hiding
             var $dtp = $(this).data("DateTimePicker");
             var currentViewDate = $dtp.viewDate();
             window.setTimeout(function () {
                 $dtp.viewDate(currentViewDate);
-            }, 500);
+            }, 50);
         });
         if ($(this).parent().is('.splitdatetimerow')) {
             $(this).on("dp.change", function (ev) {


### PR DESCRIPTION
When using min/max dates in datepicker (either one or both) when opening, closing and then opening the datepicker again, the currentDate is now and datepicker-nav is disabled. This PR fixes the behaviour, ~~but changes a depency – although an old one. I was not able to find a way to fix this from the outside, so changing it in the dependency was the only way. Actually, there might be a way~~: register an event-listener to `dp.hide` and set the `viewDate(viewDate)` manually to a correct one inside the boundaries of minDate/maxDate. This needs to be done everywhere, where we instantiate datepicker though, but that is currently only in one spot.