### PR TITLE
[A11y] fix contrast for default success color

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2783,7 +2783,7 @@ Your {organizer} team"""))  # noqa: W291
         ),
     },
     'theme_color_success': {
-        'default': '#50a167',
+        'default': '#408252',
         'type': str,
         'form_class': forms.CharField,
         'serializer_class': serializers.CharField,

--- a/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
+++ b/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
@@ -123,7 +123,7 @@ $label-danger-bg: var(--pretix-brand-danger);
 $label-danger-bg-hover: var(--pretix-brand-danger-darken-10);
 
 $alert-success-bg: var(--pretix-brand-success-tint-85);
-$alert-success-text: var(--pretix-brand-success-shade-42);
+$alert-success-text: var(--pretix-brand-success-shade-25);
 $alert-success-border: var(--pretix-brand-success);
 $alert-success-hr: var(--pretix-brand-success-darken-5);
 $alert-success-link: var(--pretix-brand-success-shade-42);

--- a/src/pretix/static/pretixbase/scss/_theme_variables.scss
+++ b/src/pretix/static/pretixbase/scss/_theme_variables.scss
@@ -16,7 +16,7 @@ $widget: false !default;
 // Input variables that may be overridden by event themes.
 $in-font-family-sans-serif: "Open Sans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $in-brand-primary: #7f5a91 !default;
-$in-brand-success: #50a167 !default;
+$in-brand-success: #408252 !default;
 $in-brand-info: #5f9cd4 !default;
 $in-brand-warning: #ffb419 !default;
 $in-brand-danger: #c44f4f !default;


### PR DESCRIPTION
This wasn’t/isn’t a problem as e.g. alert-success uses shaded colors with enough contrast. But in the event settings with the new contrast requirement of 4.5, it looks a bit odd that the default color produces a warning of to low contrast.