### PR TITLE
[A11y] change footer poweredby-link to pretix.eu if no poweredby_url

### DIFF
--- a/src/pretix/base/context.py
+++ b/src/pretix/base/context.py
@@ -35,19 +35,22 @@ def get_powered_by(request, safelink=True):
     d = gs.settings.license_check_input
     if d.get('poweredby_name'):
         if d.get('poweredby_url'):
-            n = '<a href="{}" target="_blank" rel="noopener">{}</a>'.format(
-                sl(d['poweredby_url']) if safelink else d['poweredby_url'],
-                d['poweredby_name']
+            msg = gettext('<a {a_name_attr}>powered by {name}</a> <a {a_attr}>based on pretix</a>').format(
+                name=d['poweredby_name'],
+                a_name_attr='href="{}" target="_blank" rel="noopener"'.format(
+                    sl(d['poweredby_url']) if safelink else d['poweredby_url'],
+                ),
+                a_attr='href="{}" target="_blank" rel="noopener"'.format(
+                    sl('https://pretix.eu') if safelink else 'https://pretix.eu',
+                )
             )
         else:
-            n = d['poweredby_name']
-
-        msg = gettext('powered by {name} based on <a {a_attr}>pretix</a>').format(
-            name=n,
-            a_attr='href="{}" target="_blank" rel="noopener"'.format(
-                sl('https://pretix.eu') if safelink else 'https://pretix.eu',
+            msg = gettext('<a {a_attr}>powered by {name} based on pretix</a>').format(
+                name=d['poweredby_name'],
+                a_attr='href="{}" target="_blank" rel="noopener"'.format(
+                    sl('https://pretix.eu') if safelink else 'https://pretix.eu',
+                )
             )
-        )
     else:
         msg = gettext('<a %(a_attr)s>ticketing powered by pretix</a>') % {
             'a_attr': 'href="{}" target="_blank" rel="noopener"'.format(


### PR DESCRIPTION
Due to potentially mixing links with normale text, we would need link-underlines in the footer. Instead we link the whole poweredby-footer.