### PR TITLE
[A11y] allow users to scale website

### DIFF
--- a/src/pretix/base/templates/pretixbase/email/base.html
+++ b/src/pretix/base/templates/pretixbase/email/base.html
@@ -4,7 +4,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, user-scalable=false">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style type="text/css">
         body {
             background-color: #eee;

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -18,7 +18,7 @@
     {% include "pretixpresale/fragment_js.html" %}
     <meta name="referrer" content="origin">
     {{ html_head|safe }}
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block custom_header %}{% endblock %}
     {% if settings.favicon %}
         <link rel="icon" href="{{ settings.favicon|thumb:'16x16^' }}">

--- a/src/pretix/presale/templates/pretixpresale/event/seatingplan.html
+++ b/src/pretix/presale/templates/pretixpresale/event/seatingplan.html
@@ -16,7 +16,7 @@
     {{ seatingframe_html_head|safe }}
     {% include "pretixpresale/fragment_js.html" %}
     <meta name="referrer" content="origin">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body class="full-screen-seating" data-locale="{{ request.LANGUAGE_CODE }}">
 <form method="post" data-asynctask

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -60,7 +60,7 @@ html {
 
 @media (max-width: $screen-xs-max) {
     /* scale everything to 1rem so older/smaller iPhones do not zoom inputs on focus */
-    body, .form-control {
+    .form-control {
         font-size: 1rem;
     }
 }

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -1,7 +1,7 @@
 // before variables.scss because it only affects presale, not control
 $body-bg: #f5f5f5 !default;
 
-$font-size-base: 0.875rem !default;/* 14px/16px = 0.875rem */
+$font-size-base: 1rem !default;/* 14px/16px = 0.875rem */
 
 $font-size-large:         ($font-size-base * 1.25) !default;
 $font-size-small:         ($font-size-base * .85) !default;

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -1,7 +1,7 @@
 // before variables.scss because it only affects presale, not control
 $body-bg: #f5f5f5 !default;
 
-$font-size-base: 1rem !default;/* 14px/16px = 0.875rem */
+$font-size-base: 0.875rem !default;/* 14px/16px = 0.875rem */
 
 $font-size-large:         ($font-size-base * 1.25) !default;
 $font-size-small:         ($font-size-base * .85) !default;
@@ -56,6 +56,13 @@ $input-height-small:             ($font-size-small * $line-height-small) + ($pad
 
 html {
     font-size: 1em;
+}
+
+@media (max-width: $screen-xs-max) {
+    /* scale everything to 1rem so older/smaller iPhones do not zoom inputs on focus */
+    body, .form-control {
+        font-size: 1rem;
+    }
 }
 
 /* fixe for bootstrap using px-values for fontsize */


### PR DESCRIPTION
Users need to be able to scale the website. When removing `user-scalable=false`, the website zooms slightly on smaller iPhones (e.g. iPhone SE 2020) when focusing input elements due to them having a fontsize of 14px. To remedy this, we have several options.

Original screenshot for reference:
![Bildschirmfoto 2025-04-23 um 10 20 53](https://github.com/user-attachments/assets/9c3ab72d-ee50-466f-80e3-bc3427647c8d)


1. Change everything to 16px (ie. 1rem on `body`)
![Bildschirmfoto 2025-04-23 um 10 21 39](https://github.com/user-attachments/assets/de1cd0d8-c7d9-4d0e-8d00-7fa5e7ed401b)
2. Only change font-size on inputs (ie. 1rem on `.form-control`)
![Bildschirmfoto 2025-04-23 um 10 21 12](https://github.com/user-attachments/assets/01f4c2c4-5b59-4488-b8ef-9a82727d5b7a)
3. Only change overall font-size to 1rem on smaller screens
![IMG_9889](https://github.com/user-attachments/assets/b9ade676-b7a0-486f-89ee-6e982a4fff88)
4. Only change inputs’ font-size on smaller screens
![IMG_9890](https://github.com/user-attachments/assets/558f2d45-b52e-48f5-887f-b5cc534f0e8a)

IMHO changing only the inputs’ font-size looks okay on the product-list when only entering quantities or prices, but on the checkout questions page, it looks a bit odd. Changing everything to 16px (1rem) feels a bit to big IMHO, so I would go with option 4.