### PR TITLE
[A11y] underline inline-links

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -94,7 +94,7 @@
                 </a>
             {% else %}
                 <h1>
-                    <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}">{{ event.name }}</a>
+                    <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}" class="no-underline">{{ event.name }}</a>
                     {% if request.event.settings.show_dates_on_frontpage and not event.has_subevents %}
                         <small>{{ event.get_date_range_display_as_html }}</small>
                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -94,10 +94,11 @@
                 </a>
             {% else %}
                 <h1>
-                    <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}" class="no-underline">{{ event.name }}</a>
+                    <a href="{% eventurl event "presale:event.index" cart_namespace=cart_namespace|default_if_none:"" %}" class="no-underline">{{ event.name }}
                     {% if request.event.settings.show_dates_on_frontpage and not event.has_subevents %}
-                        <small>{{ event.get_date_range_display_as_html }}</small>
+                        <small class="text-muted">{{ event.get_date_range_display_as_html }}</small>
                     {% endif %}
+                    </a>
                 </h1>
             {% endif %}
         </div>

--- a/src/pretix/presale/templates/pretixpresale/organizers/base.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/base.html
@@ -62,7 +62,7 @@
                             class="organizer-logo" />
                 </a>
             {% else %}
-                <h1><a href="{% eventurl organizer "presale:organizer.index" %}">{{ organizer.name }}</a></h1>
+                <h1><a href="{% eventurl organizer "presale:organizer.index" %}" class="no-underline">{{ organizer.name }}</a></h1>
             {% endif %}
         </div>
         {% if organizer.settings.locales|length > 1 or request.organizer.settings.customer_accounts %}

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -108,7 +108,19 @@ pre {
     font-size: $font-size-base;
 }
 
+/* make all links in textflow underlined */
+h1, h2, h3, h4, h5, h6, p, li {
+    a:not(.btn) {
+        text-decoration: underline;
+    }    
+}
 
+.no-underline, nav li a:link {
+    text-decoration: none;
+}
+.no-underline:hover, nav li a:hover {
+    text-decoration: underline;
+}
 
 
 /* See https://github.com/pretix/pretix/pull/761 */

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -121,6 +121,9 @@ a.no-underline:link, nav li a:link {
 a.no-underline:hover, nav li a:hover {
     text-decoration: underline;
 }
+.help-block a {
+    color: inherit;
+}
 
 
 /* See https://github.com/pretix/pretix/pull/761 */

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -115,10 +115,10 @@ h1, h2, h3, h4, h5, h6, p, li {
     }    
 }
 
-.no-underline, nav li a:link {
+a.no-underline:link, nav li a:link {
     text-decoration: none;
 }
-.no-underline:hover, nav li a:hover {
+a.no-underline:hover, nav li a:hover {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
Links that are inline with normal text need to be underlined as otherwise the color-contrast between a link and normal text needs to be 4.5 as well as both text and link need have a contrast to the background (white) of 4.5. This limits the colors choices dramatically, so this PR adds CSS to style links accordingly.

It adds a CSS-class `.no-underline` to mark safe links explicitly. ~~Currently I could not find any of those safe links.~~ Links in help-text or other markdown-texts or even the „Add to calendar“-link on the homepage need to be underlined.

The h1 text-link combined with the date might be a problem though. Currently only the event’s name is linked, but next to it is the date of the event. Link-to-text-contrast is very low (1.2), so I guess we need to make the whole h1 with the date linked.