### PR TITLE
[A11y] Do not underline event-titles in organizer’s event-list

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/organizers/index.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/index.html
@@ -49,7 +49,7 @@
                 <div class="event-list full-width-list alternating-rows">
                 {% for e in events %}{% eventurl e "presale:event.index" as url %}
                     <article class="row" aria-labelledby="event-{{ e.pk }}-label" aria-describedby="event-{{ e.pk }}-desc">
-                        <h3 class="col-md-4 col-xs-12"><a href="{{ url }}" id="event-{{ e.pk }}-label">{{ e.name }}</a></h3>
+                        <h3 class="col-md-4 col-xs-12"><a href="{{ url }}" id="event-{{ e.pk }}-label" class="no-underline">{{ e.name }}</a></h3>
                         <p class="col-md-3 col-xs-12" id="event-{{ e.pk }}-desc">
                         {% if e.settings.show_dates_on_frontpage %}
                             {% if e.has_subevents %}


### PR DESCRIPTION
As we have a button next to it, that works the same, it should be okay to omit the underline on the event titles.