### PR TITLE
Fix weird markup on "resend link" page

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/resend_link.html
+++ b/src/pretix/presale/templates/pretixpresale/event/resend_link.html
@@ -10,15 +10,13 @@
     <h2>
         {% trans "Resend order links" %}
     </h2>
-    <div class="row">
-        <div class="panel-body">
+    <p>
         {% blocktrans trimmed %}
             If you lost the link to your order or orders, please enter the email address you
             used for your order. We will send you an email with links to all orders you placed
             using this email address.
         {% endblocktrans %}
-    </div>
-    </div>
+    </p>
     <div class="row">
     <form class="form" method="post">
         {% csrf_token %}


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/4893a27d-f4d9-4c6b-955c-df38f5c37cb9)

After:

![image](https://github.com/user-attachments/assets/5b454344-fb11-48e6-a925-74e547ee81f0)
