### PR TITLE
Fix checkin-list-filter test randomly matching secret

### DIFF
--- a/src/tests/control/test_checkins.py
+++ b/src/tests/control/test_checkins.py
@@ -221,7 +221,7 @@ def checkin_list_env():
         item=item_ticket,
         variation=None,
         price=Decimal("23"),
-        attendee_name_parts={'full_name': "a4"},  # a3 attendee is a4
+        attendee_name_parts={'full_name': "a4attendee"},  # a3 attendee is a4attendee
         attendee_email="a3company@dummy.test"
     )
 
@@ -267,7 +267,7 @@ def test_checkins_list_ordering(client, checkin_list_env, order_key, expected):
     ('status=3&item=&user=', ['A3Ticket']),
     ('status=&item=&user=a3dummy', ['A3Ticket']),  # match order email
     ('status=&item=&user=a3dummy', ['A3Ticket']),  # match order email,
-    ('status=&item=&user=a4', ['A3Ticket']),  # match attendee name
+    ('status=&item=&user=a4attendee', ['A3Ticket']),  # match attendee name
     ('status=&item=&user=a3company', ['A3Ticket']),  # match attendee email
     ('status=1&item=&user=a3company', ['A3Ticket']),
 ])


### PR DESCRIPTION
`test_checkins_list_filter` happened to randomly falsely match op.secret with its short attendee_name „a4“. This PR changes the test to use a longer attendee_name.