### PR TITLE
[WIP] Allow registering for all events in an event series

### DIFF
--- a/local_install.sh
+++ b/local_install.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# https://docs.pretix.eu/en/latest/admin/installation/manual_smallscale.html
+
+BASE=pretix_dev # pretix for production
+
+# FIRST TIME ONLY
+# sudo apt-get install nginx postgresql redis nodejs git build-essential python3-dev python3-venv python3 python3-pip libxml2-dev libxslt1-dev libffi-dev zlib1g-dev libssl-dev gettext libpq-dev libjpeg-dev libopenjp2-7-dev
+# git clone git@github.com:carpentries/pretix.git
+# sudo adduser pretix --disabled-password --home /var/pretix
+
+# sudo -u postgres psql -c 'SHOW SERVER_ENCODING'
+# sudo -u postgres createuser pretix
+# sudo -u postgres createdb -O pretix $BASE
+# sudo mkdir /etc/$BASE
+# sudo touch /etc/$BASE/pretix.cfg
+# sudo chown -R pretix:pretix /etc/$BASE/
+# sudo chmod 0600 /etc/$BASE/pretix.cfg
+
+# EDIT CONFIG
+# sudo nano /etc/$BASE/pretix.cfg
+# sudo mkdir /var/$BASE
+# sudo chown -R pretix.pretix /var/$BASE
+# cd /var/$BASE
+# sudo -u pretix -s
+# python3 -m venv /var/$BASE/venv
+# mkdir -p /var/$BASE/data/media
+# chmod +x /var/$BASE
+
+source /var/pretix_dev/venv/bin/activate
+pip install -U pip setuptools wheel gunicorn
+pip install --target=static.dist .
+python -m pretix migrate
+cd src
+make npminstall
+cd ..
+python -m pretix rebuild
+
+#server {
+#    listen 8347 default_server;
+#    listen [::]:8347 ipv6only=on default_server;
+#    server_name test-pretix;
+
+#    location / {
+#        proxy_pass http://localhost:8346;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        proxy_set_header X-Forwarded-Proto http;
+#        proxy_set_header Host $http_host;
+#    }
+#    location /media/ {
+#        alias /var/pretix_dev/data/media/;
+#        expires 7d;
+#        access_log off;
+#    }
+#    location ^~ /media/cachedfiles {
+#        deny all;
+#        return 404;
+#    }
+#    location ^~ /media/invoices {
+#        deny all;
+#        return 404;
+#    }
+#    location /static/ {
+#        alias /var/pretix_dev/build/lib/pretix/static.dist/;
+#        access_log off;
+#        expires 365d;
+#        add_header Cache-Control "public";
+#    }
+#}
+
+## once installed
+source /var/pretix_dev/venv/bin/activate
+rm -rf static.dist/ && pip install --target=static.dist .
+
+## as a sudoer
+sudo systemctl restart pretix-web pretix-worker nginx

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -215,6 +215,12 @@ class EventMixin:
         return pytz_deprecation_shim.timezone(self.settings.timezone)
 
     @property
+    def tzstr(self):
+        tz = pytz_deprecation_shim.timezone(self.settings.timezone)
+        dftz = self.date_from.astimezone(tz)
+        return dftz.tzname()
+
+    @property
     def effective_presale_end(self):
         """
         Returns the effective presale end date, taking for subevents into consideration if the presale end

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -439,17 +439,17 @@ class CartManager:
                     raise CartError(error_messages['unavailable'])
 
             if op.subevent and op.item.pk in op.subevent.item_overrides and not op.subevent.item_overrides[op.item.pk].is_available():
-                raise CartError(error_messages['not_for_sale'])
+                raise CartError("L442: " + error_messages['not_for_sale'])
 
             if op.subevent and op.variation and op.variation.pk in op.subevent.var_overrides and \
                     not op.subevent.var_overrides[op.variation.pk].is_available():
-                raise CartError(error_messages['not_for_sale'])
+                raise CartError("L446: " + error_messages['not_for_sale'])
 
             if op.item.has_variations and not op.variation:
-                raise CartError(error_messages['not_for_sale'])
+                raise CartError("L449: " + error_messages['not_for_sale'])
 
             if op.variation and op.variation.item_id != op.item.pk:
-                raise CartError(error_messages['not_for_sale'])
+                raise CartError("L452: " + error_messages['not_for_sale'])
 
             if op.voucher and not op.voucher.applies_to(op.item, op.variation):
                 raise CartError(error_messages['voucher_invalid_item'])

--- a/src/pretix/control/views/dashboards.py
+++ b/src/pretix/control/views/dashboards.py
@@ -91,12 +91,19 @@ def base_widgets(sender, subevent=None, lazy=False, **kwargs):
         tickc = opqs.filter(
             order__event=sender, item__admission=True,
             order__status__in=(Order.STATUS_PAID, Order.STATUS_PENDING),
-        ).count()
+        )
 
         paidc = opqs.filter(
             order__event=sender, item__admission=True,
             order__status=Order.STATUS_PAID,
-        ).count()
+        )
+
+        if ('bundle_series_events' in sender.meta_data and sender.meta_data['bundle_series_events'] == "true"):
+            tickc = tickc.values('order__customer').distinct().count()
+            paidc = paidc.values('order__customer').distinct().count()
+        else:
+            tickc = tickc.count()
+            paidc = paidc.count()
 
         if subevent:
             rev = opqs.filter(

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -55,6 +55,7 @@
                         <dd>{{ line.voucher.code }}</dd>
                     </div>
                 {% endif %}
+
                 {% if line.subevent %}
                     <div class="cart-icon-details">
                         <dt class="sr-only">{% trans "Date:" context "subevent" %}</dt>
@@ -91,6 +92,7 @@
                     {% endif %}
                     {% endif %}
                 {% endif %}
+
                 {% if line.used_membership %}
                     <div class="cart-icon-details">
                         <dt class="sr-only">{% trans "Membership:" %}</dt>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
@@ -15,12 +15,14 @@
             {{ ev.get_date_range_display_as_html }}
             {% if event.settings.show_times %}
                 <br>
-                <span data-time="{{ ev.date_from.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                <span class="event-time" data-time="{{ ev.date_from.isoformat }}" data-timezone="{{ request.event.timezone }}">
+                    <br>
+                    <span class="fa fa-clock-o" aria-hidden="true"></span>
                     {% with time_human=ev.date_from|date:"TIME_FORMAT" time_24=ev.date_from|time:"H:i" %}
                         {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
                             Begin: {{ time }}
                         {% endblocktrans %}
-                        {{ request.event.timezone }}
+                        {{ request.event.tzstr }}
                     {% endwith %}
                 </span>
                 {% if event.settings.show_date_to and ev.date_to %}
@@ -30,7 +32,7 @@
                             {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
                                 End: {{ time }}
                             {% endblocktrans %}
-                            {{ request.event.timezone }}
+                            {{ request.event.tzstr }}
                         {% endwith %}
                     </span>
                 {% endif %}
@@ -43,7 +45,7 @@
                             {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
                                 Admission: {{ time }}
                             {% endblocktrans %}
-                            {{ request.event.timezone }}
+                            {{ request.event.tzstr }}
                         {% endwith %}
                     </span>
                 {% else %}
@@ -52,7 +54,7 @@
                             {% blocktrans trimmed with datetime='<time datetime="'|add:datetime_iso|add:'">'|add:datetime_human|add:"</time>"|safe %}
                                 Admission: {{ datetime }}
                             {% endblocktrans %}
-                            {{ request.event.timezone }}
+                            {{ request.event.tzstr }}
                         {% endwith %}
                     </span>
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
@@ -20,6 +20,7 @@
                         {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
                             Begin: {{ time }}
                         {% endblocktrans %}
+                        {{ request.event.timezone }}
                     {% endwith %}
                 </span>
                 {% if event.settings.show_date_to and ev.date_to %}
@@ -29,6 +30,7 @@
                             {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
                                 End: {{ time }}
                             {% endblocktrans %}
+                            {{ request.event.timezone }}
                         {% endwith %}
                     </span>
                 {% endif %}
@@ -41,6 +43,7 @@
                             {% blocktrans trimmed with time='<time datetime="'|add:time_24|add:'">'|add:time_human|add:"</time>"|safe %}
                                 Admission: {{ time }}
                             {% endblocktrans %}
+                            {{ request.event.timezone }}
                         {% endwith %}
                     </span>
                 {% else %}
@@ -49,6 +52,7 @@
                             {% blocktrans trimmed with datetime='<time datetime="'|add:datetime_iso|add:'">'|add:datetime_human|add:"</time>"|safe %}
                                 Admission: {{ datetime }}
                             {% endblocktrans %}
+                            {{ request.event.timezone }}
                         {% endwith %}
                     </span>
                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -205,35 +205,63 @@
                                 {% if var.cached_availability.0 == 100 and not item.current_unavailability_reason and not var.current_unavailability_reason %}
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
 										{% if var.order_max == 1 %}
-                                            <label class="btn btn-default btn-checkbox">
-                                                <input type="checkbox" value="1"
-                                                    {% if item.free_price %}
-                                                       data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
-                                                    {% endif %}
-                                                       {% if not ev.presale_is_running %}disabled{% endif %}
-                                                       id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
-                                                       {% if var.description %} aria-describedby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
-                                                <i class="fa fa-shopping-cart" aria-hidden="true"></i>
-                                                {% trans "Select" context "checkbox" %}
-                                            </label>
+                                            {% if 'bundle_series_events' in ev.meta_data and ev.meta_data.bundle_series_events == "true" %}
+                                                <label class="btn btn-default btn-checkbox">
+                                                    <input type="checkbox" value="1"
+                                                        {% if item.free_price %}
+                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                        {% endif %}
+                                                        disabled
+                                                        checked
+                                                        id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                        name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                        aria-label="{% blocktrans with item=item.name var=var %}Bundled {{ item }}, {{ var }} to cart{% endblocktrans %}"
+                                                        {% if var.description %} aria-describedby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
+                                                    <i class="fa fa-shopping-cart" aria-hidden="true"></i>
+                                                </label>
+                                            {% else %}
+                                                <label class="btn btn-default btn-checkbox">
+                                                    <input type="checkbox" value="1"
+                                                        {% if item.free_price %}
+                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                        {% endif %}
+                                                        {% if not ev.presale_is_running %}disabled{% endif %}
+                                                        id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                        name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                        aria-label="{% blocktrans with item=item.name var=var %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}"
+                                                        {% if var.description %} aria-describedby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
+                                                    <i class="fa fa-shopping-cart" aria-hidden="true"></i>
+                                                    {% trans "Select" context "checkbox" %}
+                                                </label>
+                                            {% endif %}
                                         {% else %}
                                             <fieldset class="input-item-count-group">
                                                 <legend class="sr-only">{% blocktrans with item=item.name %}Add {{ item }}, {{ var }} to cart{% endblocktrans %}</legend>
-                                                <button type="button" data-step="-1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
-                                                    {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
-                                                <input type="number" class="form-control input-item-count" placeholder="0" min="0"
-                                                       {% if not ev.presale_is_running %}disabled{% endif %}
+                                                {% if 'bundle_series_events' in ev.meta_data and ev.meta_data.bundle_series_events == "true" %}
+                                                    <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                                    {% if not ev.presale_is_running %}disabled{% endif %}
                                                         {% if item.free_price %}
-                                                           data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
                                                         {% endif %}
-                                                       max="{{ var.order_max }}"
-                                                       id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       aria-label="{% trans "Quantity" %}">
-                                                <button type="button" data-step="1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}"
-                                                    {% if not ev.presale_is_running %}disabled{% endif %}>+</button>
+                                                    max="{{ var.order_max }}"
+                                                    id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                    name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                    aria-label="{% trans "Quantity" %}">
+                                                {% else %}
+                                                    <button type="button" data-step="-1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="{% trans "Decrease quantity" %}"
+                                                        {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
+                                                    <input type="number" class="form-control input-item-count" placeholder="0" min="0"
+                                                        {% if not ev.presale_is_running %}disabled{% endif %}
+                                                            {% if item.free_price %}
+                                                            data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                            {% endif %}
+                                                        max="{{ var.order_max }}"
+                                                        id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                        name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                        aria-label="{% trans "Quantity" %}">
+                                                    <button type="button" data-step="1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-inc" aria-label="{% trans "Increase quantity" %}"
+                                                        {% if not ev.presale_is_running %}disabled{% endif %}>+</button>
+                                                {% endif %}
                                             </fieldset>
                                         {% endif %}
                                     </div>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
@@ -2,6 +2,16 @@
 {% load icon %}
 {% load eventurl %}
 
+{% if 'bundle_series_events' in event.meta_data and event.meta_data.bundle_series_events == "true" %}
+    {% if "voucher" in request.GET %}
+        <div class="cart-icon-details">
+            <dt><span class="fa fa-tags fa-fw" aria-hidden="true"></span> {% trans "Voucher code used:" %}</dt>
+            <dd>{{ request.GET.voucher|urlencode }}</dd>
+            <input type="hidden" name="_voucher_code" value="{{ request.GET.voucher|urlencode }}">
+        </div>
+    {% endif %}
+{% endif %}
+
 <dl class="full-width-list alternating-rows">
 {% for subev in subevent_list.subevent_list %}
     <div class="row">
@@ -27,6 +37,10 @@
             </small>
         </dd>
         <dd class="col-md-2 col-xs-6 text-right flip">
+        {% if 'bundle_series_events' in subev.meta_data and subev.meta_data.bundle_series_events == "true" %}
+            {% icon "info" %} <i>Bundled Event</i>
+            <input type="hidden" name="bundled-subevent-item_" value="{{ event.id }}_{{ subev.id }}">
+        {% else %}
             <a class="btn btn-primary btn-block" href="{% if request.GET.voucher %}{% eventurl event "presale:event.redeem" cart_namespace=cart_namespace %}?voucher={{ request.GET.voucher|urlencode }}&amp;subevent={{ subev.pk }}{% else %}{% eventurl event "presale:event.index" subevent=subev.id cart_namespace=cart_namespace %}{% endif %}">
                 {% if subev.presale_is_running and subev.best_availability_state == 100 %}
                     {% icon "ticket" %} {% trans "Tickets" %}
@@ -34,6 +48,7 @@
                     {% icon "info" %} {% trans "More info" %}
                 {% endif %}
             </a>
+        {% endif %}
         </dd>
     </div>
 {% endfor %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_list.html
@@ -14,9 +14,10 @@
             {{ subev.get_date_range_display_as_html }}
             {% if event.settings.show_times %}
                 <br>
-                <span data-time="{{ subev.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
+                <span data-time="{{ subev.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-tzstr="{{ subev.tzstr }}" data-time-short>
+                    <br>
                     {% icon "clock-o" %}
-                    <time datetime="{{ subev.date_from.isoformat }}">{{ subev.date_from|date:"TIME_FORMAT" }}</time>
+                    <time datetime="{{ subev.date_from.isoformat }}">{{ subev.date_from|date:"TIME_FORMAT" }} {{ subev.tzstr }}</time>
                 </span>
             {% endif %}
         </dd>

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -37,6 +37,14 @@
     {% else %}
         <meta property="og:url" content="{% abseventurl request.event "presale:event.index" %}" />
     {% endif %}
+
+    {% for k, v in ev.meta_data.items %}
+        <meta property="og:{{ k }}" content="{{ v }}" />
+    {% endfor %}
+
+    {% if event_logo %}
+        <meta property="og:image" content="{{ event_logo|thumb:'5000x120' }}" />
+    {% endif %}
 {% endblock %}
 {% block content %}
 
@@ -63,60 +71,65 @@
                 </div>
             {% endif %}
 
-            {% if request.GET.voucher %}
+            <!-- {% if request.GET.voucher %}
                 <div class="alert alert-info">
                     <p>{% trans "Please select a date to redeem your voucher." %}</p>
                 </div>
-            {% endif %}
+            {% endif %} -->
         {% endif %}
 
-
-    {% if subevent_list_foldable %}
-        <details class="panel panel-{% if show_cart %}primary{% else %}default{% endif %}">
-            <summary class="panel-heading">
-    {% else %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-    {% endif %}
-                <h3 class="panel-title"><b>
-                {% if subevent_list_foldable %}
-                    {% if show_cart %}
-                        {% trans "Add tickets for a different date" %}
-                    {% else %}
-                        {% trans "View other date" %}
+        {% if 'bundle_series_events' in ev.meta_data and ev.meta_data.bundle_series_events == "true" %}
+            <h3 class="panel-title"><b>
+                Bundled Event Series
+            </b></h3>
+        {% else %}
+            {% if subevent_list_foldable %}
+                <details class="panel panel-{% if show_cart %}primary{% else %}default{% endif %}">
+                    <summary class="panel-heading">
+            {% else %}
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+            {% endif %}
+                        <h3 class="panel-title"><b>
+                        {% if subevent_list_foldable %}
+                            {% if show_cart %}
+                                {% trans "Add tickets for a different date" %}
+                            {% else %}
+                                {% trans "View other date" %}
+                            {% endif %}
+                        {% else %}
+                            {% trans "Choose date to book a ticket" %}
+                        {% endif %}</b>
+                        </h3>
+            {% if subevent_list_foldable %}
+                    </summary>
+                    <div>
+            {% else %}
+                    </div>
+            {% endif %}
+                    {% if filter_form.fields %}
+                        <div class="panel-subhead">
+                            {% include "pretixpresale/fragment_event_list_filter.html" with request=request %}
+                        </div>
                     {% endif %}
-                {% else %}
-                    {% trans "Choose date to book a ticket" %}
-                {% endif %}</b>
-                </h3>
-    {% if subevent_list_foldable %}
-            </summary>
-            <div>
-    {% else %}
-            </div>
-    {% endif %}
-            {% if filter_form.fields %}
-                <div class="panel-subhead">
-                    {% include "pretixpresale/fragment_event_list_filter.html" with request=request %}
+                        <div class="panel-body">
+                            {% cache_large 15 subevent_list subevent_list_cache_key %}
+                                {% if subevent_list.list_type == "calendar" %}
+                                    {% include "pretixpresale/event/fragment_subevent_calendar.html" %}
+                                {% elif subevent_list.list_type == "week" %}
+                                    {% include "pretixpresale/event/fragment_subevent_calendar_week.html" %}
+                                {% else %}
+                                    {% include "pretixpresale/event/fragment_subevent_list.html" %}
+                                {% endif %}
+                            {% endcache_large %}
+                        </div>
+            {% if subevent_list_foldable %}
+                    </div>
+                </details>
+            {% else %}
                 </div>
             {% endif %}
-                <div class="panel-body">
-                    {% cache_large 15 subevent_list subevent_list_cache_key %}
-                        {% if subevent_list.list_type == "calendar" %}
-                            {% include "pretixpresale/event/fragment_subevent_calendar.html" %}
-                        {% elif subevent_list.list_type == "week" %}
-                            {% include "pretixpresale/event/fragment_subevent_calendar_week.html" %}
-                        {% else %}
-                            {% include "pretixpresale/event/fragment_subevent_list.html" %}
-                        {% endif %}
-                    {% endcache_large %}
-                </div>
-    {% if subevent_list_foldable %}
-            </div>
-        </details>
-    {% else %}
-        </div>
-    {% endif %}
+        {% endif %}
 
         {% if subevent %}
             <h2 class="subevent-head">{{ subevent.name }}</h2>
@@ -226,7 +239,7 @@
                                         {% if allfree %}
                                             <i class="fa fa-check" aria-hidden="true"></i> {% trans "Register" context "free_tickets" %}
                                         {% else %}
-                                           <i class="fa fa-shopping-cart" aria-hidden="true"></i> {% trans "Proceed with checkout" %}
+                                        <i class="fa fa-shopping-cart" aria-hidden="true"></i> {% trans "Proceed with checkout" %}
                                         {% endif %}
                                     {% else %}
                                         <i class="fa fa-shopping-cart" aria-hidden="true"></i> {% trans "Add to cart" %}
@@ -239,7 +252,42 @@
                 {% endif %}
             </form>
         {% endif %}
+    {% elif event.has_subevents %}
+        {% if 'bundle_series_events' in ev.meta_data and ev.meta_data.bundle_series_events == "true" %}
+            <!-- allow booking all events in a series -->
+            <form method="post" data-asynctask
+                data-asynctask-headline="{% trans "We're now trying to reserve this for you!" %}"
+                data-asynctask-text="{% blocktrans with time=event.settings.reservation_time %}Once the items are in your cart, you will have {{ time }} minutes to complete your purchase.{% endblocktrans %}"
+                class="{% if event.seating_plan_id %}has-seating{% endif %}"
+                action="{% eventurl request.event "presale:event.cart.add" cart_namespace=cart_namespace %}?next_error={{ request.path|urlencode }}">
+                {% csrf_token %}
+
+                {% include "pretixpresale/event/fragment_subevent_list.html" %}
+                {% if ev.presale_is_running %}
+                    <div class="front-page">
+                        <div class="row">
+                            <div class="col-md-4 col-md-offset-8 col-xs-12">
+                                <button class="btn btn-block btn-primary btn-lg" type="submit" id="btn-add-to-cart">
+                                    {% if request.event.settings.redirect_to_checkout_directly %}
+                                        {% if allfree %}
+                                            <i class="fa fa-check" aria-hidden="true"></i> {% trans "Register" context "free_tickets" %}
+                                        {% else %}
+                                        <i class="fa fa-shopping-cart" aria-hidden="true"></i> {% trans "Proceed with checkout" %}
+                                        {% endif %}
+                                    {% else %}
+                                        <i class="fa fa-shopping-cart" aria-hidden="true"></i> {% trans "Register for all days" %}
+                                    {% endif %}
+                                </button>
+                            </div>
+                            <div class="clearfix"></div>
+                        </div>
+                    </div>
+                {% endif %}
+            </form>
+        {% endif %}
     {% endif %}
+
+
     </main>
     {% if show_vouchers %}
         <aside class="front-page" aria-labelledby="redeem-a-voucher">

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -171,7 +171,7 @@
             </div>
         {% endif %}
         {% if not cart_namespace or subevent %}
-            <div>
+            <div class="frag-event-info">
                 {% include "pretixpresale/event/fragment_event_info.html" with event=request.event subevent=subevent ev=ev show_location=True %}
             </div>
             {% eventsignal event "pretix.presale.signals.front_page_top" request=request subevent=subevent %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -72,7 +72,7 @@
                                             {% if event.time %}
                                                 <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
                                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
-                                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }}</time>
+                                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }} {{ event.timezone }}</time>
                                                     {% if event.event.settings.show_date_to and event.time_end %}
                                                         <span aria-hidden="true">–</span><span class="sr-only">{% trans "until" context "timerange" %}</span> <time datetime="{{ event.time_end|date_fast:"H:i" }}">{{ event.time_end|date_fast:"TIME_FORMAT" }}</time>
                                                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_calendar.html
@@ -70,9 +70,9 @@
                                         {% endif %}
                                         {% if not event.continued %}
                                             {% if event.time %}
-                                                <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
+                                                <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-tzstr="{{ event.event.tzstr }}" data-time-short>
                                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
-                                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }} {{ event.timezone }}</time>
+                                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }} {{ event.event.tzstr }}</time>
                                                     {% if event.event.settings.show_date_to and event.time_end %}
                                                         <span aria-hidden="true">–</span><span class="sr-only">{% trans "until" context "timerange" %}</span> <time datetime="{{ event.time_end|date_fast:"H:i" }}">{{ event.time_end|date_fast:"TIME_FORMAT" }}</time>
                                                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
@@ -68,12 +68,12 @@
                     {% if not event.continued %}
                         {% if event.time %}
                             <span class="event-time" data-time="{{ event.event.date_from.isoformat }}"
-                                  data-timezone="{{ event.timezone }}" data-time-short>
+                                  data-timezone="{{ event.timezone }}" data-tzstr="{{ event.event.tzstr }}" data-time-short>
                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
                                 {% if not show_names|default_if_none:True %}
                                     <strong>
                                 {% endif %}
-                                <time datetime="{{ event.time|date:"H:i" }}">{{ event.time|date:"TIME_FORMAT" }} {{ event.timezone }}</time>
+                                <time datetime="{{ event.time|date:"H:i" }}">{{ event.time|date:"TIME_FORMAT" }} {{ event.event.tzstr }}</time>
                                 {% if event.time_end %}
                                     <span role="img" aria-label="{% trans "to" context "timerange" %}">–</span>
                                     <time datetime="{{ event.time_end|date:"H:i" }}">{{ event.time_end|date:"TIME_FORMAT" }}</time>

--- a/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_day_calendar.html
@@ -73,7 +73,7 @@
                                 {% if not show_names|default_if_none:True %}
                                     <strong>
                                 {% endif %}
-                                <time datetime="{{ event.time|date:"H:i" }}">{{ event.time|date:"TIME_FORMAT" }}</time>
+                                <time datetime="{{ event.time|date:"H:i" }}">{{ event.time|date:"TIME_FORMAT" }} {{ event.timezone }}</time>
                                 {% if event.time_end %}
                                     <span role="img" aria-label="{% trans "to" context "timerange" %}">–</span>
                                     <time datetime="{{ event.time_end|date:"H:i" }}">{{ event.time_end|date:"TIME_FORMAT" }}</time>

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -41,7 +41,7 @@
                             {% if event.time %}
                                 <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
-                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }}</time>
+                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }} {{ event.timezone }}</time>
                                     {% if event.time_end %}
                                         <span aria-hidden="true">–</span><span class="sr-only">{% trans "until" context "timerange" %}</span> <time datetime="{{ event.time_end|date_fast:"H:i" }}">{{ event.time_end|date_fast:"TIME_FORMAT" }}</time>
                                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_week_calendar.html
@@ -39,9 +39,9 @@
                         {% endif %}
                         {% if not event.continued %}
                             {% if event.time %}
-                                <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-time-short>
+                                <span class="event-time" data-time="{{ event.event.date_from.isoformat }}" data-timezone="{{ event.timezone }}" data-tzstr="{{ event.event.tzstr }}" data-time-short>
                                     <span class="fa fa-clock-o" aria-hidden="true"></span>
-                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }} {{ event.timezone }}</time>
+                                    <time datetime="{{ event.time|date_fast:"H:i" }}">{{ event.time|date_fast:"TIME_FORMAT" }} {{ event.event.tzstr }}</time>
                                     {% if event.time_end %}
                                         <span aria-hidden="true">–</span><span class="sr-only">{% trans "until" context "timerange" %}</span> <time datetime="{{ event.time_end|date_fast:"H:i" }}">{{ event.time_end|date_fast:"TIME_FORMAT" }}</time>
                                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -66,12 +66,14 @@
                                 {% if e.settings.show_times %}
                                     {% timezone e.tzname %}
                                         <br>
-                                        <span class="text-muted" data-time="{{ e.date_from.isoformat }}" data-timezone="{{ e.tzname }}">
+                                        <span class="text-muted" data-time="{{ e.date_from.isoformat }}" data-timezone="{{ e.timezone }}" data-tzstr="{{ e.tzstr }}">
+                                            <br>
                                             {% icon "clock-o" %}
                                             {{ e.date_from|date:"TIME_FORMAT" }}
                                             {% if e.settings.show_date_to and e.date_to and e.date_to.date == e.date_from.date %}
                                                 – {{ e.date_to|date:"TIME_FORMAT" }}
                                             {% endif %}
+                                            &nbsp;{{ e.tzstr }}
                                         </span>
                                     {% endtimezone %}
                                 {% endif %}

--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -166,12 +166,13 @@ def _item_from_post_value(request, key, value, voucher=None, voucher_ignore_if_r
         except ValueError:
             pass
     elif 'subevent' in request.POST:
+        #  single subevent
         try:
             subevent = int(request.POST.get('subevent'))
         except ValueError:
             pass
 
-    if not key.startswith('item_') and not key.startswith('variation_') and not key.startswith('seat_'):
+    if not key.startswith('item_') and not key.startswith('variation_') and not key.startswith('seat_') and not key.startswith('bundled-subevent'):
         return
 
     parts = key.split("_")
@@ -224,6 +225,22 @@ def _item_from_post_value(request, key, value, voucher=None, voucher_ignore_if_r
                 'voucher': voucher,
                 'voucher_ignore_if_redeemed': voucher_ignore_if_redeemed,
                 'subevent': subevent
+            }
+        except ValueError:
+            raise CartError(_('Please enter numbers only.'))
+    elif key.startswith('bundled-subevent-item_'):
+        try:
+            subparts = value.split("_", 2)
+            e_id = int(subparts[0])
+            subevent_id = int(subparts[1])
+            return {
+                'item': e_id,
+                'variation': None,
+                'count': 1,
+                'price': price,
+                'voucher': voucher,
+                'voucher_ignore_if_redeemed': voucher_ignore_if_redeemed,
+                'subevent': subevent_id
             }
         except ValueError:
             raise CartError(_('Please enter numbers only.'))

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -539,26 +539,27 @@ $(function () {
         var tpl = '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner text-nowrap"></div></div>';
 
         $(this).tooltip({
-            "title": gettext("Time zone:") + " " + tz.abbr(t),
+            "title": gettext("Event time zone:") + " " + tz.abbr(t),
             "template": tpl
         });
         if (t.tz(tz.name).format() !== t.tz(local_tz).format()) {
             var $add = $("<span>")
             $add.append($("<span>").addClass("fa fa-globe"))
             if ($(this).is("[data-time-short]")) {
-                $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-timeformat"))))
+                $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
             } else {
                 $add.addClass("text-muted")
                 $add.append(" " + gettext("Your local time:") + " ")
                 if (t.tz(tz.name).format("YYYY-MM-DD") != t.tz(local_tz).format("YYYY-MM-DD")) {
-                    $add.append(t.tz(local_tz).format($("body").attr("data-datetimeformat")))
+                    $add.append(t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
                 } else {
-                    $add.append(t.tz(local_tz).format($("body").attr("data-timeformat")))
+                    $add.append(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
                 }
             }
-            $add.insertAfter($(this));
+            // $add.insertAfter($(this));
+            $add.insertBefore($(this));
             $add.tooltip({
-                "title": gettext("Time zone:") + " " + moment.tz.zone(local_tz).abbr(t),
+                "title": gettext("Your time zone:") + " " + moment.tz.zone(local_tz).abbr(t),
                 "template": tpl
             });
         }
@@ -641,7 +642,7 @@ $(function () {
         var currentTimeDisplayParts = [];
         timeFormatParts.forEach(function(format) {
             currentTimeDisplayParts.push([format, $("<span></span>").appendTo(currentTimeDisplay)])
-        }); 
+        });
         var duration = this.getAttribute("data-duration").split(":").reduce(function(previousValue, currentValue, currentIndex) {
             return previousValue + (currentIndex ? parseInt(currentValue, 10) * 60 : parseInt(currentValue, 10) * 60 * 60);
         }, 0);
@@ -654,7 +655,7 @@ $(function () {
                 currentTimeBar.remove();
                 return;
             }
-            
+
             var offset = thisCalendar.querySelector("h3").getBoundingClientRect().width;
             var dx = Math.round(offset + (thisCalendar.scrollWidth-offset)*(currentTimeDelta/duration));
             currentTimeDisplayParts.forEach(function(part) {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -546,7 +546,13 @@ $(function () {
             var $add = $("<span>")
             $add.append($("<span>").addClass("fa fa-globe"))
             if ($(this).is("[data-time-short]")) {
-                $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+                if (t.tz(tz.name).format("YYYY-MM-DD") != t.tz(local_tz).format("YYYY-MM-DD")) {
+                    $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+                    // $add.append(t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
+                } else {
+                    $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+                    // $add.append(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
+                }
             } else {
                 $add.addClass("text-muted")
                 $add.append(" " + gettext("Your local time:") + " ")

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -428,6 +428,9 @@ $(function () {
         }
     });
     var update_cart_form = function () {
+        var $pageDetails = $('head');
+        var bundle = $pageDetails.find('meta[property="og:bundle_series_events"]').attr("content");
+
         var is_enabled = $(".product-row input[type=checkbox]:checked, .variations input[type=checkbox]:checked, .product-row input[type=radio]:checked, .variations input[type=radio]:checked").length;
         if (!is_enabled) {
             $(".input-item-count").each(function () {
@@ -441,14 +444,12 @@ $(function () {
                 }
             });
         }
-        if (!is_enabled && (!$(".has-seating").length || $("#seating-dummy-item-count").length)) {
+        if (!bundle && !is_enabled && (!$(".has-seating").length || $("#seating-dummy-item-count").length)) {
             $("#btn-add-to-cart").prop("disabled", !is_enabled).popover({
                 'content': function () { return gettext("Please enter a quantity for one of the ticket types.") },
                 'placement': 'top',
                 'trigger': 'hover focus'
             });
-        } else {
-            $("#btn-add-to-cart").prop("disabled", false).popover("destroy")
         }
     };
     update_cart_form();

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -554,12 +554,12 @@ $(function () {
                     // $add.append(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
                 }
             } else {
-                $add.addClass("text-muted")
+                // $add.addClass("text-muted")
                 $add.append(" " + gettext("Your local time:") + " ")
                 if (t.tz(tz.name).format("YYYY-MM-DD") != t.tz(local_tz).format("YYYY-MM-DD")) {
-                    $add.append(t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
+                    $add.append($("<strong>").text(t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
                 } else {
-                    $add.append(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
+                    $add.append($("<strong>").text(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
                 }
             }
             // $add.insertAfter($(this));
@@ -570,6 +570,52 @@ $(function () {
             });
         }
     });
+
+    // $(".frag-event-info").each(function() {
+    //     var fei = $(this);
+    //     var $infodiv = fei.find(".info-row").first();
+    //     var $newinfodiv = $("<div>");
+    //     $newinfodiv.addClass("info-row");
+    //     $newinfodiv.append($("<span>").addClass("fa fa-globe fa-fw"));
+    //     // aria-hidden="true" title="{% trans "When does the event happen?" %}"></span>
+
+    //     var $newp = $("<p>");
+    //     $newp.append($("<span>").addClass("sr-only"));
+
+    //     fei.find("span[data-timezone], small[data-timezone]").first().each(function() {
+    //         var tsp = $(this)
+    //         var t = moment.tz(tsp.attr("data-time"), tsp.attr("data-timezone"))
+    //         var tz = moment.tz.zone(tsp.attr("data-timezone"))
+
+    //         if (t.tz(tz.name).format() !== t.tz(local_tz).format()) {
+    //             var $add = $("<span>")
+    //             //$add.append($("<span>").addClass("fa fa-globe"))
+    //             if (tsp.is("[data-time-short]")) {
+    //                 if (t.tz(tz.name).format("YYYY-MM-DD") != t.tz(local_tz).format("YYYY-MM-DD")) {
+    //                     $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+    //                     // $add.append(t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
+    //                 } else {
+    //                     $add.append($("<em>").text(" " + t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+    //                     // $add.append(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t))
+    //                 }
+    //             } else {
+    //                 // $add.addClass("text-muted")
+    //                 // $add.append(" " + gettext("Your local time:") + " ")
+    //                 if (t.tz(tz.name).format("YYYY-MM-DD") != t.tz(local_tz).format("YYYY-MM-DD")) {
+    //                     $add.append($("<strong>").text(t.tz(local_tz).format($("body").attr("data-datetimeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+    //                 } else {
+    //                     $add.append($("<strong>").text(t.tz(local_tz).format($("body").attr("data-timeformat")) + " " + moment.tz.zone(local_tz).abbr(t)))
+    //                 }
+    //             }
+    //             // $add.insertBefore(infodiv);
+    //             $newp.append($add);
+    //         }
+    //     });
+
+    //     $newinfodiv.append($newp);
+    //     $newinfodiv.insertBefore($infodiv);
+    //     // fei.append($newinfodiv.append($newp))
+    // });
 
     // For a very weird reason, window width is 0 on an initial load of the widget
     if ($(window).width() > 0) {


### PR DESCRIPTION
This PR constrains attendees to registering for all events in an event series if that series has the "bundle_event_series" meta_data tag set to "true". This is by no means optimal as it would be better to have an actual event setting to do this.

In essence, this is a hacky workaround, and still needs work:

- [ ] Implement voucher code processing properly
- [ ] Add a proper event setting instead of the meta_data tag
