### PR TITLE
[A11y] replace b with strong for better semantics

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/live.html
+++ b/src/pretix/control/templates/pretixcontrol/event/live.html
@@ -85,7 +85,7 @@
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" name="delete" value="yes" />
-                            <b>{% trans "Permanently delete all orders created in test mode" %}</b>
+                            <strong>{% trans "Permanently delete all orders created in test mode" %}</strong>
                         </label>
                     </div>
                     <div class="text-right">

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -79,7 +79,7 @@
                 <div class="panel panel-default">
                 <div class="panel-heading">
             {% endif %}
-            <h3 class="panel-title"><b>
+            <h3 class="panel-title"><strong>
                 {% if subevent_list_foldable %}
                     {% if show_cart %}
                         {% trans "Add tickets for a different date" %}
@@ -88,7 +88,7 @@
                     {% endif %}
                 {% else %}
                     {% trans "Choose date to book a ticket" %}
-                {% endif %}</b>
+                {% endif %}</strong>
             </h3>
             {% if subevent_list_foldable %}
                 </summary>

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_address_delete.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_address_delete.html
@@ -7,7 +7,7 @@
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">
-                {% icon "address-card-o" %} <b>{% trans "Delete address" %}</b>
+                {% icon "address-card-o" %} <strong>{% trans "Delete address" %}</strong>
             </h3>
         </div>
         <div class="panel-body account-addresses">

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_addresses.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_addresses.html
@@ -8,7 +8,7 @@
         <div class="panel-heading">
             <h3 class="panel-title">
                 {% icon "address-card-o" %}
-                <b>{% trans "Addresses" %}</b> ({{ page_obj.paginator.count }})
+                <strong>{% trans "Addresses" %}</strong> ({{ page_obj.paginator.count }})
             </h3>
         </div>
         <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_membership.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_membership.html
@@ -13,7 +13,7 @@
                 {% else %}
                     {% icon "id-badge" %}
                 {% endif %}
-                <b>{% trans "Your membership" %}</b>
+                <strong>{% trans "Your membership" %}</strong>
                 {% if membership.testmode %}
                     <span class="h6">
                     {% textbubble "warning" %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_memberships.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_memberships.html
@@ -9,7 +9,7 @@
         <div class="panel-heading">
             <h3 class="panel-title">
                 {% icon "id-badge" %}
-                <b>{% trans "Memberships" %}</b> ({{ page_obj.paginator.count }})
+                <strong>{% trans "Memberships" %}</strong> ({{ page_obj.paginator.count }})
             </h3>
         </div>
         <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_orders.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_orders.html
@@ -10,7 +10,7 @@
         <div class="panel-heading">
             <h3 class="panel-title">
                 {% icon "shopping-cart" %}
-                <b>{% trans "Orders" %}</b> ({{ page_obj.paginator.count }})
+                <strong>{% trans "Orders" %}</strong> ({{ page_obj.paginator.count }})
             </h3>
         </div>
         <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_profile_delete.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_profile_delete.html
@@ -7,7 +7,7 @@
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">
-                {% icon "user" %} <b>{% trans "Delete profile" %}</b>
+                {% icon "user" %} <strong>{% trans "Delete profile" %}</strong>
             </h3>
         </div>
         <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_profiles.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_profiles.html
@@ -8,7 +8,7 @@
         <div class="panel-heading">
             <h3 class="panel-title">
                 {% icon "users" %}
-                <b>{% trans "Attendee profiles" %}</b> ({{ page_obj.paginator.count }})
+                <strong>{% trans "Attendee profiles" %}</strong> ({{ page_obj.paginator.count }})
             </h3>
         </div>
         <div class="panel-body">

--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -34,13 +34,13 @@
     <div class="panel panel-default">
         <div class="panel-heading">
             <h2 class="panel-title">
-                <b>
+                <strong>
                 {% if "old" in request.GET %}
                     {% trans "Past events" %}
                 {% else %}
                     {% trans "Upcoming events" %}
                 {% endif %}
-                </b>
+                </strong>
             </h2>
         </div>
     {% if filter_form.fields %}


### PR DESCRIPTION
In some panels we use `<b>` to make the panel more prominent than others. So accordings to a11y-testing b adds additional semantic meaning to the heading-elements of a panel, so it should be replaced with strong.