### PR TITLE
[A11y] Fix cookie-consent-form labels + help-text markup

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/fragment_modals.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_modals.html
@@ -55,7 +55,7 @@
                 <div class="modal-card-content">
                     <h3 id="cookie-consent-modal-label"></h3>
                     <div id="cookie-consent-modal-description">
-                        <form method="dialog" class="form-horizontal">
+                        <form class="form-horizontal">
                         {% with request.event|default:request.organizer as sh %}
                             <h3>{{ sh.settings.cookie_consent_dialog_title }}</h3>
                             {{ sh.settings.cookie_consent_dialog_text|rich_text }}

--- a/src/pretix/presale/templates/pretixpresale/fragment_modals.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_modals.html
@@ -55,6 +55,7 @@
                 <div class="modal-card-content">
                     <h3 id="cookie-consent-modal-label"></h3>
                     <div id="cookie-consent-modal-description">
+                        <form method="dialog" class="form-horizontal">
                         {% with request.event|default:request.organizer as sh %}
                             <h3>{{ sh.settings.cookie_consent_dialog_title }}</h3>
                             {{ sh.settings.cookie_consent_dialog_text|rich_text }}
@@ -70,39 +71,41 @@
                                 </summary>
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" disabled checked="">
-                                        {% trans "Required cookies" %}<br>
-                                        <span class="text-muted">
-                                            {% trans "Functional cookies (e.g. shopping cart, login, payment, language preference) and technical cookies (e.g. security purposes)" %}
-                                        </span>
+                                        <input type="checkbox" disabled checked="" aira-describedby="cookie-consent-checkbox-required-description">
+                                        {% trans "Required cookies" %}
                                     </label>
+                                </div>
+                                <div class="help-block" id="cookie-consent-checkbox-required-description">
+                                    <p>{% trans "Functional cookies (e.g. shopping cart, login, payment, language preference) and technical cookies (e.g. security purposes)" %}</p>
                                 </div>
                                 {% for cp in cookie_providers %}
                                     <div class="checkbox">
                                         <label>
-                                            <input type="checkbox" name="{{ cp.identifier }}">
-                                            {{ cp.provider_name }}<br>
-                                            <span class="text-muted">
-                                                {% for c in cp.usage_classes %}
-                                                    {% if forloop.counter0 > 0 %}&middot; {% endif %}
-                                                    {% if c.value == 1 %}
-                                                        {% trans "Functionality" context "cookie_usage" %}
-                                                    {% elif c.value == 2 %}
-                                                        {% trans "Analytics" context "cookie_usage" %}
-                                                    {% elif c.value == 3 %}
-                                                        {% trans "Marketing" context "cookie_usage" %}
-                                                    {% elif c.value == 4 %}
-                                                        {% trans "Social features" context "cookie_usage" %}
-                                                    {% endif %}
-                                                {% endfor %}
-                                                {% if cp.privacy_url %}
-                                                    &middot;
-                                                    <a href="{% safelink cp.privacy_url %}" target="_blank">
-                                                        {% trans "Privacy policy" %}
-                                                    </a>
-                                                {% endif %}
-                                            </span>
+                                            <input type="checkbox" name="{{ cp.identifier }}" aira-describedby="cookie-consent-checkbox-{{ cp.identifier }}-description">
+                                            {{ cp.provider_name }}
                                         </label>
+                                    </div>
+                                    <div class="help-block" id="cookie-consent-checkbox-{{ cp.identifier }}-description">
+                                        <p>
+                                        {% for c in cp.usage_classes %}
+                                            {% if forloop.counter0 > 0 %}&middot; {% endif %}
+                                            {% if c.value == 1 %}
+                                                {% trans "Functionality" context "cookie_usage" %}
+                                            {% elif c.value == 2 %}
+                                                {% trans "Analytics" context "cookie_usage" %}
+                                            {% elif c.value == 3 %}
+                                                {% trans "Marketing" context "cookie_usage" %}
+                                            {% elif c.value == 4 %}
+                                                {% trans "Social features" context "cookie_usage" %}
+                                            {% endif %}
+                                        {% endfor %}
+                                        {% if cp.privacy_url %}
+                                            &middot;
+                                            <a href="{% safelink cp.privacy_url %}" target="_blank">
+                                                {% trans "Privacy policy" %}
+                                            </a>
+                                        {% endif %}
+                                        </p>
                                     </div>
                                 {% endfor %}
                             </details>
@@ -130,6 +133,7 @@
                                 </p>
                             {% endif %}
                         {% endwith %}
+                        <form>
                     </div>
                 </div>
             </div>

--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -53,6 +53,15 @@ a.btn, button.btn {
     }
   }
 }
+.checkbox + .help-block {
+  padding-left: 20px;
+  margin-top: 0;
+  margin-bottom: 0;
+  p {
+    margin-bottom: 0;
+  }
+}
+
 output {
   padding-top: $padding-base-vertical;
 }


### PR DESCRIPTION
This PR fixes the cookie-consent dialog’s labels and help-texts – one should not have links in labels. Consent-Checkboxes are marked up similar to the checkout-style checkboxes.

This PR does one change to the checkout-style checkboxes: it indents the help-text the same as the label.

![Bildschirmfoto 2025-05-15 um 12 21 08](https://github.com/user-attachments/assets/704a9cb7-aa6f-4738-b2b1-fa1676f43dbe)

Before:

![Bildschirmfoto 2025-05-15 um 12 25 59](https://github.com/user-attachments/assets/2e45d462-3a6e-4c1f-893b-e186555d0238)


After:
![Bildschirmfoto 2025-05-15 um 12 25 20](https://github.com/user-attachments/assets/82f4504d-9e4f-4ec6-8f2c-55ed9f228db2)
