### PR TITLE
Fix order export for empty attendee_name_parts

### DIFF
--- a/src/pretix/base/exporters/orderlist.py
+++ b/src/pretix/base/exporters/orderlist.py
@@ -712,7 +712,7 @@ class OrderListExporter(MultiSheetListExporter):
                 if name_scheme and len(name_scheme['fields']) > 1:
                     for k, label, w in name_scheme['fields']:
                         row.append(
-                            get_name_parts_localized(op.attendee_name_parts, k)
+                            get_name_parts_localized(op.attendee_name_parts, k) if op.attendee_name_parts else ''
                         )
                 row += [
                     op.attendee_email,


### PR DESCRIPTION
Not 100% sure how we end up with an empty list of attendee_name_parts here, maybe through changing name_scheme during the event or by importing orders? This PR adds a safeguard to the export.