### PR TITLE
Remove line-break before "required" in label on small screens

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -147,18 +147,31 @@ output {
 }
 .label-required {
   color: $text-muted;
-  display: block;
+  display: inline;
   font-weight: normal;
   font-style: normal;
   font-size: 85%;
 }
-.checkbox .label-required {
-  display: inline;
+.has-error .label-required {
+  color: inherit;
+}
+.label-required {
   &:before {
     content: " (";
   }
   &:after {
     content: ")";
+  }
+}
+@media (min-width: $screen-md-min) {
+  .form-group:not(:has(.checkbox)) {
+    .label-required {
+      display: block;
+    }
+    .label-required:before,
+    .label-required:after {
+      content: "";
+    }
   }
 }
 


### PR DESCRIPTION
Before
![Bildschirmfoto 2025-05-06 um 14 47 55](https://github.com/user-attachments/assets/53702408-7bf6-4bfa-853a-9512af371ccb)

After
![Bildschirmfoto 2025-05-06 um 14 47 30](https://github.com/user-attachments/assets/50ebf7f5-4369-4e9f-8a8d-cfcfb7db2e10)
