### PR TITLE
[A11y] Fix sneak-peek for cart

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
@@ -13,7 +13,7 @@
 {% endblock %}
 {% block content %}
 <aside aria-label="{% trans "Your cart" %}">
-    <details class="panel panel-default cart{% if "open_cart" not in request.GET %} sneak-peek{% endif %}" {% if "open_cart" in request.GET %}open{% endif %}>
+    <details class="panel panel-default cart sneak-peek-container" open>
         <summary class="panel-heading">
             <h2 class="panel-title">
                 <span>
@@ -33,11 +33,15 @@
         </summary>
         {% if "open_cart" not in request.GET %}
         <p class="sneak-peek-trigger">
-            <button type="button" class="btn btn-default">{% trans "Show full cart" %}</button>
+            <button type="button" class="btn btn-default" aria-controls="cart-foldable-container">{% trans "Show full cart" %}</button>
         </p>
         {% endif %}
         <div>
+            {% if "open_cart" not in request.GET %}
+            <div class="panel-body sneak-peek-content" id="cart-foldable-container">
+            {% else %}
             <div class="panel-body">
+            {% endif %}
                 {% include "pretixpresale/event/fragment_cart.html" with cart=cart event=request.event %}
             </div>
         </div>

--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -47,12 +47,6 @@ setup_collapsible_details = function (el) {
             return true;
         }
         var $details = $(this).closest("details");
-        /*
-        if ($details.hasClass('sneak-peek')) {
-            // if sneak-peek is active, needs to be handled differently
-            return true;
-        }
-        */
         var isOpen = $details.prop("open");
         var $detailsNotSummary = $details.children(':not(summary)');
         if ($detailsNotSummary.is(':animated')) {
@@ -76,13 +70,6 @@ setup_collapsible_details = function (el) {
         if (32 == event.keyCode || (13 == event.keyCode && !isOpera)) {
             // Space or Enter is pressed — trigger the `click` event on the `summary` element
             // Opera already seems to trigger the `click` event when Enter is pressed
-            var $details = $(this).closest("details");
-            /*
-            if ($details.hasClass('sneak-peek')) {
-                // if sneak-peek is active, needs to be handled differently
-                return true;
-            }
-            */
             event.preventDefault();
             $(this).click();
         }

--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -39,6 +39,19 @@ setup_collapsible_details = function (el) {
                 }
             });
         }, { once: true });
+
+        var container = this.closest('details.sneak-peek-container');
+        if (container) {
+            function removeSneekPeakWhenClosed(e) {
+                if (e.newState == "closed") {
+                    container.removeEventListener("toggle", removeSneekPeakWhenClosed);
+                    trigger.remove();
+                    content.removeAttribute('aria-hidden');
+                    content.classList.remove('sneak-peek-content');
+                }
+            }
+            container.addEventListener("toggle", removeSneekPeakWhenClosed);
+        }
     });
 
     var isOpera = Object.prototype.toString.call(window.opera) == '[object Opera]';

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -521,11 +521,16 @@ details summary {
     transform: rotate(-90deg);
 }
 
-details.sneak-peek {
+.sneak-peek-container {
     position: relative;
-    height: 11em;
+}
+.sneak-peek-content {
+    height: 8em;
     overflow: hidden;
     transition: height .5s;
+}
+.nojs .sneak-peek-content {
+    height: auto;
 }
 .sneak-peek-trigger {
     display: grid;
@@ -540,6 +545,14 @@ details.sneak-peek {
     bottom: 0;
     left: 0;
     z-index: 10;
+    opacity: 1;
+    transition: opacity .5s;
+}
+.nojs .sneak-peek-trigger {
+    display: none;
+}
+.sneak-peek-trigger:has(button[aria-expanded="true"]) {
+    opacity: 0;
 }
 
 form.download-btn-form {


### PR DESCRIPTION
The half-open cart is complicated for accessibility. The containing panel needs to be open for the button „show full cart“ to be visible and accessible. Therefore this PR adds an additional foldable element inside the details/summary. To not irritate screenreader users by removing the trigger-button, one needs to keep it in the DOM as long as it has focus.

This PR changes the behaviour when clicking on summary. Before it was opening the hidden cart inside the details, but should have closed the open details. This was confusing for screenreader users. So this PR keeps the default details/summary behaviour (which causes a click on the panel-title to close the panel) and only have the half-open cart open with a click on the button „show full cart“.

When sneak-peek is inside details (as it is currently with cart), closing the details then the sneek-peak is opened and removed. I.e. clicking on the panel-title of the cart and hiding the half-open cart and the re-opening the panel, reveals the fully opened cart.