### PR TITLE
[A11y] logout-button make label visible

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/fragment_login_status.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_login_status.html
@@ -9,11 +9,9 @@
                title="{% trans "View customer account" %}" data-toggle="tooltip">
                 <span class="fa fa-user" aria-hidden="true"></span>
                 {{ request.customer.name|default:request.customer.email }}</a>
-            <a href="{% if request.event_domain %}{% abseventurl request.event "presale:organizer.customer.logout" %}{% else %}{% abseventurl request.organizer "presale:organizer.customer.logout" %}{% endif %}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}"
-               aria-label="{% trans "Log out" %}" data-toggle="tooltip" data-placement="left"
-               title="{% trans "Log out" %}">
+            <a href="{% if request.event_domain %}{% abseventurl request.event "presale:organizer.customer.logout" %}{% else %}{% abseventurl request.organizer "presale:organizer.customer.logout" %}{% endif %}?next={{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}">
                 <span class="fa fa-sign-out" aria-hidden="true"></span>
-                <span class="sr-only">{% trans "Log out" %}</span>
+                {% trans "Log out" %}
             </a>
         {% else %}
             <a href="{% abseventurl request.organizer "presale:organizer.customer.login" %}{% if request.resolver_match.url_name != "organizer.customer.login" %}?next={% if request.event_domain %}{{ request.scheme }}://{{ request.get_host }}{% endif %}{{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}{% endif %}{% if request.event_domain %}&request_cross_domain_customer_auth=true{% endif %}">

--- a/src/pretix/presale/templates/pretixpresale/fragment_login_status.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_login_status.html
@@ -15,6 +15,7 @@
             </a>
         {% else %}
             <a href="{% abseventurl request.organizer "presale:organizer.customer.login" %}{% if request.resolver_match.url_name != "organizer.customer.login" %}?next={% if request.event_domain %}{{ request.scheme }}://{{ request.get_host }}{% endif %}{{ request.path|urlencode }}%3F{{ request.META.QUERY_STRING|urlencode }}{% endif %}{% if request.event_domain %}&request_cross_domain_customer_auth=true{% endif %}">
+                <span class="fa fa-sign-in" aria-hidden="true"></span>
                 {% trans "Log in" %}</a>
 
         {% endif %}


### PR DESCRIPTION
Not necessarly a a11y-issue as it is a button and that can have a aria-label, but it is a best practise to have a visual label as well. And as „Log in“ is written out, I think „Log out“ should be as well. Also added a login-icon to the login-link.

Before:
![Bildschirmfoto 2025-05-15 um 12 35 25](https://github.com/user-attachments/assets/94e226c7-692f-4680-936d-94fcb7afaf2e)

After:
![Bildschirmfoto 2025-05-15 um 12 38 25](https://github.com/user-attachments/assets/837e337d-5efd-4d5e-b8b1-39b76b7093ba)
![Bildschirmfoto 2025-05-15 um 12 35 46](https://github.com/user-attachments/assets/bb21dec5-121e-41c2-b1f7-79a34897f107)
