### PR TITLE
[A11y] Widget fix event status color contrast

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -541,7 +541,7 @@
       box-sizing: border-box;
       span {
         display: inline;
-        padding: 2px 6px 3px;
+        padding: 4px 1.25em 3px 6px;
         font-size: 75%;
         font-weight: bold;
         line-height: 1;

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -556,7 +556,7 @@
 
   .pretix-widget-event-availability-orange .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-orange.pretix-widget-event-calendar-event {
-    background-color: $brand-warning;
+    background-color: $state-warning-text;
   }
   .pretix-widget-event-availability-none .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-none.pretix-widget-event-calendar-event {
@@ -564,11 +564,11 @@
   }
   .pretix-widget-event-availability-green .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-green.pretix-widget-event-calendar-event {
-    background-color: $brand-success;
+    background-color: $state-success-text;
   }
   .pretix-widget-event-availability-red .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-red.pretix-widget-event-calendar-event {
-    background-color: $brand-danger;
+    background-color: $state-danger-text;
   }
   .pretix-widget-event-availability-low .pretix-widget-event-list-entry-availability span {
     border-left: 10px solid $brand-warning;
@@ -1020,16 +1020,16 @@
       color: white;
       cursor: pointer;
       &.pretix-widget-day-availability-red {
-        background: $brand-danger;
+        background: $state-danger-text;
       }
       &.pretix-widget-day-availability-green {
-        background: $brand-success;
+        background: $state-success-text;
       }
       &.pretix-widget-day-availability-low {
         border-right: 5px solid $brand-warning;
       }
       &.pretix-widget-day-availability-orange {
-        background: $brand-warning;
+        background: $state-warning-text;
       }
     }
 

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -556,19 +556,19 @@
 
   .pretix-widget-event-availability-orange .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-orange.pretix-widget-event-calendar-event {
-    background-color: $state-warning-text;
+    background: linear-gradient(to left, $brand-warning 1em, var(--pretix-brand-warning-darken-25) 1em);
   }
   .pretix-widget-event-availability-none .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-none.pretix-widget-event-calendar-event {
-    background-color: $brand-primary;
+    background: linear-gradient(to left, var(--pretix-brand-primary-lighten-20) 1em, $brand-primary 1em);
   }
   .pretix-widget-event-availability-green .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-green.pretix-widget-event-calendar-event {
-    background-color: $state-success-text;
+    background: linear-gradient(to left, $brand-success 1em, var(--pretix-brand-success-darken-10) 1em);
   }
   .pretix-widget-event-availability-red .pretix-widget-event-list-entry-availability span,
   .pretix-widget-event-availability-red.pretix-widget-event-calendar-event {
-    background-color: $state-danger-text;
+    background: linear-gradient(to left, var(--pretix-brand-danger-lighten-15) 1em, $brand-danger 1em);
   }
   .pretix-widget-event-availability-low .pretix-widget-event-list-entry-availability span {
     border-left: 10px solid $brand-warning;
@@ -618,7 +618,7 @@
     .pretix-widget-event-calendar-event {
       display: block;
       border-radius: 4px;
-      padding: 5px;
+      padding: 5px 1.25em 5px 5px;
       color: white;
       cursor: pointer;
       margin-bottom: 5px;
@@ -1016,20 +1016,20 @@
       }
     }
     td.pretix-widget-has-events {
-      background: $brand-primary;
+      background: linear-gradient(to right, $brand-primary 1.8em, var(--pretix-brand-primary-lighten-20) 1.8em);
       color: white;
       cursor: pointer;
       &.pretix-widget-day-availability-red {
-        background: $state-danger-text;
+        background: linear-gradient(to right, $brand-danger 1.8em, var(--pretix-brand-danger-lighten-15) 1.8em);
       }
       &.pretix-widget-day-availability-green {
-        background: $state-success-text;
+        background: linear-gradient(to right, var(--pretix-brand-success-darken-10) 1.8em, $brand-success 1.8em);
       }
       &.pretix-widget-day-availability-low {
         border-right: 5px solid $brand-warning;
       }
       &.pretix-widget-day-availability-orange {
-        background: $state-warning-text;
+        background: linear-gradient(to right, var(--pretix-brand-warning-darken-25) 1.8em, $brand-warning 1.8em);
       }
     }
 


### PR DESCRIPTION
This one is ugly, we need to meet contrast value of 4.5 for texts in calendar view in the widget. This PR uses the colors used for text in alert-boxes. They have a slightly larger contrast than necessary as they do not work against white but a slight shade of the respective alert-color.

The super ugly problem is, what do we do with yellow or in this case: brown? There is no way we can meet the needed contrast with the current layout which is white text on a solid color.

I guess we could try an make it similar to the alert-boxes and the calendar on the main shop-page.