### PR TITLE
Add CSS for right-to-left language input fields

### DIFF
--- a/src/pretix/_base_settings.py
+++ b/src/pretix/_base_settings.py
@@ -121,6 +121,7 @@ LANGUAGES_OFFICIAL = {
     'en', 'de', 'de-informal'
 }
 LANGUAGES_RTL = {
+    # When adding more right-to-left languages, also update pretix/static/pretixbase/scss/_rtl.scss
     'ar', 'hw'
 }
 LANGUAGES_INCUBATING = {

--- a/src/pretix/static/pretixbase/scss/_rtl.scss
+++ b/src/pretix/static/pretixbase/scss/_rtl.scss
@@ -47,3 +47,9 @@ html.rtl {
     }
   }
 }
+
+input[lang=ar], textarea[lang=ar], div[lang=ar], pre[lang=ar],
+input[lang=hw], textarea[lang=hw], div[lang=hw], pre[lang=hw] {
+  /* Keep list of languages in sync with pretix._base_settings.LANGUAGES_RTL */
+  direction: rtl;
+}


### PR DESCRIPTION
See discussion in https://github.com/raphaelm/django-i18nfield/issues/39