### PR TITLE
[A11y] Fix tab order on checkout-step customer (remove autofocus on email-field)

### DIFF
--- a/src/pretix/presale/forms/customer.py
+++ b/src/pretix/presale/forms/customer.py
@@ -54,7 +54,7 @@ class AuthenticationForm(forms.Form):
     required_css_class = 'required'
     email = forms.EmailField(
         label=_("Email"),
-        widget=forms.EmailInput(attrs={'autofocus': True})
+        widget=forms.EmailInput()
     )
     password = forms.CharField(
         label=_("Password"),


### PR DESCRIPTION
The autofocus-attribute on the email-field on the login-page is actually one of the few occassions autofocus is reasonable. The problem is, the same form is used on the checkout-stop customer and messes up the tab-order as initially the customer-login form is hidden, but the input is still focused. This PR fixes the tab-order problem by removing the autofocus-attribute. One could argue to add it to the „global“ login-form, but I think it is not really needed there, so better leave it out as autofocus and a11y do not go that well together.