### PR TITLE
Fix source order for cart-exists-message

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1035,11 +1035,10 @@ Vue.component('pretix-widget-event-form', {
         // Resume cart
         + '<div class="pretix-widget-info-message pretix-widget-clickable"'
         + '     v-if="$root.cart_exists">'
+        + '<span :id="id_cart_exists_msg">' + strings['cart_exists'] + '</span>'
         + '<button @click.prevent.stop="$parent.resume" class="pretix-widget-resume-button" type="button" v-bind:aria-describedby="id_cart_exists_msg">'
         + strings['resume_checkout']
         + '</button>'
-        + '<span :id="id_cart_exists_msg">' + strings['cart_exists'] + '</span>'
-        + '<div class="pretix-widget-clear"></div>'
         + '</div>'
 
         // Seating plan

--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -151,7 +151,6 @@
   border-radius: $input-border-radius;
 
   .pretix-widget-resume-button {
-    float: right;
     margin-left: 10px;
   }
 
@@ -160,6 +159,8 @@
   }
 
   .pretix-widget-info-message {
+    display: flex;
+    justify-content: space-between;
     padding: 10px;
     text-align: left;
     margin: 10px 0;


### PR DESCRIPTION
Seems redundant to me as the button is aria-describedby the cart-exists-message coming after it. But it came up in a11y-testing, so I take the chance and „fix“ it with v2.