### PR TITLE
Use he as language code for Hebrew

### DIFF
--- a/src/pretix/_base_settings.py
+++ b/src/pretix/_base_settings.py
@@ -122,7 +122,7 @@ LANGUAGES_OFFICIAL = {
 }
 LANGUAGES_RTL = {
     # When adding more right-to-left languages, also update pretix/static/pretixbase/scss/_rtl.scss
-    'ar', 'hw'
+    'ar', 'he'
 }
 LANGUAGES_INCUBATING = {
     'pt-br', 'gl',

--- a/src/pretix/static/pretixbase/scss/_rtl.scss
+++ b/src/pretix/static/pretixbase/scss/_rtl.scss
@@ -49,7 +49,7 @@ html.rtl {
 }
 
 input[lang=ar], textarea[lang=ar], div[lang=ar], pre[lang=ar],
-input[lang=hw], textarea[lang=hw], div[lang=hw], pre[lang=hw] {
+input[lang=he], textarea[lang=he], div[lang=he], pre[lang=he] {
   /* Keep list of languages in sync with pretix._base_settings.LANGUAGES_RTL */
   direction: rtl;
 }


### PR DESCRIPTION
As per [the pretix translation](https://translate.pretix.eu/languages/he/), the [gettext manual](https://www.gnu.org/software/gettext/manual/html_node/Usual-Language-Codes.html), and [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes#he)