### PR TITLE
[A11y] fix waitinglist-link not being recognizable as a link

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_availability.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_availability.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load icon %}
 {% load eventurl %}
 
 {% if item.current_unavailability_reason == 'require_voucher' %}
@@ -20,14 +21,15 @@
 {% elif avail <= 10 %}
     <div class="col-md-2 col-sm-3 col-xs-6 availability-box gone">
         {% if price or original_price %}
-            <strong>{% trans "SOLD OUT" %}</strong>
+            <strong>{% icon "ban" %} {% trans "SOLD OUT" %}</strong>
         {% else %}
-            <strong>{% trans "FULLY BOOKED" %}</strong>
+            <strong>{% icon "ban" %} {% trans "FULLY BOOKED" %}</strong>
         {% endif %}
+            </span>
         {% if allow_waitinglist and item.allow_waitinglist %}
             <br/>
-            <a href="{% eventurl event "presale:event.waitinglist" cart_namespace=cart_namespace|default_if_none:"" %}?item={{ item.pk }}{% if var %}&var={{ var.pk }}{% endif %}{% if subevent %}&subevent={{ subevent.pk }}{% endif %}">
-                <span class="fa fa-plus-circle" aria-hidden="true"></span>
+            <a href="{% eventurl event "presale:event.waitinglist" cart_namespace=cart_namespace|default_if_none:"" %}?item={{ item.pk }}{% if var %}&var={{ var.pk }}{% endif %}{% if subevent %}&subevent={{ subevent.pk }}{% endif %}" class="btn btn-default btn-xs">
+                {% icon "plus-circle" %}
                 {% trans "Waiting list" %}
             </a>
         {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load icon %}
 {% load l10n %}
 {% load eventurl %}
 {% load money %}
@@ -82,9 +83,9 @@
                             {% if not event.settings.show_variations_expanded %}
                                 {% if item.best_variation_availability <= 10 %}
                                     {% if not item.min_price %}
-                                        <strong class="gone">{% trans "FULLY BOOKED" %}</strong>
+                                        <strong class="gone">{% icon "ban" %} {% trans "FULLY BOOKED" %}</strong>
                                     {% else %}
-                                        <strong class="gone">{% trans "SOLD OUT" %}</strong>
+                                        <strong class="gone">{% icon "ban" %} {% trans "SOLD OUT" %}</strong>
                                     {% endif %}
                                     {% if allow_waitinglist and item.allow_waitinglist %}
                                         <br/>

--- a/src/pretix/static/pretixpresale/scss/_event.scss
+++ b/src/pretix/static/pretixpresale/scss/_event.scss
@@ -23,7 +23,7 @@
         text-align: center;
 
         &.gone, .gone {
-            color: $alert-danger-text;
+            color: $brand-danger;
         }
         &.unavailable, .unavailable {
             color: $alert-warning-text;


### PR DESCRIPTION
This PR make the waitinglist-link look like a button to make it recognizable as a link/interactive element. Alternative would have been to underline it.

This PR also improves the red for the status `.gone` – the original brand-danger did not have the needed contrast, but now has. So use brand-danger instead of a very dark red, which is optimized for use in the alert-danger context.

Before
![Bildschirmfoto 2025-05-19 um 11 55 32](https://github.com/user-attachments/assets/5f54880b-8c1a-41b3-a3af-3d20d104fcd5)

After
![Bildschirmfoto 2025-05-19 um 11 56 00](https://github.com/user-attachments/assets/015061ef-f103-4dea-9c58-815a2ad10aba)

Alternative
![Bildschirmfoto 2025-05-19 um 11 55 21](https://github.com/user-attachments/assets/e097f668-8650-4f44-977d-f0324c7b8067)
