### PR TITLE
[A11y] Fix checkbox:focus style

### DIFF
--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -156,6 +156,7 @@ button:focus, a:focus, .btn:focus, summary:focus, div:focus,
 button:active:focus, a:active:focus, .btn:active:focus, summary:active:focus, div:active:focus,
 button.active:focus, a.active:focus, .btn.active:focus,
 input:focus, .form-control:focus, .btn-checkbox:has(input:focus),
+input[type="file"]:focus, input[type="radio"]:focus, input[type="checkbox"]:focus,
 .input-item-count-group:has(input:focus), .input-group-price:has(input:focus) {
     outline: 2px solid $link-hover-color;
     outline-offset: 2px;


### PR DESCRIPTION
The default bottostrap focus outline – especially the outline-offset – was not properly overwritten.

Before (barely noticable the first checkbox has focus)

![Bildschirmfoto 2025-05-21 um 07 38 01](https://github.com/user-attachments/assets/abc1a6f7-2838-4e46-9a5d-10a6679b43c8)

After
![Bildschirmfoto 2025-05-21 um 07 37 26](https://github.com/user-attachments/assets/e577e545-ab3d-4fd6-970e-11030f5502e9)
