### PR TITLE
[A11y] Fix placeholder color contrast

### DIFF
--- a/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
+++ b/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
@@ -9,7 +9,7 @@ $gray-lightest: lighten(#000, 97.25%);
 $font-family-sans-serif: var(--pretix-font-family-sans-serif);
 $text-color: #222222 !default;
 $text-muted: #737373 !default;
-$input-color-placeholder: lighten(#000, 70%) !default;
+$input-color-placeholder: lighten(#000, 58%) !default;
 
 $border-radius-base: var(--pretix-border-radius-base);
 $border-radius-large: var(--pretix-border-radius-large);


### PR DESCRIPTION
Not sure how this slipped in original a11y-testing, but in the widget the placeholder-attribute’s color-contrast was marked to low. It needs to be 3:1. This PR fixes the placeholder color contrast for all of pretix (not just widget and presale). It changes from `#b3b3b3` to `#949494`.