### PR TITLE
[A11y] add skip-link to main content

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -44,7 +44,7 @@
 </head>
 <body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}">
 {{ html_page_header|safe }}
-<nav id="skip-to-main" role="navigation" aria-label="{% trans "Skip-Link" %}" class="sr-only on-focus-visible">
+<nav id="skip-to-main" role="navigation" aria-label="{% trans "Skip link" context "skip-to-main-nav" %}" class="sr-only on-focus-visible">
   <p><a href="#content">{% trans "Skip to main content" %}</a></p>
 </nav>
 <header>

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -44,6 +44,9 @@
 </head>
 <body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}">
 {{ html_page_header|safe }}
+<nav id="skip-to-main" role="navigation" aria-label="{% trans "Skip-Link" %}" class="sr-only on-focus-visible">
+  <p><a href="#content">{% trans "Skip to main content" %}</a></p>
+</nav>
 <header>
 {% if ie_deprecation_warning %}
     <div class="old-browser-warning">

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -264,8 +264,8 @@ function setup_basics(el) {
     el.find(".js-only").removeClass("js-only");
     el.find(".js-hidden").hide();
     // make sure to always have a #content for skip-link to work
-    if (!el.find("#content").length) {
-        el.find("main").first().attr("id", "content");
+    if (!document.querySelector("#content")) {
+        (document.querySelector('main') || document.querySelector('.page-header + *')).id = "content"
     }
 
     el.find("div.collapsed").removeClass("collapsed").addClass("collapse");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -263,6 +263,10 @@ function setup_basics(el) {
 
     el.find(".js-only").removeClass("js-only");
     el.find(".js-hidden").hide();
+    // make sure to always have a #content for skip-link to work
+    if (!el.find("#content").length) {
+        el.find("main").first().attr("id", "content");
+    }
 
     el.find("div.collapsed").removeClass("collapsed").addClass("collapse");
     el.find(".has-error, .alert-danger").each(function () {

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -69,6 +69,17 @@ html {
     }
 }
 
+.on-focus-visible:focus, .on-focus-visible:focus-within {
+    height: auto;
+    width: auto;
+    overflow: auto;
+    clip: auto;
+}
+#skip-to-main {
+    /* padding is needed to make focus-outline visible */
+    padding: 6px;
+}
+
 /* fixe for bootstrap using px-values for fontsize */
 .panel-title {
     font-size: ($font-size-base * 1.125);

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -77,9 +77,14 @@ html {
 }
 #skip-to-main {
     /* padding is needed to make focus-outline visible */
-    padding: 6px;
-
+    padding: 8px;
+    background-color: inherit;
+    p {
+        margin: 0;
+    }
     a {
+        padding: .125em .5em;
+        display: inline-block;
         color: var(--pretix-link-contrast-color);
         outline-color: inherit;
     }

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -78,6 +78,14 @@ html {
 #skip-to-main {
     /* padding is needed to make focus-outline visible */
     padding: 6px;
+
+    a {
+        color: var(--pretix-link-contrast-color);
+        outline-color: inherit;
+    }
+    a:active, a:hover, a:focus {
+        color: var(--pretix-link-hover-contrast-color);
+    }
 }
 
 /* fixe for bootstrap using px-values for fontsize */


### PR DESCRIPTION
This PR adds a skip-link as the first element on the page to skip to the main-area on the page. JavaScript makes sure, there will be an element `*#content` available on the page, that can be linked to. The skip-link is only is visible when it has focus.