### PR TITLE
[A11y] make text "required" visible in labels

### DIFF
--- a/src/pretix/presale/forms/renderers.py
+++ b/src/pretix/presale/forms/renderers.py
@@ -33,6 +33,7 @@ def render_label(content, label_for=None, label_class=None, label_title='', labe
     """
     Render a label with content
     """
+    tag = 'label'
     attrs = attrs or {}
     if label_for:
         attrs['for'] = label_for
@@ -58,6 +59,7 @@ def render_label(content, label_for=None, label_class=None, label_title='', labe
         attrs['class'] += ' label-empty'
         # usually checkboxes have overall empty labels and special labels per checkbox
         # => remove for-attribute as well as "required"-text appended to label
+        tag = 'div'
         if 'for' in attrs:
             del attrs['for']
     elif not optional:
@@ -66,7 +68,7 @@ def render_label(content, label_for=None, label_class=None, label_title='', labe
     builder = '<{tag}{attrs}>{content}{opt}</{tag}>'
     return format_html(
         builder,
-        tag='label',
+        tag=tag,
         attrs=mark_safe(flatatt(attrs)) if attrs else '',
         opt=mark_safe(opt),
         content=text_value(content),

--- a/src/pretix/presale/forms/renderers.py
+++ b/src/pretix/presale/forms/renderers.py
@@ -63,7 +63,7 @@ def render_label(content, label_for=None, label_class=None, label_title='', labe
         if 'for' in attrs:
             del attrs['for']
     elif not optional:
-        opt += '<i class="sr-only label-required">, {}</i>'.format(pgettext('form', 'required'))
+        opt += '<i class="label-required">{}</i>'.format(pgettext('form', 'required'))
 
     builder = '<{tag}{attrs}>{content}{opt}</{tag}>'
     return format_html(

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -145,10 +145,22 @@ output {
   color: $brand-primary;
   font-weight: bold;
 }
-.form-group.required .control-label:after {
-  content: '*';
-  color: $brand-primary;
+.label-required {
+  color: $text-muted;
+  display: block;
+  font-weight: normal;
+  font-style: normal;
 }
+.checkbox .label-required {
+  display: inline;
+  &:before {
+    content: " (";
+  }
+  &:after {
+    content: ")";
+  }
+}
+
 .form-control-text {
   padding-top: 7px;
 }

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -150,6 +150,7 @@ output {
   display: block;
   font-weight: normal;
   font-style: normal;
+  font-size: 85%;
 }
 .checkbox .label-required {
   display: inline;


### PR DESCRIPTION
The * after the label for required inputs is not explained anywhere. We do have `.sr-only` „required“ in the labels, but users without screen-reader need an explanation what the * means. One of the solutions can be a footnote before (or maybe after) the form explaining what the * means – this would require a lot of work on every form and probably isn’t the visually most pleasing option.

This PR explores the option to change the * to the actual text „required“, like so:

![Bildschirmfoto 2025-04-25 um 12 32 42](https://github.com/user-attachments/assets/9af29bbe-8da7-4437-bf67-34dc062d1503)
![Bildschirmfoto 2025-04-25 um 12 32 49](https://github.com/user-attachments/assets/664d5a53-1ce0-4d9e-9b6a-6aa701b9fe95)

Another alternative, that I need to check, is to instead of a CSS-content generated star, to use an image/icon with a title-attribute. Although I doubt that that would be enough, as the error states that the * needs a „visual explanation“.