### PR TITLE
Fix rem-based input height

### DIFF
--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -31,9 +31,9 @@ $padding-xs-horizontal:     0.3571428571rem !default;/* 5px / 14px */
 $navbar-height:             3.5714285714rem !default;/* 50px / 14px */
 
 
-$input-height-base:              ($line-height-computed + ($padding-base-vertical * 2) + 0.1428571429rem) !default; /* 2px@14px = 0.1428571429rem */
-$input-height-large:             ($font-size-large * $line-height-large) + ($padding-large-vertical * 2) + 0.1428571429rem !default;
-$input-height-small:             ($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 0.1428571429rem !default;
+$input-height-base:              ($line-height-computed + ($padding-base-vertical * 2)) !default;
+$input-height-large:             ($font-size-large * $line-height-large) + ($padding-large-vertical * 2) !default;
+$input-height-small:             ($font-size-small * $line-height-small) + ($padding-small-vertical * 2) !default;
 
 
 /* imports */


### PR DESCRIPTION
When we changed our fontsize to a rem-based system, we overlooked a small detail on the text-inputs’ vs. buttons’ height – inputs were slightly higher than buttons. This PR fixes the height difference.

Before:
![Bildschirmfoto 2025-04-23 um 18 09 57](https://github.com/user-attachments/assets/e6e4a2a7-b91e-43a0-a946-a64788c37483)
After:
![Bildschirmfoto 2025-04-23 um 18 10 10](https://github.com/user-attachments/assets/d38a65d5-06e8-4d50-855a-f4c87c45a70c)