### PR TITLE
[A11y] fix input border & focus style

### DIFF
--- a/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
+++ b/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
@@ -14,6 +14,7 @@ $input-color-placeholder: lighten(#000, 70%) !default;
 $border-radius-base: var(--pretix-border-radius-base);
 $border-radius-large: var(--pretix-border-radius-large);
 $border-radius-small: var(--pretix-border-radius-small);
+$input-border: #949494 !default;
 
 $navbar-inverse-bg: #3b1c4a !default;
 $navbar-inverse-link-color: white;
@@ -72,7 +73,7 @@ $panel-default-heading-bg: #e5e5e5 !default;
 
 $link-hover-color: var(--pretix-brand-primary-darken-15);
 
-$btn-default-border: #CCCCCC;
+$btn-default-border: #949494;;
 
 $btn-primary-border: var(--pretix-brand-primary-darken-5);
 $btn-primary-border-active: var(--pretix-brand-primary-darken-30);

--- a/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
+++ b/src/pretix/static/pretixbase/scss/_bootstrap_vars.scss
@@ -73,7 +73,7 @@ $panel-default-heading-bg: #e5e5e5 !default;
 
 $link-hover-color: var(--pretix-brand-primary-darken-15);
 
-$btn-default-border: #949494;;
+$btn-default-border: #949494;
 
 $btn-primary-border: var(--pretix-brand-primary-darken-5);
 $btn-primary-border-active: var(--pretix-brand-primary-darken-30);

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -1,6 +1,5 @@
 // before variables.scss because it only affects presale, not control
 $body-bg: #f5f5f5 !default;
-$input-border: #949494;
 
 $font-size-base: 0.875rem !default;/* 14px/16px = 0.875rem */
 

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -17,9 +17,9 @@
       text-decoration: $link-hover-decoration;
     }
     &:focus {
-      outline: thin dotted;
-      outline: 5px auto -webkit-focus-ring-color;
-      outline-offset: -2px;
+      outline: 2px solid $brand-primary;
+      outline-offset: 2px;
+      z-index: 999;
     }
   }
   img {
@@ -57,6 +57,9 @@
       &.focus {
         text-decoration: none;
         @include tab-focus;
+        outline: 2px solid $brand-primary;
+        outline-offset: 2px;
+        z-index: 999;
       }
     }
     &.disabled,
@@ -88,6 +91,11 @@
       background-color: #e6e6e6;
       border-color: #adadad;
     }
+    &:focus-within {
+      outline: 2px solid $brand-primary;
+      outline-offset: 2px;
+      z-index: 999;
+    }
   }
   .pretix-widget-icon-cart {
     display: inline-block;
@@ -114,9 +122,9 @@
     $color-rgba: rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
 
     &:focus {
-      border-color: $input-border-focus;
-      outline: 0;
-      @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px $color-rgba);
+      outline: 2px solid $brand-primary;
+      outline-offset: 2px;
+      z-index: 999;
     }
   }
   input[type=number] {
@@ -352,11 +360,14 @@
     font-size: 12px;
   }
 
-  .pretix-widget-item-picture {
+  .pretix-widget-item-picture-link {
     width: 60px;
     height: 60px;
     margin-right: 10px;
     float: left;
+  }
+  .pretix-widget-item-picture {
+    max-width: 100%;
   }
 
   .pretix-widget-action {


### PR DESCRIPTION
Changing the `$btn-default-border:` and `$input-border` in pretixbase instead of presale main.scss fixes contrast issues in all of pretix. This might be considered a breaking change with the widget – but we have already changed lots of colors in the past, which also came through to the widget. So I would say, it should be fine to keep using `$btn-default-border:` and `$input-border`, which then would tickle down into widget.v1.scss. Or should I hard-code the old values in widget.v1.scss?