### PR TITLE
Add order secret as email placeholder

### DIFF
--- a/src/pretix/base/services/placeholders.py
+++ b/src/pretix/base/services/placeholders.py
@@ -322,6 +322,9 @@ def base_placeholders(sender, **kwargs):
             'code', ['order'], lambda order: order.code, 'F8VVL'
         ),
         SimpleFunctionalTextPlaceholder(
+            'secret', ['order'], lambda order: order.secret, '6zzjnumtsx136ddy'
+        ),
+        SimpleFunctionalTextPlaceholder(
             'total', ['order'], lambda order: LazyNumber(order.total), lambda event: LazyNumber(Decimal('42.23'))
         ),
         SimpleFunctionalTextPlaceholder(


### PR DESCRIPTION
This PR introduces a new feature that allows for the use of the order secret as a placeholder in email content settings. This enhancement enables greater customization, such as the creation of links to login pages from external tools that utilize the same secret for authentication. 

As part of our integration of pretix as the external presale platform for StuStaPay, we aim to streamline our customer experience. After purchasing a ticket through pretix, we want our customers to seamlessly log in to our customer frontend to manage tasks such as account balance charging. To facilitate this, we export pretix's order secret, enabling customers to use it in the URL for login purposes (see the example below). Currently, pretix does not provide the option to include the order secret within the payment confirmation email setup. This PR adds this functionality.


![screenshot of the email setup page with secret placeholder](https://github.com/user-attachments/assets/6e9e0c06-0be4-493a-8be9-9721600e7512)

