### PR TITLE
Double item thumbnail size for high-density screens

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -47,8 +47,9 @@
                                         data-title="{{ item.name|force_escape|force_escape }}"
                                         {# Yes, double-escape to prevent XSS in lightbox #}
                                         data-lightbox="{{ item.id }}">
-                                    <img src="{{ item.picture|thumb:'60x60^' }}"
-                                            alt="{{ item.name }}"/>
+                                    <img src="{{ item.picture|thumb:'120x120^' }}"
+                                         width="60"
+                                         alt="{{ item.name }}"/>
                                 </a>
                             {% endif %}
                             <div class="product-description {% if item.picture %}with-picture{% endif %}">
@@ -238,8 +239,9 @@
                                     data-title="{{ item.name|force_escape|force_escape }}"
                                     {# Yes, double-escape to prevent XSS in lightbox #}
                                     data-lightbox="{{ item.id }}">
-                                <img src="{{ item.picture|thumb:'60x60^' }}"
-                                        alt="{{ item.name }}"/>
+                                <img src="{{ item.picture|thumb:'120x120^' }}"
+                                     width="60"
+                                     alt="{{ item.name }}"/>
                             </a>
                         {% endif %}
                         <div class="product-description {% if item.picture %}with-picture{% endif %}">

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -38,7 +38,8 @@
                                         {# Yes, double-escape to prevent XSS in lightbox #}
                                    data-lightbox="{{ item.id }}"
                                    aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
-                                    <img src="{{ item.picture|thumb:'60x60^' }}"
+                                    <img src="{{ item.picture|thumb:'120x120^' }}"
+                                         width="60"
                                          alt="{{ item.name }}"/>
                                 </a>
                             {% endif %}
@@ -257,7 +258,8 @@
                                     {# Yes, double-escape to prevent XSS in lightbox #}
                                data-lightbox="{{ item.id }}"
                                aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
-                                <img src="{{ item.picture|thumb:'60x60^' }}"
+                                <img src="{{ item.picture|thumb:'120x120^' }}"
+                                     width="60"
                                      alt="{{ item.name }}"/>
                             </a>
                         {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/voucher.html
+++ b/src/pretix/presale/templates/pretixpresale/event/voucher.html
@@ -93,8 +93,9 @@
                                                     {# Yes, double-escape to prevent XSS in lightbox #}
                                                data-lightbox="{{ item.id }}"
                                                aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
-                                            <img src="{{ item.picture|thumb:'60x60^' }}"
-                                                        alt="{{ item.name }}"/>
+                                            <img src="{{ item.picture|thumb:'120x120^' }}"
+                                                 width="60"
+                                                 alt="{{ item.name }}"/>
                                             </a>
                                         {% endif %}
                                         <div class="product-description {% if item.picture %}with-picture{% endif %}">
@@ -274,7 +275,8 @@
                                                 {# Yes, double-escape to prevent XSS in lightbox #}
                                            data-lightbox="{{ item.id }}"
                                            aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
-                                            <img src="{{ item.picture|thumb:'60x60^' }}"
+                                            <img src="{{ item.picture|thumb:'120x120^' }}"
+                                                 width="60"
                                                  alt="{{ item.name }}"/>
                                         </a>
                                     {% endif %}

--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -295,7 +295,7 @@ class WidgetAPIProductList(EventListMixin, View):
                     {
                         'id': item.pk,
                         'name': str(item.name),
-                        'picture': get_picture(self.request.event, item.picture, '60x60^') if item.picture else None,
+                        'picture': get_picture(self.request.event, item.picture, '120x120^') if item.picture else None,
                         'picture_fullsize': get_picture(self.request.event, item.picture) if item.picture else None,
                         'description': str(rich_text(item.description, safelinks=False)) if item.description else None,
                         'has_variations': item.has_variations,


### PR DESCRIPTION
On high-pixel density screens (such as modern smartphones), the 60x60 thunbnail size looks kind of grainy, especially with text embedded. 
This PR suggests doubling the thumbnail resolution and preserving the size of the img tag via the width attribute.
Naturally this increases traffic / decreases load speed, thus I totally understand if this is not a feasible option.
Maybe adding this as a configuration option could make sense?

Thank you kindly for considering and reviewing! I have sent the CLA to the support email as outlined in the contributor's guide.