### PR TITLE
[A11y] fix datepicker rejecting without error message

### DIFF
--- a/src/pretix/presale/forms/renderers.py
+++ b/src/pretix/presale/forms/renderers.py
@@ -65,6 +65,8 @@ def render_label(content, label_for=None, label_class=None, label_title='', labe
     elif not optional:
         opt += '<i class="label-required">{}</i>'.format(pgettext('form', 'required'))
 
+    opt += '<strong class="label-alert" role="alert"></strong>'
+
     builder = '<{tag}{attrs}>{content}{opt}</{tag}>'
     return format_html(
         builder,

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -60,6 +60,7 @@ var form_handlers = function (el) {
             locale: $("body").attr("data-datetimelocale"),
             useCurrent: false,
             showClear: !$(this).prop("required"),
+            keepInvalid: true,
             icons: {
                 time: 'fa fa-clock-o',
                 date: 'fa fa-calendar',
@@ -82,8 +83,7 @@ var form_handlers = function (el) {
                     Math.abs(+new Date(opts.minDate) - new Date()) < Math.abs(+new Date(opts.maxDate) - new Date())
             ) ? opts.minDate : opts.maxDate;
         }
-        var alert = $('<span role="alert"></span>');
-        $("#"+this.getAttribute("aria-describedby")).prepend(alert);
+        var alert = $('label[for=' + this.id + '] .label-alert');
         $(this).datetimepicker(opts).on("dp.hide", function() {
             // when min/max is used in datetimepicker, closing and re-opening the picker opens at the wrong date
             // therefore keep the current viewDate and re-set it after datetimepicker is done hiding
@@ -93,14 +93,21 @@ var form_handlers = function (el) {
                 $dtp.viewDate(currentViewDate);
             }, 50);
         }).on('dp.error', function (e) {
-            console.log(this, e.date, e.oldDate, opts["minDate"], opts["maxDate"]);
-            alert.text("Mist, das ist ein Fehler! ");
-            // TODO: 
+            if (e.date) {
+                if (e.date.isBefore(opts["minDate"])) {
+                    alert.text(gettext("The date you entered is too early."));
+                } else if (e.date.isAfter(opts["maxDate"])) {
+                    alert.text(gettext("The date you entered is too late."));
+                }
+            } else {
+                alert.text(gettext("We could not recognize the date you entered."));
+            }
             var self = this;
             window.setTimeout(function () {
-                console.log(self);
-                //self.focus();
+                self.focus();
             }, 50);
+        }).on('dp.change', function (e) {
+            alert.text("");
         });
         
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -82,6 +82,8 @@ var form_handlers = function (el) {
                     Math.abs(+new Date(opts.minDate) - new Date()) < Math.abs(+new Date(opts.maxDate) - new Date())
             ) ? opts.minDate : opts.maxDate;
         }
+        var alert = $('<span role="alert"></span>');
+        $("#"+this.getAttribute("aria-describedby")).prepend(alert);
         $(this).datetimepicker(opts).on("dp.hide", function() {
             // when min/max is used in datetimepicker, closing and re-opening the picker opens at the wrong date
             // therefore keep the current viewDate and re-set it after datetimepicker is done hiding
@@ -90,7 +92,18 @@ var form_handlers = function (el) {
             window.setTimeout(function () {
                 $dtp.viewDate(currentViewDate);
             }, 50);
+        }).on('dp.error', function (e) {
+            console.log(this, e.date, e.oldDate, opts["minDate"], opts["maxDate"]);
+            alert.text("Mist, das ist ein Fehler! ");
+            // TODO: 
+            var self = this;
+            window.setTimeout(function () {
+                console.log(self);
+                //self.focus();
+            }, 50);
         });
+        
+
         if ($(this).parent().is('.splitdatetimerow')) {
             $(this).on("dp.change", function (ev) {
                 var $timepicker = $(this).closest(".splitdatetimerow").find(".timepickerfield");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -111,7 +111,7 @@ var form_handlers = function (el) {
         }).on('dp.change', function (e) {
             container.removeClass("has-error");
             alert.text("");
-        }).on('blur', function (e) {
+        }).on('blur', function (e) {// dp.change does not trigger when changed to empty string - although documentation notes otherwise
             if (!this.value) {
                 container.removeClass("has-error");
                 alert.text("");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -83,7 +83,8 @@ var form_handlers = function (el) {
                     Math.abs(+new Date(opts.minDate) - new Date()) < Math.abs(+new Date(opts.maxDate) - new Date())
             ) ? opts.minDate : opts.maxDate;
         }
-        var alert = $('label[for=' + this.id + '] .label-alert');
+        var container = $(this).closest(".form-group");
+        var alert = $('.label-alert', container);
         $(this).datetimepicker(opts).on("dp.hide", function() {
             // when min/max is used in datetimepicker, closing and re-opening the picker opens at the wrong date
             // therefore keep the current viewDate and re-set it after datetimepicker is done hiding
@@ -93,6 +94,7 @@ var form_handlers = function (el) {
                 $dtp.viewDate(currentViewDate);
             }, 50);
         }).on('dp.error', function (e) {
+            container.addClass("has-error");
             if (e.date) {
                 if (e.date.isBefore(opts["minDate"])) {
                     alert.text(gettext("The date you entered is too early."));
@@ -107,7 +109,13 @@ var form_handlers = function (el) {
                 self.focus();
             }, 50);
         }).on('dp.change', function (e) {
+            container.removeClass("has-error");
             alert.text("");
+        }).on('blur', function (e) {
+            if (!this.value) {
+                container.removeClass("has-error");
+                alert.text("");
+            }
         });
         
 

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -154,6 +154,10 @@ output {
   font-size: 85%;
   color: $text-muted;
 }
+.has-error .label-required,
+.has-error .label-alert {
+  color: inherit;
+}
 .label-required {
   &:before {
     content: " (";

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -145,20 +145,37 @@ output {
   color: $brand-primary;
   font-weight: bold;
 }
-.label-required {
-  color: $text-muted;
-  display: block;
+
+.label-required,
+.label-alert {
+  display: inline;
   font-weight: normal;
   font-style: normal;
   font-size: 85%;
+  color: $text-muted;
 }
-.checkbox .label-required {
-  display: inline;
+.label-required {
   &:before {
     content: " (";
   }
   &:after {
     content: ")";
+  }
+}
+.label-alert:not(:empty):before {
+  content: " – ";
+}
+@media (min-width: $screen-md-min) {
+  .form-group:not(:has(.checkbox)) {
+    .label-required,
+    .label-alert:not(:empty) {
+      display: block;
+    }
+    .label-required:before,
+    .label-required:after,
+    .label-alert:before {
+      content: "";
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a `strong[role=alert]` to every label of a CheckoutFieldRenderer. Every element with a role=alert needs to be present in the DOM onload, otherwise it does not get read out. The „live“ error-message is displayed at the label and by that differs from the normal server-side errors, which are displayed after the input with a aria-describedby for several reasons:

1. The alert is only read out when used inside the label. When used inside a help-text linked with aria-describedby (like all server-side errors), it is not read by VoiceOver. One could add a help-text element after the input with role=alert, that is not linked by aria-describedby, but then the error is only read once the error-message was changed, not again when one leaves the date-input and enters it again. So the error-message is not that helpful.
2. It does not make the form „jump“ so much on showing the error message as it is either inline after the label (smaller screens) or below the left-floated label.
3. In this special case, the calendar-widget opens on focus and usually overlays the help-text following the input – exception being on smaller screens where the label is above the input and when the user has not scrolled as far so that the calendar-widget is opened above the input. We might hide the calender-widget once we encountered a dp.error and focussed the input again as dp.error is usually only triggered when a date is manually entered not using the widget.

![Bildschirmfoto 2025-05-06 um 12 27 59](https://github.com/user-attachments/assets/029b3950-8066-4e24-b562-b5ea481ed6be)

![Bildschirmfoto 2025-05-06 um 12 28 19](https://github.com/user-attachments/assets/1310a063-f0b1-48b6-b852-89d47a884a85)
