### PR TITLE
[A11y] Fix color contrast on headings-small-color

### DIFF
--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -39,6 +39,9 @@ $input-height-small:             ($font-size-small * $line-height-small) + ($pad
 /* imports */
 @import "../../pretixbase/scss/_theme_variables.scss";
 @import "../../pretixbase/scss/bootstrap_vars.scss";
+
+$headings-small-color: $text-muted;
+
 @import "../../bootstrap/scss/_bootstrap_reduced.scss";
 @import "../../pretixbase/scss/_theme.scss";
 @import "../../lightbox/css/lightbox.scss";


### PR DESCRIPTION
$headings-small-color was defined as light-grey, which is to light of a contrast for smaller than 24px. It also makes it more consistent with text-muted.

One could argue that bigger fonts could optically use lighter colors to optically match the perceived color/lightness of smaller type, but generally the contrast is to low then for a11y. Alternatively we could increase the font-size for `h1 small` from 65% to 66%, which would bump the fontsize up a little bit bigger than 24px and keep the lighter gray. Stilll all other smaller headlines (h2, h3, etc.) would need the $text-muted darker color. So I decided to just generally go with the darker color.