### PR TITLE
Fix bulk voucher CSV field description

### DIFF
--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -294,7 +294,7 @@ class VoucherBulkForm(VoucherForm):
         }),
         required=False,
         help_text=_('You can either supply a list of email addresses with one email address per line, or the contents '
-                    'of a CSV file with a title column and one or more of the columns "email", "number", "name", '
+                    'of a CSV file with a title row and one or more of the columns "email", "number", "name", '
                     'or "tag".')
     )
     Recipient = namedtuple('Recipient', 'email number name tag')


### PR DESCRIPTION
"title column" made me think of a column for the "title" part of names – looking at [the docs](https://docs.pretix.eu/guides/vouchers/#sending-out-vouchers-via-email), I think "title row" is better (though linking to the docs directly might be worthwhile here anyways?)