### PR TITLE
Add common modal support for no-product-selected-error

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -48,7 +48,14 @@
 <nav id="skip-to-main" role="navigation" aria-label="{% trans "Skip link" context "skip-to-main-nav" %}" class="sr-only on-focus-visible">
   <p><a href="#content">{% trans "Skip to main content" %}</a></p>
 </nav>
-<dialog id="dialog-info" aria-labelledby="dialog-info-label" aria-describedby="dialog-info-description">
+{% comment %}
+    <dialog> needs to be available onload and role-attribute cannot be changed dynamically.
+    Therefore we need two dialogs, one normal (e.g. for status info like "loading") and one
+    alertdialog with a confirm-button.
+    Note: dialog[aria-describedby] is not read out on VoiceOver, so we add both label and 
+    description to aria-labelledby.
+{% endcomment %}
+<dialog id="dialog-info" aria-labelledby="dialog-info-label dialog-info-description">
     <div class="modal-card">
         <div class="modal-card-icon">
             {% icon "cog big-rotating-icon" %}
@@ -59,7 +66,7 @@
         </div>
     </div>
 </dialog>
-<dialog id="dialog-alert" role="alertdialog" aria-labelledby="dialog-alert-label" aria-describedby="dialog-alert-description">
+<dialog id="dialog-alert" role="alertdialog" aria-labelledby="dialog-alert-label dialog-alert-description">
     <div class="modal-card">
         <div class="modal-card-icon">
             {% icon "cog big-rotating-icon" %}

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -1,6 +1,7 @@
 {% load compress %}
 {% load static %}
 {% load i18n %}
+{% load icon %}
 {% load safelink %}
 {% load statici18n %}
 {% load thumb %}
@@ -47,6 +48,31 @@
 <nav id="skip-to-main" role="navigation" aria-label="{% trans "Skip link" context "skip-to-main-nav" %}" class="sr-only on-focus-visible">
   <p><a href="#content">{% trans "Skip to main content" %}</a></p>
 </nav>
+<dialog id="dialog-info" aria-labelledby="dialog-info-label" aria-describedby="dialog-info-description">
+    <div class="modal-card">
+        <div class="modal-card-icon">
+            {% icon "cog big-rotating-icon" %}
+        </div>
+        <div class="modal-card-content">
+            <h2 id="dialog-info-label">Hier die Überschrift</h2>
+            <p id="dialog-info-description">Hier kommt der Text. Danach der Status-Absatz.</p>
+        </div>
+    </div>
+</dialog>
+<dialog id="dialog-alert" role="alertdialog" aria-labelledby="dialog-alert-label" aria-describedby="dialog-alert-description">
+    <div class="modal-card">
+        <div class="modal-card-icon">
+            {% icon "cog big-rotating-icon" %}
+        </div>
+        <div class="modal-card-content">
+            <h2 id="dialog-alert-label">Hier die Überschrift</h2>
+            <p id="dialog-alert-description"></p>
+        </div>
+    </div>
+    <form method="dialog" class="text-right">
+        <button class="btn btn-primary">OK</button>
+    </form>
+</dialog>
 <header>
 {% if ie_deprecation_warning %}
     <div class="old-browser-warning">

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -225,8 +225,7 @@ $(function () {
         async_task_old_url = location.href;
         $("body").data('ajaxing', true);
 
-        const ac = new AbortController();
-        window.pretix.dialog({
+        window.pretix.dialog.open({
             label: this.getAttribute("data-asynctask-headline") || gettext("We are processing your request …"),
             message: (this.getAttribute("data-asynctask-text") || "") + gettext(
                 'We are currently sending your request to the server. If this takes longer ' +
@@ -234,10 +233,10 @@ $(function () {
                 'this page and try again.'
             ),
             icon: 'cog',
-        }, ac.signal);
+        });
 
         window.setTimeout(function() {
-            ac.abort();
+            window.pretix.dialog.close();
         }, 2000);
         return false;
 

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -224,21 +224,22 @@ $(function () {
         async_task_is_long = $(this).is("[data-asynctask-long]");
         async_task_old_url = location.href;
         $("body").data('ajaxing', true);
-        if ($(this).is("[data-asynctask-headline]")) {
-            waitingDialog.show($(this).attr("data-asynctask-headline"));
-        } else {
-            waitingDialog.show(gettext('We are processing your request …'));
-        }
-        if ($(this).is("[data-asynctask-text]")) {
-            $("#loadingmodal p.text").text($(this).attr("data-asynctask-text")).show();
-        } else {
-            $("#loadingmodal p.text").hide();
-        }
-        $("#loadingmodal p.status").text(gettext(
-            'We are currently sending your request to the server. If this takes longer ' +
-            'than one minute, please check your internet connection and then reload ' +
-            'this page and try again.'
-        ));
+
+        const ac = new AbortController();
+        window.pretix.dialog({
+            label: this.getAttribute("data-asynctask-headline") || gettext("We are processing your request …"),
+            message: (this.getAttribute("data-asynctask-text") || "") + gettext(
+                'We are currently sending your request to the server. If this takes longer ' +
+                'than one minute, please check your internet connection and then reload ' +
+                'this page and try again.'
+            ),
+            icon: 'cog',
+        }, ac.signal);
+
+        window.setTimeout(function() {
+            ac.abort();
+        }, 2000);
+        return false;
 
         var action = this.action;
         var formData = new FormData(this);

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -382,39 +382,32 @@ function get_label_text_for_id(id) {
 
 
 window.pretix = window.pretix || {};
-window.pretix.dialog = function(opt, signal) {
-    // always close any open dialogs
-    $("dialog[open]").each(function() {
-        this.close();
-    });
-    if (!opt) {
-        return;
-    }
-    const id = "dialog-" + (opt.confirm ? "alert" : "info");
-    const dialog = document.getElementById(id);
-    $("#" + id + "-label").text(opt.label);
-    $("#" + id + "-description").text(opt.message);
-    $(".modal-card-icon .fa", dialog).attr('class', 'fa fa-' + (opt.icon || "exclamation-triangle"));
-    if (opt.confirm) {
-        $("button", dialog).attr("value", opt.confirm.toString()).text(opt.confirm === true ? gettext("OK") : opt.confirm);
-    }
+window.pretix.dialog = {
+    close: function() {
+        $("#dialog-alert[open], #dialog-info[open]").each(function() {
+            this.close();
+        });
+    },
+    open: function(opt) {
+        window.pretix.dialog.close();
 
-    return new Promise((resolve, reject) => {
-        if (signal) {
-            function onAbort() {
-                dialog.close();
-            }
-            signal.addEventListener('abort', onAbort, { once: true });
+        const id = "dialog-" + (opt.confirm ? "alert" : "info");
+        const dialog = document.getElementById(id);
+        $("#" + id + "-label").text(opt.label);
+        $("#" + id + "-description").text(opt.message);
+        $(".modal-card-icon .fa", dialog).attr('class', 'fa fa-' + (opt.icon || "exclamation-triangle"));
+        if (opt.confirm) {
+            $("button", dialog).attr("value", opt.confirm.toString()).text(opt.confirm === true ? gettext("OK") : opt.confirm);
         }
-        dialog.addEventListener('close', function() {
-            if (signal) {
-                signal.removeEventListener('abort', onAbort);
-            }
-            resolve(dialog.returnValue);
-        }, { once: true });
 
-        dialog.showModal();
-    })
+        return new Promise((resolve, reject) => {
+            dialog.addEventListener('close', function() {
+                resolve(dialog.returnValue);
+            }, { once: true });
+
+            dialog.showModal();
+        })
+    }
 };
 
 
@@ -436,7 +429,7 @@ $(function () {
 
         e.preventDefault();
         e.stopPropagation();
-        window.pretix.dialog({
+        window.pretix.dialog.open({
             label: gettext("You have not selected any ticket."),
             message: gettext("Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart."),
             icon: 'exclamation',

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -421,7 +421,6 @@ $(function () {
         e.preventDefault();
         e.stopPropagation();
         window.pretix.dialog({
-            type: "alert",
             label: gettext("You have not selected any ticket."),
             message: gettext("Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart."),
             icon: 'exclamation',

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -374,6 +374,47 @@ body.loading .container {
     -webkit-transition: opacity .5s ease-in-out;
 }
 
+
+#dialog-info, #dialog-alert {
+    border: none;
+    background: white;
+    border-radius: $border-radius-large;
+    box-shadow: 0 7px 14px 0 rgba(78, 50, 92, 0.1),0 3px 6px 0 rgba(0,0,0,.07);
+    padding: 20px;
+
+
+    max-width: 32em;
+    max-height: calc(100vh - 100px);
+    overflow-y: auto;
+
+
+    &::backdrop {
+        background: rgba(255, 255, 255, .7);
+    }
+
+    .modal-card {
+        display: flex;
+        align-items: center;
+
+        .modal-card-icon {
+            width: 150px;
+            text-align: center;
+            color: $brand-primary;
+            font-size: 120px;
+        }
+        .modal-card-content {
+            text-align: left;
+            h2 {
+                margin-top: 0;
+                font-size: 1.25em;
+                font-weight: bold;
+                color: $brand-primary;
+            }
+        }
+    }
+}
+
+
 .typo-alert span[data-typosuggest] {
     text-decoration: underline;
     cursor: pointer;


### PR DESCRIPTION
This PR explores ways to add common modal-dialogs which make it easier to create accessible modals.

The current idea is to use events `pretix:alert` or  `pretix:info` to trigger a listener, that fills the dialogs with the info and does showModal() on the correct one. In the current example, cart triggers a pretix:alert to have a role=alertdialog open and show a confirmation-button. The async-task could e.g. trigger pretix:info, which opens a normal dialog without the option of a confirm-button.

The current layout of the overlay is based on the #loadingmodal. An alternative might be to use a style similar to the existing `alert-*` boxes, which allow for different colors depending on the level (e.g. info or warning or even danger). Another alternative might be a panel.

Currently no returnValue is provided when the alertdialog is closed as there is no need for currently. It could be done in a number of ways. Easiest would be a callback in the triggered event-details – although combining an event with a callback seems to be a strange combination. Another way could be another event, e.g. `document.addListener("pretix:alert:close", function() …, { once: true })`. Last, but not least, when e.g. not using events at all, we could use a global function `pretix.alert()` instead, that returns a Promise, which we could then act upon.