### PR TITLE
[A11y] fix border contrast for inputs

### DIFF
--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -41,19 +41,21 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 .btn-default {
-  box-shadow: 0px 0px 0px 1px #cccccc inset;
+  box-shadow: 0px 0px 0px 1px $input-border inset;
   box-sizing: border-box;
 }
 
 .btn-default:hover, .btn-default:focus {
-  box-shadow: 0px 0px 0px 1px #cccccc inset, inset 0 1px 3px 0 #BFBFBF;
+  box-shadow: 0px 0px 0px 1px $input-border inset, inset 0 1px 3px 0 #BFBFBF;
   background: $btn-default-bg;
 }
 
 .btn-default:active, .btn-default:active:hover, .btn-default:active:focus {
-  box-shadow: 0px 0px 0px 1px #cccccc inset, inset 0 1px 8px 0 #BFBFBF;
   background: $btn-default-bg;
   outline: 0;
+}
+.btn-default.active, .btn-default.active:hover, .btn-default.active:focus {
+  box-shadow: 0px 0px 0px 1px $input-border inset, inset 0 1px 8px 0 #BFBFBF;  
 }
 
 .btn-primary:hover, .btn-primary:focus {

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -1,5 +1,6 @@
 // before variables.scss because it only affects presale, not control
 $body-bg: #f5f5f5 !default;
+$input-border: #949494;
 
 $font-size-base: 0.875rem !default;/* 14px/16px = 0.875rem */
 
@@ -103,9 +104,19 @@ a, .btn-link {
 /* see line 26, pretix/static/bootstrap/scss/bootstrap/_buttons.scss */
 button:focus, a:focus, .btn:focus, summary:focus,
 /*button:active, a:active, .btn:active, summary:active,*/
-button:active:focus, a:active:focus, .btn:active:focus, summary:active:focus {
+button:active:focus, a:active:focus, .btn:active:focus, summary:active:focus,
+input:focus, .form-control:focus, .btn-checkbox:has(input:focus) {
     outline: 2px solid $link-hover-color;
     outline-offset: 2px;
+}
+input:focus, .form-control:focus {
+    border-color: $input-border;
+    z-index: 2;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+.btn-checkbox input:focus {
+    outline: none;
 }
 
 footer {

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -105,18 +105,22 @@ a, .btn-link {
 button:focus, a:focus, .btn:focus, summary:focus,
 /*button:active, a:active, .btn:active, summary:active,*/
 button:active:focus, a:active:focus, .btn:active:focus, summary:active:focus,
-input:focus, .form-control:focus, .btn-checkbox:has(input:focus) {
+input:focus, .form-control:focus, .btn-checkbox:has(input:focus),
+.input-item-count-group:has(input:focus), .input-group-price:has(input:focus) {
     outline: 2px solid $link-hover-color;
     outline-offset: 2px;
 }
 input:focus, .form-control:focus {
     border-color: $input-border;
-    z-index: 2;
     -webkit-box-shadow: none;
     box-shadow: none;
 }
-.btn-checkbox input:focus {
+.btn-checkbox input:focus, .input-item-count-group input:focus, .input-group-price input:focus {
     outline: none;
+}
+/* border-radius on these containers is needed for correctly rounded focus-outlines */
+.input-item-count-group, .input-group-price {
+    border-radius: var(--pretix-border-radius-base);
 }
 
 footer {


### PR DESCRIPTION
Text inputs need a contrast at least 3:1 to its surrounding (white in our case). This PR increases the contrast of the border and also adds the 2px focus-outline used on buttons to text inputs.

Before:

![Bildschirmfoto 2025-04-22 um 10 00 17](https://github.com/user-attachments/assets/b59b3e1a-5594-4ab6-ab7a-ca73a3eab1b4)


After:

![Bildschirmfoto 2025-04-22 um 10 10 00](https://github.com/user-attachments/assets/c25f3817-c32e-45d7-9da1-ef7e31442ac9)


It further improves the cart-select-button-checkbox focus state by adding the focus-outline to the `.btn-checkbox` instead of the checkbox.

Before:

![Bildschirmfoto 2025-04-22 um 10 00 45](https://github.com/user-attachments/assets/bfed275e-cd84-4bf4-982d-a32786d97751)


After:

![Bildschirmfoto 2025-04-22 um 09 59 01](https://github.com/user-attachments/assets/5ec73bc4-a9da-4075-9fdc-9d3e1ac0cbd3)
