### PR TITLE
Product list: Fix DOM position of label causing wrong border

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -301,8 +301,8 @@
                             <p>
                         {% endif %}
                         {% if item.free_price %}
+                            <label class="sr-only" for="price-item-{{ item.pk }}">{% blocktrans trimmed with item=item.name currency=event.currency %}Set price in {{ currency }} for {{ item }}{% endblocktrans %}</label>
                             <div class="input-group input-group-price">
-                                <label class="sr-only" for="price-item-{{ item.pk }}">{% blocktrans trimmed with item=item.name currency=event.currency %}Set price in {{ currency }} for {{ item }}{% endblocktrans %}</label>
                                 <span class="input-group-addon" aria-hidden="true">{{ event.currency }}</span>
                                 <input type="number" class="form-control input-item-price" placeholder="0"
                                        id="{{ form_prefix }}price-item-{{ item.pk }}"

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -318,8 +318,8 @@
                                         <p>
                                     {% endif %}
                                     {% if item.free_price %}
+                                        <label class="sr-only" for="price-item-{{ item.pk }}">{% blocktrans trimmed with item=item.name currency=event.currency %}Set price in {{ currency }} for {{ item }}{% endblocktrans %}</label>
                                         <div class="input-group input-group-price">
-                                            <label class="sr-only" for="price-item-{{ item.pk }}">{% blocktrans trimmed with item=item.name currency=event.currency %}Set price in {{ currency }} for {{ item }}{% endblocktrans %}</label>
                                             <span class="input-group-addon">{{ event.currency }}</span>
                                             <input type="number" class="form-control input-item-price" placeholder="0"
                                                     min="{% if event.settings.display_net_prices %}{{ item.display_price.net|stringformat:"0.2f" }}{% else %}{{ item.display_price.gross|stringformat:"0.2f" }}{% endif %}"


### PR DESCRIPTION
While reviewing #5022, I noticed a double border that is caused by a new label element interfering with the :first-child select. The bug is not new with #5022, but becomes more visible.

Before:

![Screenshot 2025-04-23 at 12-49-39 Vouchermesse](https://github.com/user-attachments/assets/f9966ae1-d6e0-40f8-be30-509a055938e8)

After:

![image](https://github.com/user-attachments/assets/b403a4d3-1281-4d11-8de7-4603318c8564)