### PR TITLE
Close dialog onclick on backdrop

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -390,6 +390,13 @@ $(function () {
         sessionStorage.removeItem('scrollpos');
     }
 
+    $("dialog").on("mousedown", function (e) {
+        if (e.target == this) {
+            // dialog has no padding, so this triggers only onclick on backdrop
+            this.close();
+        }
+    });
+
     $(".accordion-radio").click(function() {
         var $input = $("input", this);
         if (!$input.prop("checked")) $input.prop('checked', true).trigger("change");


### PR DESCRIPTION
TODO: Test how this interferes with cancel-suppressing the closing the dialog. Currently we do not suppress cancel, but would be good to know.