### PR TITLE
Presale: Hide subevent lists if subevents exist but none are visible (Z#23186153)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -71,15 +71,15 @@
         {% endif %}
 
 
-        {% if subevent_list.visible_events %}
-    {% if subevent_list_foldable %}
-        <details class="panel panel-{% if show_cart %}primary{% else %}default{% endif %}">
-            <summary class="panel-heading">
-    {% else %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-    {% endif %}
-                <h3 class="panel-title"><b>
+        {% if subevent_list.list_type != "list" or subevent_list.visible_events %}
+            {% if subevent_list_foldable %}
+                <details class="panel panel-{% if show_cart %}primary{% else %}default{% endif %}">
+                <summary class="panel-heading">
+            {% else %}
+                <div class="panel panel-default">
+                <div class="panel-heading">
+            {% endif %}
+            <h3 class="panel-title"><b>
                 {% if subevent_list_foldable %}
                     {% if show_cart %}
                         {% trans "Add tickets for a different date" %}
@@ -89,35 +89,35 @@
                 {% else %}
                     {% trans "Choose date to book a ticket" %}
                 {% endif %}</b>
-                </h3>
-    {% if subevent_list_foldable %}
-            </summary>
-            <div>
-    {% else %}
-            </div>
-    {% endif %}
+            </h3>
+            {% if subevent_list_foldable %}
+                </summary>
+                <div>
+            {% else %}
+                </div>
+            {% endif %}
             {% if filter_form.fields %}
                 <div class="panel-subhead">
                     {% include "pretixpresale/fragment_event_list_filter.html" with request=request %}
                 </div>
             {% endif %}
-                <div class="panel-body">
-                    {% cache_large 15 subevent_list subevent_list_cache_key %}
-                        {% if subevent_list.list_type == "calendar" %}
-                            {% include "pretixpresale/event/fragment_subevent_calendar.html" %}
-                        {% elif subevent_list.list_type == "week" %}
-                            {% include "pretixpresale/event/fragment_subevent_calendar_week.html" %}
-                        {% else %}
-                            {% include "pretixpresale/event/fragment_subevent_list.html" %}
-                        {% endif %}
-                    {% endcache_large %}
-                </div>
-    {% if subevent_list_foldable %}
+            <div class="panel-body">
+                {% cache_large 15 subevent_list subevent_list_cache_key %}
+                    {% if subevent_list.list_type == "calendar" %}
+                        {% include "pretixpresale/event/fragment_subevent_calendar.html" %}
+                    {% elif subevent_list.list_type == "week" %}
+                        {% include "pretixpresale/event/fragment_subevent_calendar_week.html" %}
+                    {% else %}
+                        {% include "pretixpresale/event/fragment_subevent_list.html" %}
+                    {% endif %}
+                {% endcache_large %}
             </div>
-        </details>
-    {% else %}
-        </div>
-    {% endif %}
+            {% if subevent_list_foldable %}
+                </div>
+                </details>
+            {% else %}
+                </div>
+            {% endif %}
         {% endif %}
 
         {% if subevent %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -71,6 +71,7 @@
         {% endif %}
 
 
+        {% if subevent_list.visible_events %}
     {% if subevent_list_foldable %}
         <details class="panel panel-{% if show_cart %}primary{% else %}default{% endif %}">
             <summary class="panel-heading">
@@ -117,6 +118,7 @@
     {% else %}
         </div>
     {% endif %}
+        {% endif %}
 
         {% if subevent %}
             <h2 class="subevent-head">{{ subevent.name }}</h2>

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -705,7 +705,6 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
                 self.kwargs.get('cart_namespace'),
                 voucher,
             )
-            context['visible_events'] = sum(len(i) for i in ebd.values() if isinstance(i, list)) > 0
 
             # Hide names of subevents in event series where it is always the same.  No need to show the name of the museum thousands of times
             # in the calendar. We previously only looked at the current time range for this condition which caused weird side-effects, so we need
@@ -765,7 +764,6 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
                 self.kwargs.get('cart_namespace'),
                 voucher,
             )
-            context['visible_events'] = sum(len(i) for i in ebd.values() if isinstance(i, list)) > 0
 
             # Hide names of subevents in event series where it is always the same.  No need to show the name of the museum thousands of times
             # in the calendar. We previously only looked at the current time range for this condition which caused weird side-effects, so we need

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -705,6 +705,7 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
                 self.kwargs.get('cart_namespace'),
                 voucher,
             )
+            context['visible_events'] = sum(len(i) for i in ebd.values() if isinstance(i, list)) > 0
 
             # Hide names of subevents in event series where it is always the same.  No need to show the name of the museum thousands of times
             # in the calendar. We previously only looked at the current time range for this condition which caused weird side-effects, so we need
@@ -764,6 +765,7 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
                 self.kwargs.get('cart_namespace'),
                 voucher,
             )
+            context['visible_events'] = sum(len(i) for i in ebd.values() if isinstance(i, list)) > 0
 
             # Hide names of subevents in event series where it is always the same.  No need to show the name of the museum thousands of times
             # in the calendar. We previously only looked at the current time range for this condition which caused weird side-effects, so we need
@@ -815,6 +817,7 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
                     se for se in context['subevent_list']
                     if not se.presale_has_ended and (se.best_availability_state is None or se.best_availability_state >= Quota.AVAILABILITY_RESERVED)
                 ]
+            context['visible_events'] = len(context['subevent_list']) > 0
         return context
 
 


### PR DESCRIPTION
Add new ctx to count visible subevents to use in template
(why not |length filter in tag? because the different list-types and branches in the template make that veeery complicated)