### PR TITLE
[A11y] fix skip-link z-index

### DIFF
--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -76,6 +76,7 @@ html {
     clip: auto;
 }
 #skip-to-main {
+    z-index: 9999;
     /* padding is needed to make focus-outline visible */
     padding: 8px;
     background-color: inherit;


### PR DESCRIPTION
The skip-link can be overlayed by a the back-to-organizer-link or by a `.panel` in the widget. Interestingly this wasn’t a problem in my testing, but came up during external a11y-testing. As a safe-gurad, this PR adds a z-index of 9999 to the skip-link.