### PR TITLE
[A11y] show dialog when empty add-to-cart instead of disabling the button

### DIFF
--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -2,7 +2,7 @@
 # This file is part of pretix (Community Edition).
 #
 # Copyright (C) 2014-2020 Raphael Michel and contributors
-# Copyright (C) 2020-2025 rami.io GmbH and contributors
+# Copyright (C) 2020-2021 rami.io GmbH and contributors
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
 # Public License as published by the Free Software Foundation in version 3 of the License.

--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -28,7 +28,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def begindialog(html_id, label, description, *args, **kwargs):
+def dialog(html_id, label, description, *args, **kwargs):
     format_kwargs = {
         "id": html_id,
         "label": label,

--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -22,6 +22,7 @@
 from django import template
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+
 from django.utils.translation import gettext_lazy as _  # NOQA
 
 register = template.Library()
@@ -38,7 +39,7 @@ def dialog(html_id, label, description, *args, **kwargs):
     }
     result = """
     <dialog {alert}
-        id="{id}" 
+        id="{id}"
         aria-labelledby="{id}-label"
         aria-describedby="{id}-description">
         <form method="dialog" class="modal-card form-horizontal">

--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -41,7 +41,7 @@ def dialog(html_id, label, description, *args, **kwargs):
         id="{id}" 
         aria-labelledby="{id}-label"
         aria-describedby="{id}-description">
-        <form method="dialog" class="modal-card">
+        <form method="dialog" class="modal-card form-horizontal">
             {icon}
             <div class="modal-card-content">
                 <h2 id="{id}-label">{label}</h2>

--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -52,35 +52,8 @@ def begindialog(html_id, label, description, *args, **kwargs):
 
 @register.simple_tag
 def enddialog(*args, **kwargs):
-    cancel = kwargs.get("cancel", False)
-    confirm = kwargs.get("confirm", True)
-    if not cancel and not confirm:
-        raise template.TemplateSyntaxError(
-            "You cannot have confirm=False if there is no cancel=True"
-        )
-        confirm = True
-
-    format_kwargs = {
-        "cancel": format_html(
-            '<button value="0" class="btn btn-{}">{}{}</button>',
-            kwargs.get("cancel_class", "danger"),
-            format_html('<span class="fa fa-{}" aria-hidden="true"></span> ', kwargs["cancel_icon"]) if "cancel_icon" in kwargs else "",
-            _("Cancel") if cancel is True else cancel,
-        ) if cancel else "",
-        "confirm": format_html(
-            '<button value="1" class="btn btn-{}">{}{}</button>',
-            kwargs.get("confirm_class", "primary"),
-            format_html('<span class="fa fa-{}" aria-hidden="true"></span> ', kwargs["confirm_icon"]) if "confirm_icon" in kwargs else "",
-            _("OK") if confirm is True else confirm,
-        ) if confirm else "",
-    }
-    result = """
-                <div class="modal-card-confirm">
-                    {confirm}
-                    {cancel}
-                </div>
+    return mark_safe("""
             </div>
         </form>
     </dialog>
-    """
-    return format_html(result, **format_kwargs)
+    """)

--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -75,10 +75,10 @@ def enddialog(*args, **kwargs):
         ) if confirm else "",
     }
     result = """
-            </div>
-            <div class="modal-card-confirm">
-                {cancel}
-                {confirm}
+                <div class="modal-card-confirm">
+                    {confirm}
+                    {cancel}
+                </div>
             </div>
         </form>
     </dialog>

--- a/src/pretix/base/templatetags/dialog.py
+++ b/src/pretix/base/templatetags/dialog.py
@@ -1,0 +1,86 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020 Raphael Michel and contributors
+# Copyright (C) 2020-2025 rami.io GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+from django import template
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _  # NOQA
+
+register = template.Library()
+
+
+@register.simple_tag
+def begindialog(html_id, label, description, *args, **kwargs):
+    format_kwargs = {
+        "id": html_id,
+        "label": label,
+        "description": description,
+        "icon": format_html('<div class="modal-card-icon"><span class="fa fa-{}" aria-hidden="true"></span></div>', kwargs["icon"]) if "icon" in kwargs else "",
+        "alert": mark_safe('role="alertdialog"') if kwargs.get("alert", "False") != "False" else "",
+    }
+    result = """
+    <dialog {alert}
+        id="{id}" 
+        aria-labelledby="{id}-label"
+        aria-describedby="{id}-description">
+        <form method="dialog" class="modal-card">
+            {icon}
+            <div class="modal-card-content">
+                <h2 id="{id}-label">{label}</h2>
+                <p id="{id}-description">{description}</p>
+    """
+    return format_html(result, **format_kwargs)
+
+
+@register.simple_tag
+def enddialog(*args, **kwargs):
+    cancel = kwargs.get("cancel", False)
+    confirm = kwargs.get("confirm", True)
+    if not cancel and not confirm:
+        raise template.TemplateSyntaxError(
+            "You cannot have confirm=False if there is no cancel=True"
+        )
+        confirm = True
+
+    format_kwargs = {
+        "cancel": format_html(
+            '<button value="0" class="btn btn-{}">{}{}</button>',
+            kwargs.get("cancel_class", "danger"),
+            format_html('<span class="fa fa-{}" aria-hidden="true"></span> ', kwargs["cancel_icon"]) if "cancel_icon" in kwargs else "",
+            _("Cancel") if cancel is True else cancel,
+        ) if cancel else "",
+        "confirm": format_html(
+            '<button value="1" class="btn btn-{}">{}{}</button>',
+            kwargs.get("confirm_class", "primary"),
+            format_html('<span class="fa fa-{}" aria-hidden="true"></span> ', kwargs["confirm_icon"]) if "confirm_icon" in kwargs else "",
+            _("OK") if confirm is True else confirm,
+        ) if confirm else "",
+    }
+    result = """
+            </div>
+            <div class="modal-card-confirm">
+                {cancel}
+                {confirm}
+            </div>
+        </form>
+    </dialog>
+    """
+    return format_html(result, **format_kwargs)

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -247,6 +247,7 @@
                 {% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." as description_nothing_to_add %}
                 {% begindialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation" %}
                     <p class="text-muted">More optional content that is not part of the description, useful for e.g. loading modal steps, that is way to long for aria-describedby.</p>
+                    <p class="modal-card-confirm"><button class="btn btn-primary">{% trans "OK" %}</button></p>
                 {% enddialog %}
             {% endif %}
         {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -7,6 +7,7 @@
 {% load thumb %}
 {% load eventsignal %}
 {% load rich_text %}
+{% load icon %}
 
 {% block title %}
     {% if "year" in request.GET %}
@@ -240,6 +241,25 @@
                     </div>
                 {% endif %}
             </form>
+            {% if ev.presale_is_running and display_add_to_cart %}
+                <dialog role="alertdialog"
+                    id="dialog-add-to-cart-none" 
+                    aria-labelledby="dialog-add-to-cart-none-label"
+                    aria-describedby="dialog-add-to-cart-none-description">
+                    <form class="modal-card" method="dialog">
+                        <div class="modal-card-icon">
+                            {% icon "exclamation" %}
+                        </div>
+                        <div class="modal-card-content">
+                            <h2 id="dialog-add-to-cart-none-label">{% trans "You have not selected any ticket." %}</h2>
+                            <p id="dialog-add-to-cart-none-description">{% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." %}</p>
+                        </div>
+                        <div class="modal-card-confirm">
+                            <button>{% trans "Okay, I will select a ticket." %}</button>
+                        </div>
+                    </form>
+                </dialog>
+            {% endif %}
         {% endif %}
     {% endif %}
     </main>

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -8,6 +8,7 @@
 {% load eventsignal %}
 {% load rich_text %}
 {% load icon %}
+{% load dialog %}
 
 {% block title %}
     {% if "year" in request.GET %}
@@ -242,23 +243,11 @@
                 {% endif %}
             </form>
             {% if ev.presale_is_running and display_add_to_cart %}
-                <dialog role="alertdialog"
-                    id="dialog-add-to-cart-none" 
-                    aria-labelledby="dialog-add-to-cart-none-label"
-                    aria-describedby="dialog-add-to-cart-none-description">
-                    <form class="modal-card" method="dialog">
-                        <div class="modal-card-icon">
-                            {% icon "exclamation" %}
-                        </div>
-                        <div class="modal-card-content">
-                            <h2 id="dialog-add-to-cart-none-label">{% trans "You have not selected any ticket." %}</h2>
-                            <p id="dialog-add-to-cart-none-description">{% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." %}</p>
-                        </div>
-                        <div class="modal-card-confirm">
-                            <button>{% trans "Okay, I will select a ticket." %}</button>
-                        </div>
-                    </form>
-                </dialog>
+                {% trans "You have not selected any ticket." as label_nothing_to_add %}
+                {% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." as description_nothing_to_add %}
+                {% begindialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation" %}
+                    <p class="text-muted">More optional content that is not part of the description, useful for e.g. loading modal steps, that is way to long for aria-describedby.</p>
+                {% enddialog %}
             {% endif %}
         {% endif %}
     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -245,7 +245,7 @@
             {% if ev.presale_is_running and display_add_to_cart %}
                 {% trans "You didn’t selected any ticket." as label_nothing_to_add %}
                 {% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." as description_nothing_to_add %}
-                {% begindialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation-circle" %}
+                {% dialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation-circle" %}
                     <p class="modal-card-confirm"><button class="btn btn-primary">{% trans "OK" %}</button></p>
                 {% enddialog %}
             {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -246,7 +246,6 @@
                 {% trans "You didn’t selected any ticket." as label_nothing_to_add %}
                 {% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." as description_nothing_to_add %}
                 {% begindialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation-circle" %}
-                    <p class="text-muted">More optional content that is not part of the description, useful for e.g. loading modal steps, that is way to long for aria-describedby.</p>
                     <p class="modal-card-confirm"><button class="btn btn-primary">{% trans "OK" %}</button></p>
                 {% enddialog %}
             {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -243,7 +243,7 @@
                 {% endif %}
             </form>
             {% if ev.presale_is_running and display_add_to_cart %}
-                {% trans "You didn’t selected any ticket." as label_nothing_to_add %}
+                {% trans "You didn’t select any ticket." as label_nothing_to_add %}
                 {% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." as description_nothing_to_add %}
                 {% dialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation-circle" %}
                     <p class="modal-card-confirm"><button class="btn btn-primary">{% trans "OK" %}</button></p>

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -243,9 +243,9 @@
                 {% endif %}
             </form>
             {% if ev.presale_is_running and display_add_to_cart %}
-                {% trans "You have not selected any ticket." as label_nothing_to_add %}
+                {% trans "You didn’t selected any ticket." as label_nothing_to_add %}
                 {% trans "Please tick a checkbox or enter a quantity for one of the ticket types to add to the cart." as description_nothing_to_add %}
-                {% begindialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation" %}
+                {% begindialog "dialog-nothing-to-add" label_nothing_to_add description_nothing_to_add icon="exclamation-circle" %}
                     <p class="text-muted">More optional content that is not part of the description, useful for e.g. loading modal steps, that is way to long for aria-describedby.</p>
                     <p class="modal-card-confirm"><button class="btn btn-primary">{% trans "OK" %}</button></p>
                 {% enddialog %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_modals.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_modals.html
@@ -53,7 +53,7 @@
     {% endif %}
     {% if cookie_providers %}
         {% with request.event|default:request.organizer as sh %}
-            {% dialog "cookie-consent-modal" sh.settings.cookie_consent_dialog_title sh.settings.cookie_consent_dialog_text|rich_text icon="user-secret" %}
+            {% dialog "cookie-consent-modal" sh.settings.cookie_consent_dialog_title sh.settings.cookie_consent_dialog_text|rich_text icon="shield" %}
                 {% if sh.settings.cookie_consent_dialog_text_secondary %}
                     <div class="text-muted">
                         {{ sh.settings.cookie_consent_dialog_text_secondary|rich_text }}

--- a/src/pretix/presale/templates/pretixpresale/fragment_modals.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_modals.html
@@ -2,6 +2,8 @@
 {% load rich_text %}
 {% load safelink %}
 {% load escapejson %}
+{% load icon %}
+{% load dialog %}
 <div id="ajaxerr">
 </div>
 <div id="popupmodal" hidden aria-live="polite">
@@ -50,93 +52,74 @@
         {{ cookie_consent_from_widget|json_script:"cookie-consent-from-widget" }}
     {% endif %}
     {% if cookie_providers %}
-        <div id="cookie-consent-modal" aria-live="polite">
-            <div class="modal-card">
-                <div class="modal-card-content">
-                    <h3 id="cookie-consent-modal-label"></h3>
-                    <div id="cookie-consent-modal-description">
-                        <form class="form-horizontal">
-                        {% with request.event|default:request.organizer as sh %}
-                            <h3>{{ sh.settings.cookie_consent_dialog_title }}</h3>
-                            {{ sh.settings.cookie_consent_dialog_text|rich_text }}
-                            {% if sh.settings.cookie_consent_dialog_text_secondary %}
-                                <div class="text-muted">
-                                    {{ sh.settings.cookie_consent_dialog_text_secondary|rich_text }}
-                                </div>
-                            {% endif %}
-                            <details id="cookie-consent-details">
-                                <summary>
-                                    <span class="fa fa-fw chevron"></span>
-                                    {% trans "Adjust settings in detail" %}
-                                </summary>
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" disabled checked="" aira-describedby="cookie-consent-checkbox-required-description">
-                                        {% trans "Required cookies" %}
-                                    </label>
-                                </div>
-                                <div class="help-block" id="cookie-consent-checkbox-required-description">
-                                    <p>{% trans "Functional cookies (e.g. shopping cart, login, payment, language preference) and technical cookies (e.g. security purposes)" %}</p>
-                                </div>
-                                {% for cp in cookie_providers %}
-                                    <div class="checkbox">
-                                        <label>
-                                            <input type="checkbox" name="{{ cp.identifier }}" aira-describedby="cookie-consent-checkbox-{{ cp.identifier }}-description">
-                                            {{ cp.provider_name }}
-                                        </label>
-                                    </div>
-                                    <div class="help-block" id="cookie-consent-checkbox-{{ cp.identifier }}-description">
-                                        <p>
-                                        {% for c in cp.usage_classes %}
-                                            {% if forloop.counter0 > 0 %}&middot; {% endif %}
-                                            {% if c.value == 1 %}
-                                                {% trans "Functionality" context "cookie_usage" %}
-                                            {% elif c.value == 2 %}
-                                                {% trans "Analytics" context "cookie_usage" %}
-                                            {% elif c.value == 3 %}
-                                                {% trans "Marketing" context "cookie_usage" %}
-                                            {% elif c.value == 4 %}
-                                                {% trans "Social features" context "cookie_usage" %}
-                                            {% endif %}
-                                        {% endfor %}
-                                        {% if cp.privacy_url %}
-                                            &middot;
-                                            <a href="{% safelink cp.privacy_url %}" target="_blank">
-                                                {% trans "Privacy policy" %}
-                                            </a>
-                                        {% endif %}
-                                        </p>
-                                    </div>
-                                {% endfor %}
-                            </details>
-                            <div class="row">
-                                <div class="col-xs-12 col-md-6">
-                                    <p>
-                                        <button type="button" class="btn btn-lg btn-block btn-primary" id="cookie-consent-button-no"
-                                                data-summary-text="{{ sh.settings.cookie_consent_dialog_button_no }}"
-                                                data-detail-text="{% trans "Save selection" %}">
-                                            {{ sh.settings.cookie_consent_dialog_button_no }}
-                                        </button>
-                                    </p>
-                                </div>
-                                <div class="col-xs-12 col-md-6">
-                                    <p>
-                                        <button type="button" class="btn btn-lg btn-block btn-primary" id="cookie-consent-button-yes">
-                                            {{ sh.settings.cookie_consent_dialog_button_yes }}
-                                        </button>
-                                    </p>
-                                </div>
-                            </div>
-                            {% if sh.settings.privacy_url %}
-                                <p class="text-center">
-                                    <a href="{% safelink sh.settings.privacy_url %}" target="_blank" rel="noopener">{% trans "Privacy policy" %}</a>
-                                </p>
-                            {% endif %}
-                        {% endwith %}
-                        <form>
+        {% with request.event|default:request.organizer as sh %}
+            {% dialog "cookie-consent-modal" sh.settings.cookie_consent_dialog_title sh.settings.cookie_consent_dialog_text|rich_text icon="user-secret" %}
+                {% if sh.settings.cookie_consent_dialog_text_secondary %}
+                    <div class="text-muted">
+                        {{ sh.settings.cookie_consent_dialog_text_secondary|rich_text }}
                     </div>
-                </div>
-            </div>
-        </div>
+                {% endif %}
+                <details id="cookie-consent-details">
+                    <summary>
+                        <span class="fa fa-fw chevron"></span>
+                        {% trans "Adjust settings in detail" %}
+                    </summary>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" disabled checked="" aira-describedby="cookie-consent-checkbox-required-description">
+                            {% trans "Required cookies" %}
+                        </label>
+                    </div>
+                    <div class="help-block" id="cookie-consent-checkbox-required-description">
+                        <p>{% trans "Functional cookies (e.g. shopping cart, login, payment, language preference) and technical cookies (e.g. security purposes)" %}</p>
+                    </div>
+                    {% for cp in cookie_providers %}
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="{{ cp.identifier }}" aira-describedby="cookie-consent-checkbox-{{ cp.identifier }}-description">
+                                {{ cp.provider_name }}
+                            </label>
+                        </div>
+                        <div class="help-block" id="cookie-consent-checkbox-{{ cp.identifier }}-description">
+                            <p>
+                            {% for c in cp.usage_classes %}
+                                {% if forloop.counter0 > 0 %}&middot; {% endif %}
+                                {% if c.value == 1 %}
+                                    {% trans "Functionality" context "cookie_usage" %}
+                                {% elif c.value == 2 %}
+                                    {% trans "Analytics" context "cookie_usage" %}
+                                {% elif c.value == 3 %}
+                                    {% trans "Marketing" context "cookie_usage" %}
+                                {% elif c.value == 4 %}
+                                    {% trans "Social features" context "cookie_usage" %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if cp.privacy_url %}
+                                &middot;
+                                <a href="{% safelink cp.privacy_url %}" target="_blank">
+                                    {% trans "Privacy policy" %}
+                                </a>
+                            {% endif %}
+                            </p>
+                        </div>
+                    {% endfor %}
+                </details>
+                <p class="modal-card-confirm modal-card-confirm-spread">
+                    <button class="btn btn-lg btn-default" id="cookie-consent-button-no" value="no" autofocus="true"
+                            data-summary-text="{{ sh.settings.cookie_consent_dialog_button_no }}"
+                            data-detail-text="{% trans "Save selection" %}">
+                        {{ sh.settings.cookie_consent_dialog_button_no }}
+                    </button>
+                    <button class="btn btn-lg btn-primary" id="cookie-consent-button-yes" value="yes">
+                        {{ sh.settings.cookie_consent_dialog_button_yes }}
+                    </button>
+                </p>
+                {% if sh.settings.privacy_url %}
+                    <p class="text-center">
+                        <small><a href="{% safelink sh.settings.privacy_url %}" target="_blank" rel="noopener">{% trans "Privacy policy" %}</a></small>
+                    </p>
+                {% endif %}
+            {% enddialog %}
+        {% endwith %}
     {% endif %}
 {% endif %}

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -281,9 +281,9 @@ dialog {
   .modal-card {
     display: flex;
     flex-direction: column;
+    align-content: stretch;
   }
   .modal-card-icon {
-    width: 100%;
     background: $brand-primary;
     font-size: 2em;
     color: white;
@@ -293,10 +293,10 @@ dialog {
   .modal-card-content {
     padding: 1.5em;
   }
-  .modal-card-content *:last-child {
+  .modal-card-content>*:last-child {
     margin-bottom: 0;
   }
-  .modal-card-content *:first-child {
+  .modal-card-content>*:first-child {
     margin-top: 0;
   }
 
@@ -305,6 +305,10 @@ dialog {
     display: flex;
     justify-content: flex-end;
     gap: 1em;
+    align-items: center;
+  }
+  .modal-card-confirm-spread {
+    justify-content: space-between;
   }
 }
 dialog[open] {
@@ -329,10 +333,8 @@ dialog::backdrop {
       padding: 2em;
     }
     .modal-card-icon {
-      max-width: 6em;
-      width: 25%;
       font-size: 4em;
-      padding: 6px;
+      padding: 6px 16px;
     }
   }
 }

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -262,3 +262,78 @@ svg.svg-icon {
 @include table-row-variant('info', var(--pretix-brand-info-success-lighten-30), var(--pretix-brand-info-success-lighten-25));
 @include table-row-variant('warning', var(--pretix-brand-warning-lighten-40), var(--pretix-brand-warning-lighten-35));
 @include table-row-variant('danger', var(--pretix-brand-danger-lighten-30), var(--pretix-brand-danger-lighten-25));
+
+
+
+
+dialog {
+  border: none;
+  width: 80%;
+  max-width: 43em;
+  padding: 0;
+  box-shadow: 0 7px 14px 0 rgba(78, 50, 92, 0.1),0 3px 6px 0 rgba(0,0,0,.07);
+  background: white;
+  border-radius: $border-radius-large;
+
+  opacity: 0;
+  transition: all 1s allow-discrete;
+
+  .modal-card {
+    display: flex;
+    flex-direction: column;
+  }
+  .modal-card-icon {
+    width: 100%;
+    background: $brand-primary;
+    font-size: 2em;
+    color: white;
+    text-align: center;
+    padding: 3px;
+  }
+  .modal-card-content {
+    padding: 1.5em;
+  }
+  .modal-card-content *:last-child {
+    margin-bottom: 0;
+  }
+  .modal-card-content *:first-child {
+    margin-top: 0;
+  }
+
+  .modal-card-confirm {
+    margin-top: 2em;
+    display: flex;
+    justify-content: flex-end;
+    gap: 1em;
+  }
+}
+dialog[open] {
+  opacity: 1;
+}
+@starting-style {
+  dialog[open] {
+    opacity: 0;
+  }
+}
+dialog::backdrop {
+  background-color: rgba(255, 255, 255, .5);
+  transition: all 8s allow-discrete;
+}
+
+@media screen and (min-width: $screen-sm-min) {
+  dialog {
+    .modal-card {
+      flex-direction: row;
+    }
+    .modal-card-content {
+      padding: 2em;
+    }
+    .modal-card-icon {
+      max-width: 6em;
+      width: 25%;
+      font-size: 4em;
+      padding: 10px;
+    }
+  }
+}
+

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -267,6 +267,7 @@ svg.svg-icon {
 
 
 dialog {
+  position: relative;
   border: none;
   width: 80%;
   max-width: 43em;
@@ -276,7 +277,7 @@ dialog {
   border-radius: $border-radius-large;
 
   opacity: 0;
-  transition: all .5s allow-discrete;
+  transition: opacity .5s allow-discrete;
 
   .modal-card {
     display: flex;
@@ -314,7 +315,7 @@ dialog {
 dialog::backdrop {
   background-color: rgba(255, 255, 255, .5);
   opacity: 0;
-  transition: all .5s allow-discrete;
+  transition: opacity .5s allow-discrete;
 }
 dialog[open], dialog[open]::backdrop {
   opacity: 1;
@@ -327,7 +328,7 @@ dialog[open], dialog[open]::backdrop {
 
 @media screen and (min-width: $screen-sm-min) {
   dialog {
-    .modal-card {
+    .modal-card:has(.modal-card-icon) {
       flex-direction: row;
     }
     .modal-card-content {

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -276,7 +276,7 @@ dialog {
   border-radius: $border-radius-large;
 
   opacity: 0;
-  transition: all 1s allow-discrete;
+  transition: all .5s allow-discrete;
 
   .modal-card {
     display: flex;
@@ -311,17 +311,18 @@ dialog {
     justify-content: space-between;
   }
 }
-dialog[open] {
+dialog::backdrop {
+  background-color: rgba(255, 255, 255, .5);
+  opacity: 0;
+  transition: all .5s allow-discrete;
+}
+dialog[open], dialog[open]::backdrop {
   opacity: 1;
 }
 @starting-style {
-  dialog[open] {
+  dialog[open], dialog[open]::backdrop  {
     opacity: 0;
   }
-}
-dialog::backdrop {
-  background-color: rgba(255, 255, 255, .5);
-  transition: all 8s allow-discrete;
 }
 
 @media screen and (min-width: $screen-sm-min) {

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -339,3 +339,17 @@ dialog::backdrop {
   }
 }
 
+.shake-once {
+  animation: shake .2s;
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
+}
+
+@keyframes shake {
+  0% { transform: skewX(0deg); }
+  20% { transform: skewX(-5deg); }
+  40% { transform: skewX(5deg); }
+  60% { transform: skewX(-5deg); }
+  80% { transform: skewX(5deg); }
+  100% { transform: skewX(0deg); }
+}

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -267,7 +267,6 @@ svg.svg-icon {
 
 
 dialog {
-  position: relative;
   border: none;
   width: 80%;
   max-width: 43em;

--- a/src/pretix/static/pretixbase/scss/_theme.scss
+++ b/src/pretix/static/pretixbase/scss/_theme.scss
@@ -332,7 +332,7 @@ dialog::backdrop {
       max-width: 6em;
       width: 25%;
       font-size: 4em;
-      padding: 10px;
+      padding: 6px;
     }
   }
 }

--- a/src/pretix/static/pretixpresale/js/ui/cookieconsent.js
+++ b/src/pretix/static/pretixpresale/js/ui/cookieconsent.js
@@ -107,10 +107,20 @@ $(function () {
     }
 
     _set_button_text();
+    function disableCancel(e) {
+        consent_modal.classList.add("shake-once");
+        consent_modal.addEventListener("animationend", function () {
+            consent_modal.classList.remove("shake-once");
+        }, { once: true });
+        e.preventDefault();
+    }
     if (show_dialog) {
-        // We use .css() instead of .show() because of some weird issue that only occurs in Firefox
-        // and only within the widget.
-        consent_modal.css("display", "block");
+        // disable ESC if we show the dialog the first time/due to changes
+        // Could be a helper with: window.pretix.dialog.disableCancel(consent_modal, {once: true})
+        consent_modal.addEventListener("cancel", disableCancel);
+        consent_modal.addEventListener("close", function () {
+            consent_modal.removeEventListener("cancel", disableCancel);
+        }, { once: true })
         consent_modal.showModal();
     }
 

--- a/src/pretix/static/pretixpresale/js/ui/cookieconsent.js
+++ b/src/pretix/static/pretixpresale/js/ui/cookieconsent.js
@@ -107,21 +107,16 @@ $(function () {
     }
 
     _set_button_text();
-    function disableCancel(e) {
-        consent_modal.classList.add("shake-once");
-        consent_modal.addEventListener("animationend", function () {
-            consent_modal.classList.remove("shake-once");
-        }, { once: true });
-        e.preventDefault();
-    }
     if (show_dialog) {
-        // disable ESC if we show the dialog the first time/due to changes
-        // Could be a helper with: window.pretix.dialog.disableCancel(consent_modal, {once: true})
-        consent_modal.addEventListener("cancel", disableCancel);
-        consent_modal.addEventListener("close", function () {
-            consent_modal.removeEventListener("cancel", disableCancel);
-        }, { once: true })
         consent_modal.showModal();
+        consent_modal.addEventListener("cancel", function() {
+            // Dialog was initially shown, interpret Escape as „do not consent to new providers“
+            var consent = {};
+            consent_checkboxes.each(function () {
+                consent[this.name] = storage_val[this.name] || false;
+            });
+            update_consent(consent, false);
+        }, {once : true});
     }
 
     consent_modal.addEventListener("close", function () {

--- a/src/pretix/static/pretixpresale/js/ui/cookieconsent.js
+++ b/src/pretix/static/pretixpresale/js/ui/cookieconsent.js
@@ -6,7 +6,7 @@ $(function () {
     var storage_key = $("#cookie-consent-storage-key").text();
     var widget_consent = $("#cookie-consent-from-widget").text();
     var consent_checkboxes = $("#cookie-consent-details input[type=checkbox][name]");
-    var consent_modal = $("#cookie-consent-modal");
+    var consent_modal = document.getElementById("cookie-consent-modal");
 
     function update_consent(consent, sessionOnly) {
         if (storage_key && window.sessionStorage && sessionOnly) {
@@ -111,22 +111,24 @@ $(function () {
         // We use .css() instead of .show() because of some weird issue that only occurs in Firefox
         // and only within the widget.
         consent_modal.css("display", "block");
+        consent_modal.showModal();
     }
 
-    $("#cookie-consent-button-yes, #cookie-consent-button-no").on("click", function () {
-        consent_modal.hide();
+    consent_modal.addEventListener("close", function () {
+        if (!consent_modal.returnValue) {// ESC, do not save
+            return;
+        }
         var consent = {};
-        var consent_all = this.id == "cookie-consent-button-yes";
+        var consent_all = consent_modal.returnValue == "yes";
         consent_checkboxes.each(function () {
             consent[this.name] = this.checked = consent_all || this.checked;
         });
         if (consent_all) _set_button_text();
-        // Always save explicit consent to permanent storage
         update_consent(consent, false);
     });
     consent_checkboxes.on("change", _set_button_text);
     $("#cookie-consent-reopen").on("click", function (e) {
-        consent_modal.show()
+        consent_modal.showModal()
         e.preventDefault()
         return true
     })

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -491,7 +491,7 @@ $(function () {
         e.preventDefault();
         e.stopPropagation();
 
-        document.querySelector("#dialog-add-to-cart-none").showModal();
+        document.querySelector("#dialog-nothing-to-add").showModal();
     });
 
     $(".table-calendar td.has-events").click(function () {

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -478,33 +478,21 @@ $(function () {
             sessionStorage.setItem('scrollpos', window.scrollY);
         });
     }
-    var update_cart_form = function () {
-        var is_enabled = $(".product-row input[type=checkbox]:checked, .variations input[type=checkbox]:checked, .product-row input[type=radio]:checked, .variations input[type=radio]:checked").length;
-        if (!is_enabled) {
-            $(".input-item-count").each(function () {
-                if ($(this).val() && $(this).val() !== "0") {
-                    is_enabled = true;
-                }
-            });
-            $(".input-seat-selection option").each(function() {
-                if ($(this).val() && $(this).val() !== "" && $(this).prop('selected')) {
-                    is_enabled = true;
-                }
-            });
+    $("form:has(#btn-add-to-cart)").on("submit", function(e) {
+        if (
+            (this.classList.contains("has-seating") && this.querySelector("pretix-seating-checkout-button button")) ||
+            this.querySelector("input[type=checkbox]:checked") || 
+            [...this.querySelectorAll(".input-item-count[type=text]")].some(input => input.value && input.value !== "0") // TODO: seating hat noch einen seating-dummy-item-count, das ist Mist!
+        ) {
+            // okay, let the submit-event bubble to async-task
+            return;
         }
-        if (!is_enabled && (!$(".has-seating").length || $("#seating-dummy-item-count").length)) {
-            $("#btn-add-to-cart").prop("disabled", !is_enabled).popover({
-                'content': function () { return gettext("Please enter a quantity for one of the ticket types.") },
-                'placement': 'top',
-                'trigger': 'hover focus'
-            });
-        } else {
-            $("#btn-add-to-cart").prop("disabled", false).popover("destroy")
-        }
-    };
-    update_cart_form();
-    $(".product-row input[type=checkbox], .variations input[type=checkbox], .product-row input[type=radio], .variations input[type=radio], .input-item-count, .input-seat-selection")
-        .on("change mouseup keyup", update_cart_form);
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        document.querySelector("#dialog-add-to-cart-none").showModal();
+    });
 
     $(".table-calendar td.has-events").click(function () {
         var $grid = $(this).closest("[role='grid']");

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -289,7 +289,7 @@ body.loading .container {
     font-size: 120px;
     color: $brand-primary;
 }
-#loadingmodal, #ajaxerr, #cookie-consent-modal, #popupmodal {
+#loadingmodal, #ajaxerr, #popupmodal {
     position: fixed;
     top: 0;
     left: 0;
@@ -359,7 +359,7 @@ body.loading .container {
     }
 }
 @media (max-width: 700px) {
-    #loadingmodal, #ajaxerr, #cookie-consent-modal, #popupmodal {
+    #loadingmodal, #ajaxerr, #popupmodal {
         .modal-card {
             margin: 25px auto 0;
             max-height: calc(100vh - 50px - 20px);


### PR DESCRIPTION
This is a draft to use a dialog[role=alertdialog] to show a message to the user when trying to add no products to the cart. The dialog currently has no styling yet, it is just to show how easy native dialogs would be and IMHO there is no need for a custom `window.pretix.dialog` implementation. Just add the dialog to the DOM and use it in JS directly. ~We might be able to make it easier to create a correct `<dialog>` by adding a blocktag-templatetag in django, but for the draft that seemed out of scope.~

I also added a simple_tag `{% dialog %}` and `{% enddialog %}` to help with most of the boilerplate.

![Bildschirmfoto 2025-05-20 um 10 57 08](https://github.com/user-attachments/assets/a65ce3c3-3913-49e8-b368-8f021f5f6987)