### PR TITLE
Fix datepicker locale when using min/max

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -69,8 +69,6 @@ var cart = {
 $(function () {
     "use strict";
 
-    moment.locale($("body").attr("data-locale").substr(0, 2));
-
     if ($("#cart-deadline").length) {
         cart.init();
     }

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -328,6 +328,7 @@ $(function () {
     "use strict";
 
     $("body").removeClass("nojs");
+    moment.locale($("body").attr("data-datetimelocale"));
 
     var scrollpos = sessionStorage ? sessionStorage.getItem('scrollpos') : 0;
     if (scrollpos) {


### PR DESCRIPTION
When using min/max with datepicker, the minDate/maxDate is parsed with moment() and replaces the viewDate inside datepicker. We have three options to fix this bug:

1. Change bootstrap-datepicker dependency to apply `options.locale` when parsing a date.
2. Add our own parseInputDate to `options` when instantiating datepickers
3. Globally tell `moment()` to use `body[data-datetimelocale]`

I did not want to change a dependency if not needed (1.). Providing a custom `options.parseInputDate` seemed error-prone as we need to provide it everywhere where we instantiate a datepicker (2.). So I chose 3, which IMHO anyways feels like the right way to do to make sure all dates on the page are used with the correct locale.