### PR TITLE
Fix page-header-links outline color contrast

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -35,8 +35,9 @@ h3, .h3 {
 .page-header-links > div.header-part {
   padding-top: 15px;
 
-  a:link, a:visited {
+  a {
     color: var(--pretix-link-contrast-color);
+    outline-color: inherit;
   }
   a:active, a:hover, a:focus {
     color: var(--pretix-link-hover-contrast-color);


### PR DESCRIPTION
When using a dark background, the focus outline was not following the contrast-color.

Before:
![Bildschirmfoto 2025-05-13 um 07 36 55](https://github.com/user-attachments/assets/89b09a4a-b86e-4970-974e-89ca5c964648)


After:
![Bildschirmfoto 2025-05-13 um 07 35 28](https://github.com/user-attachments/assets/07f695b2-f31a-4405-93c4-e848bc9de918)
