### PR TITLE
FormFieldRenderer: do not set placeholder automatically

### DIFF
--- a/src/pretix/base/reldate.py
+++ b/src/pretix/base/reldate.py
@@ -28,6 +28,9 @@ from dateutil import parser
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.formats import get_format
+from django.utils.functional import lazy
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -206,14 +209,27 @@ class RelativeDateTimeWidget(forms.MultiWidget):
     def __init__(self, *args, **kwargs):
         self.status_choices = kwargs.pop('status_choices')
         base_choices = kwargs.pop('base_choices')
+
+        def placeholder_datetime_format():
+            df = get_format('DATETIME_INPUT_FORMATS')[0]
+            return now().replace(
+                year=2000, month=12, day=31, hour=18, minute=0, second=0, microsecond=0
+            ).strftime(df)
+
+        def placeholder_time_format():
+            tf = get_format('TIME_INPUT_FORMATS')[0]
+            return datetime.time(8, 30, 0).strftime(tf)
+
         widgets = reldatetimeparts(
             status=forms.RadioSelect(choices=self.status_choices),
             absolute=forms.DateTimeInput(
-                attrs={'class': 'datetimepicker'}
+                attrs={'placeholder': lazy(placeholder_datetime_format, str), 'class': 'datetimepicker'}
             ),
             rel_days_number=forms.NumberInput(),
             rel_mins_relationto=forms.Select(choices=base_choices),
-            rel_days_timeofday=forms.TimeInput(attrs={'placeholder': _('Time'), 'class': 'timepickerfield'}),
+            rel_days_timeofday=forms.TimeInput(
+                attrs={'placeholder': lazy(placeholder_time_format, str), 'class': 'timepickerfield'}
+            ),
             rel_mins_number=forms.NumberInput(),
             rel_days_relationto=forms.Select(choices=base_choices),
             rel_mins_relation=forms.Select(choices=BEFORE_AFTER_CHOICE),

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -113,7 +113,6 @@ class EventWizardFoundationForm(forms.Form):
                 attrs={
                     'data-model-select2': 'generic',
                     'data-select2-url': reverse('control:organizers.select2') + '?can_create=1',
-                    'data-placeholder': _('Organizer')
                 }
             ),
             empty_label=None,

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -2444,7 +2444,7 @@ class CheckinFilterForm(FilterForm):
                     'event': self.event.slug,
                     'organizer': self.event.organizer.slug,
                 }),
-                'data-placeholder': _('Check-in list'),
+                'data-placeholder': _('All Check-in lists'),
             }
         )
         self.fields['checkin_list'].widget.choices = self.fields['checkin_list'].choices

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -1246,9 +1246,7 @@ class SubEventFilterForm(FilterForm):
     )
     query = forms.CharField(
         label=_('Event name'),
-        widget=forms.TextInput(attrs={
-            'placeholder': _('Event name'),
-        }),
+        widget=forms.TextInput(),
         required=False
     )
 

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -2444,7 +2444,7 @@ class CheckinFilterForm(FilterForm):
                     'event': self.event.slug,
                     'organizer': self.event.organizer.slug,
                 }),
-                'data-placeholder': _('All Check-in lists'),
+                'data-placeholder': _('All check-in lists'),
             }
         )
         self.fields['checkin_list'].widget.choices = self.fields['checkin_list'].choices

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -1693,9 +1693,7 @@ class EventFilterForm(FilterForm):
     )
     query = forms.CharField(
         label=_('Event name'),
-        widget=forms.TextInput(attrs={
-            'placeholder': _('Event name'),
-        }),
+        widget=forms.TextInput(),
         required=False
     )
     date_from = forms.DateField(

--- a/src/pretix/control/forms/item.py
+++ b/src/pretix/control/forms/item.py
@@ -324,7 +324,6 @@ class QuotaForm(I18nModelForm):
                         'event': self.event.slug,
                         'organizer': self.event.organizer.slug,
                     }),
-                    'data-placeholder': pgettext_lazy('subevent', 'Date')
                 }
             )
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices

--- a/src/pretix/control/forms/item.py
+++ b/src/pretix/control/forms/item.py
@@ -47,9 +47,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import (
-    gettext as __, gettext_lazy as _, pgettext_lazy,
-)
+from django.utils.translation import gettext as __, gettext_lazy as _
 from django_scopes.forms import (
     SafeModelChoiceField, SafeModelMultipleChoiceField,
 )

--- a/src/pretix/control/forms/item.py
+++ b/src/pretix/control/forms/item.py
@@ -346,6 +346,9 @@ class QuotaForm(I18nModelForm):
         field_classes = {
             'subevent': SafeModelChoiceField,
         }
+        widgets = {
+            'size': forms.NumberInput(attrs={'placeholder': _('Unlimited')})
+        }
 
     def save(self, *args, **kwargs):
         creating = not self.instance.pk

--- a/src/pretix/control/forms/orders.py
+++ b/src/pretix/control/forms/orders.py
@@ -397,7 +397,6 @@ class OrderPositionAddForm(forms.Form):
                         'event': order.event.slug,
                         'organizer': order.event.organizer.slug,
                     }),
-                    'data-placeholder': pgettext_lazy('subevent', 'Date')
                 }
             )
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices
@@ -693,7 +692,6 @@ class OrderContactForm(forms.ModelForm):
                     'data-select2-url': reverse('control:organizer.customers.select2', kwargs={
                         'organizer': self.instance.event.organizer.slug,
                     }),
-                    'data-placeholder': _('Customer')
                 }
             )
             self.fields['customer'].widget.choices = self.fields['customer'].choices

--- a/src/pretix/control/forms/organizer.py
+++ b/src/pretix/control/forms/organizer.py
@@ -778,7 +778,6 @@ class GiftCardUpdateForm(forms.ModelForm):
                 'data-select2-url': reverse('control:organizer.ticket_select2', kwargs={
                     'organizer': organizer.slug,
                 }),
-                'data-placeholder': _('Ticket')
             }
         )
         self.fields['owner_ticket'].widget.choices = self.fields['owner_ticket'].choices
@@ -814,7 +813,6 @@ class ReusableMediumUpdateForm(forms.ModelForm):
                 'data-select2-url': reverse('control:organizer.ticket_select2', kwargs={
                     'organizer': organizer.slug,
                 }),
-                'data-placeholder': _('Ticket')
             }
         )
         self.fields['linked_orderposition'].widget.choices = self.fields['linked_orderposition'].choices
@@ -827,7 +825,6 @@ class ReusableMediumUpdateForm(forms.ModelForm):
                 'data-select2-url': reverse('control:organizer.giftcards.select2', kwargs={
                     'organizer': organizer.slug,
                 }),
-                'data-placeholder': _('Gift card')
             }
         )
         self.fields['linked_giftcard'].widget.choices = self.fields['linked_giftcard'].choices
@@ -841,7 +838,6 @@ class ReusableMediumUpdateForm(forms.ModelForm):
                     'data-select2-url': reverse('control:organizer.customers.select2', kwargs={
                         'organizer': organizer.slug,
                     }),
-                    'data-placeholder': _('Customer')
                 }
             )
             self.fields['customer'].widget.choices = self.fields['customer'].choices

--- a/src/pretix/control/forms/subevents.py
+++ b/src/pretix/control/forms/subevents.py
@@ -133,16 +133,12 @@ class SubEventBulkEditForm(I18nModelForm):
             # i18n fields
             if k in self.mixed_values:
                 self.fields[k].widget.attrs['placeholder'] = '[{}]'.format(_('Selection contains various values'))
-            else:
-                self.fields[k].widget.attrs['placeholder'] = ''
             self.fields[k].one_required = False
 
         for k in ('geo_lat', 'geo_lon', 'comment'):
             # scalar fields
             if k in self.mixed_values:
                 self.fields[k].widget.attrs['placeholder'] = '[{}]'.format(_('Selection contains various values'))
-            else:
-                self.fields[k].widget.attrs['placeholder'] = ''
             self.fields[k].widget.is_required = False
             self.fields[k].required = False
 

--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -41,7 +41,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import EmailValidator
 from django.db.models.functions import Upper
 from django.urls import reverse
-from django.utils.translation import gettext_lazy as _, pgettext_lazy
+from django.utils.translation import gettext_lazy as _
 from django_scopes.forms import SafeModelChoiceField
 
 from pretix.base.email import get_available_placeholders

--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -115,7 +115,6 @@ class VoucherForm(I18nModelForm):
                         'event': instance.event.slug,
                         'organizer': instance.event.organizer.slug,
                     }),
-                    'data-placeholder': pgettext_lazy('subevent', 'Date')
                 }
             )
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices

--- a/src/pretix/control/templates/pretixcontrol/event/fragment_geodata.html
+++ b/src/pretix/control/templates/pretixcontrol/event/fragment_geodata.html
@@ -15,7 +15,7 @@
             <span class="optional">{% trans "Optional" %}</span>
         </label>
         <div class="col-md-4">
-            {% bootstrap_field form.geo_lat layout="inline" %}
+            {% bootstrap_field form.geo_lat layout="inline" placeholder=_("Latitude") %}
             {% if global_settings.opencagedata_apikey %}
                 <p class="attrib">
                     <a href="https://openstreetmap.org/" target="_blank">
@@ -25,7 +25,7 @@
             {% endif %}
         </div>
         <div class="col-md-4">
-            {% bootstrap_field form.geo_lon layout="inline" %}
+            {% bootstrap_field form.geo_lon layout="inline" placeholder=_("Longitude") %}
         </div>
         <div class="col-md-1">
         </div>

--- a/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/bulk.html
@@ -289,13 +289,13 @@
                                     {% bootstrap_field f.DELETE form_group_class="" layout="inline" %}
                                 </div>
                                 <div class="col-sm-4">
-                                    {% bootstrap_field f.time_from layout="inline" %}
+                                    {% bootstrap_field f.time_from layout="inline" placeholder=time_begin_sample %}
                                 </div>
                                 <div class="col-sm-4">
-                                    {% bootstrap_field f.time_to layout="inline" %}
+                                    {% bootstrap_field f.time_to layout="inline" placeholder=time_end_sample %}
                                 </div>
                                 <div class="col-sm-3">
-                                    {% bootstrap_field f.time_admission layout="inline" %}
+                                    {% bootstrap_field f.time_admission layout="inline" placeholder=time_admission_sample %}
                                 </div>
                                 <div class="col-sm-1 text-right flip">
                                     <button type="button" class="btn btn-danger btn-block"
@@ -315,13 +315,13 @@
                                     {% bootstrap_field time_formset.empty_form.DELETE form_group_class="" layout="inline" %}
                                 </div>
                                 <div class="col-sm-4">
-                                    {% bootstrap_field time_formset.empty_form.time_from layout="inline" %}
+                                    {% bootstrap_field time_formset.empty_form.time_from layout="inline" placeholder=time_begin_sample %}
                                 </div>
                                 <div class="col-sm-4">
-                                    {% bootstrap_field time_formset.empty_form.time_to layout="inline" %}
+                                    {% bootstrap_field time_formset.empty_form.time_to layout="inline" placeholder=time_end_sample %}
                                 </div>
                                 <div class="col-sm-3">
-                                    {% bootstrap_field time_formset.empty_form.time_admission layout="inline" %}
+                                    {% bootstrap_field time_formset.empty_form.time_admission layout="inline" placeholder=time_admission_sample %}
                                 </div>
                                 <div class="col-sm-1 text-right flip">
                                     <button type="button" class="btn btn-danger btn-block"
@@ -338,13 +338,13 @@
                             <label for="subevent_add_many_slots_first">
                                 <strong>{% trans "Start of first slot" %}</strong>
                             </label>
-                            <input class="form-control timepickerfield" id="subevent_add_many_slots_first" value="{{ time_begin_sample }}">
+                            <input class="form-control timepickerfield" id="subevent_add_many_slots_first" value="{{ time_begin_sample }}" placeholder="{{ time_begin_sample }}">
                         </div>
                         <div class="col-md-2 col-sm-12">
                             <label for="subevent_add_many_slots_end">
                                 <strong>{% trans "End of time slots" %}</strong>
                             </label>
-                            <input class="form-control timepickerfield" id="subevent_add_many_slots_end" value="{{ time_end_sample }}">
+                            <input class="form-control timepickerfield" id="subevent_add_many_slots_end" value="{{ time_end_sample }}" placeholder="{{ time_end_sample }}">
                         </div>
                         <div class="col-md-3 col-sm-12">
                             <label for="subevent_add_many_slots_length">
@@ -409,8 +409,8 @@
         </fieldset>
         <fieldset>
             <legend>{% trans "Timeline" %}</legend>
-            {% bootstrap_field form.rel_presale_start layout="control" %}
-            {% bootstrap_field form.rel_presale_end layout="control" %}
+            {% bootstrap_field form.rel_presale_start layout="control" placeholder=datetime_sample %}
+            {% bootstrap_field form.rel_presale_end layout="control" placeholder=datetime_sample %}
         </fieldset>
         <fieldset>
             <legend>{% trans "Quotas" %}</legend>

--- a/src/pretix/control/templates/pretixcontrol/subevents/bulk_edit.html
+++ b/src/pretix/control/templates/pretixcontrol/subevents/bulk_edit.html
@@ -51,7 +51,7 @@
                             <div class="field-content">
                                 <div class="row">
                                     <div class="col-md-6">
-                                        {% bootstrap_field form.geo_lat layout="inline" %}
+                                        {% bootstrap_field form.geo_lat layout="inline" placeholder=_("Latitude") %}
                                         {% if global_settings.opencagedata_apikey %}
                                             <p class="attrib">
                                                 <a href="https://openstreetmap.org/" target="_blank" tabindex="-1">
@@ -61,7 +61,7 @@
                                         {% endif %}
                                     </div>
                                     <div class="col-md-6">
-                                        {% bootstrap_field form.geo_lon layout="inline" %}
+                                        {% bootstrap_field form.geo_lon layout="inline" placeholder=_("Longitude") %}
                                     </div>
                                 </div>
                             </div>

--- a/src/pretix/control/views/subevents.py
+++ b/src/pretix/control/views/subevents.py
@@ -49,7 +49,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.formats import get_format
 from django.utils.functional import cached_property
-from django.utils.timezone import make_aware
+from django.utils.timezone import now, make_aware
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django.views import View
 from django.views.generic import CreateView, FormView, ListView, UpdateView
@@ -768,8 +768,15 @@ class SubEventBulkCreate(SubEventEditorMixin, EventPermissionRequiredMixin, Asyn
         ctx['time_formset'] = self.time_formset
 
         tf = get_format('TIME_INPUT_FORMATS')[0]
+        ctx['time_admission_sample'] = time(8, 30, 0).strftime(tf)
         ctx['time_begin_sample'] = time(9, 0, 0).strftime(tf)
         ctx['time_end_sample'] = time(18, 0, 0).strftime(tf)
+
+        df = get_format('DATETIME_INPUT_FORMATS')[0]
+        ctx['datetime_sample'] = now().replace(
+            year=2000, month=12, day=31, hour=18, minute=0, second=0, microsecond=0
+        ).strftime(df)
+
         return ctx
 
     @cached_property

--- a/src/pretix/control/views/subevents.py
+++ b/src/pretix/control/views/subevents.py
@@ -49,7 +49,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.formats import get_format
 from django.utils.functional import cached_property
-from django.utils.timezone import now, make_aware
+from django.utils.timezone import make_aware, now
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django.views import View
 from django.views.generic import CreateView, FormView, ListView, UpdateView

--- a/src/pretix/plugins/autocheckin/forms.py
+++ b/src/pretix/plugins/autocheckin/forms.py
@@ -176,7 +176,6 @@ class AutoCheckinRuleForm(forms.ModelForm):
                         "organizer": self.event.organizer.slug,
                     },
                 ),
-                "data-placeholder": _("Check-in list"),
             }
         )
         self.fields["list"].widget.choices = self.fields["list"].choices

--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/new_refund_control_form.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/new_refund_control_form.html
@@ -2,7 +2,7 @@
 {% load ibanformat %}
 {% load bootstrap3 %}
 
-{% bootstrap_field form.payer layout="inline" %}
-{% bootstrap_field form.iban layout="inline" %}
-{% bootstrap_field form.bic layout="inline" %}
+{% bootstrap_field form.payer layout="inline" placeholder=_("Account holder") %}
+{% bootstrap_field form.iban layout="inline" placeholder=_("IBAN") %}
+{% bootstrap_field form.bic layout="inline" placeholder=_("BIC (optional)") %}
 {% bootstrap_form_errors form error_types="all" %}

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -279,7 +279,6 @@ class OrderMailForm(BaseMailForm):
                         'event': event.slug,
                         'organizer': event.organizer.slug,
                     }),
-                    'data-placeholder': pgettext_lazy('subevent', 'Date')
                 }
             )
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices
@@ -360,7 +359,6 @@ class RuleForm(FormPlaceholderMixin, I18nModelForm):
                         'event': self.event.slug,
                         'organizer': self.event.organizer.slug,
                     }),
-                    'data-placeholder': pgettext_lazy('subevent', 'Date')
                 }
             )
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -711,6 +711,7 @@ BOOTSTRAP3 = {
         'bulkedit_inline': 'pretix.control.forms.renderers.InlineBulkEditFieldRenderer',
         'checkout': 'pretix.presale.forms.renderers.CheckoutFieldRenderer',
     },
+    'set_placeholder': False,
 }
 
 PASSWORD_HASHERS = [

--- a/src/pretix/static/pretixcontrol/scss/auth.scss
+++ b/src/pretix/static/pretixcontrol/scss/auth.scss
@@ -34,10 +34,6 @@ footer {
 	margin: auto;
 	padding-bottom: 0;
 
-	.control-label {
-		display: none;
-	}
-
 	.buttons {
 		text-align: right;
 	}


### PR DESCRIPTION
This PR removes the automatism to set the placeholder to the same value as label if not otherwise defined. This makes the forms IMHO way cleaner.

Before:
![Bildschirmfoto 2025-05-21 um 13 24 44](https://github.com/user-attachments/assets/6cf88f36-4b8e-47b8-a3c1-37108e7dfdc6)

After:
![Bildschirmfoto 2025-05-21 um 13 24 11](https://github.com/user-attachments/assets/98b92500-ab45-486c-8a74-db6129a06b54)
