### PR TITLE
Checkout: Center-align step-done fa

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_checkout.scss
+++ b/src/pretix/static/pretixpresale/scss/_checkout.scss
@@ -62,6 +62,9 @@
     &.step-done .checkout-step-label a {
       color: $brand-primary;
     }
+    &.step-done a .fa:first-child {
+      margin-right: 0;
+    }
 
     &.step-current .checkout-step-icon {
       border: 1px solid $brand-primary;


### PR DESCRIPTION
counteract change introduced in b638c009523dc687e053fe0cca71e1657961f22b

Before:
![image](https://github.com/user-attachments/assets/85fe9f6c-a03f-452f-8eb7-b3317540a64f)

After:
![image](https://github.com/user-attachments/assets/18af9054-ebdb-43df-8736-5cdefd20a04a)
