### PR TITLE
Widget v2: Remove link from variation-product title

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -539,7 +539,7 @@ Vue.component('item', {
         + '<div class="pretix-widget-item-info-col">'
         + '<a :href="item.picture_fullsize" v-if="item.picture" class="pretix-widget-item-picture-link" @click.prevent.stop="lightbox"><img :src="item.picture" class="pretix-widget-item-picture" :alt="picture_alt_text"></a>'
         + '<div class="pretix-widget-item-title-and-description">'
-        + '<strong class="pretix-widget-item-title" :id="item_label_id" role="heading" v-bind:aria-level="headingLevel" @click="titleOnClick">{{ item.name }}</strong>'
+        + '<strong class="pretix-widget-item-title" :id="item_label_id" role="heading" v-bind:aria-level="headingLevel">{{ item.name }}</strong>'
         + '<div class="pretix-widget-item-description" :id="item_desc_id" v-if="item.description" v-html="item.description"></div>'
         + '<p class="pretix-widget-item-meta" v-if="item.order_min && item.order_min > 1">'
         + '<small>{{ min_order_str }}</small>'
@@ -620,13 +620,6 @@ Vue.component('item', {
                 description: this.item.name,
             }
         },
-        titleOnClick: function () {
-            // focus associated input and open variations, if any
-            this.$el.querySelector(".pretix-widget-item-availability-col input, .pretix-widget-item-availability-col .pretix-widget-collapse-indicator")?.focus();
-            if (this.item.has_variations) {
-                this.expanded = true;
-            }
-        }
     },
     computed: {
         classObject: function () {

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -539,12 +539,7 @@ Vue.component('item', {
         + '<div class="pretix-widget-item-info-col">'
         + '<a :href="item.picture_fullsize" v-if="item.picture" class="pretix-widget-item-picture-link" @click.prevent.stop="lightbox"><img :src="item.picture" class="pretix-widget-item-picture" :alt="picture_alt_text"></a>'
         + '<div class="pretix-widget-item-title-and-description">'
-        + '<a v-if="item.has_variations && show_toggle" :id="item_label_id" role="heading" v-bind:aria-level="headingLevel" class="pretix-widget-item-title" :href="\'#\' + item.id + \'-variants\'"'
-        + '   @click.prevent.stop="expand"'
-        + '>'
-        + '{{ item.name }}'
-        + '</a>'
-        + '<strong v-else class="pretix-widget-item-title" :id="item_label_id" role="heading" v-bind:aria-level="headingLevel">{{ item.name }}</strong>'
+        + '<strong class="pretix-widget-item-title" :id="item_label_id" role="heading" v-bind:aria-level="headingLevel" @click="titleOnClick">{{ item.name }}</strong>'
         + '<div class="pretix-widget-item-description" :id="item_desc_id" v-if="item.description" v-html="item.description"></div>'
         + '<p class="pretix-widget-item-meta" v-if="item.order_min && item.order_min > 1">'
         + '<small>{{ min_order_str }}</small>'
@@ -569,7 +564,7 @@ Vue.component('item', {
         // Availability
         + '<div class="pretix-widget-item-availability-col">'
         + '<button class="pretix-widget-collapse-indicator" v-if="show_toggle" @click.prevent.stop="expand"'
-        + '   v-bind:aria-expanded="expanded ? \'true\': \'false\'" v-bind:aria-controls="item.id + \'-variants\'">{{ variationsToggleLabel }}</button>'
+        + '   v-bind:aria-expanded="expanded ? \'true\': \'false\'" v-bind:aria-controls="item.id + \'-variants\'" v-bind:aria-describedby="item_desc_id">{{ variationsToggleLabel }}</button>'
         + '<availbox v-if="!item.has_variations" :item="item"></availbox>'
         + '</div>'
 
@@ -624,6 +619,9 @@ Vue.component('item', {
                 image: this.item.picture_fullsize,
                 description: this.item.name,
             }
+        },
+        titleOnClick: function () {
+            this.$el.querySelector(".pretix-widget-item-availability-col input, .pretix-widget-item-availability-col .pretix-widget-collapse-indicator")?.focus();
         }
     },
     computed: {

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -621,7 +621,11 @@ Vue.component('item', {
             }
         },
         titleOnClick: function () {
+            // focus associated input and open variations, if any
             this.$el.querySelector(".pretix-widget-item-availability-col input, .pretix-widget-item-availability-col .pretix-widget-collapse-indicator")?.focus();
+            if (this.item.has_variations) {
+                this.expanded = true;
+            }
         }
     },
     computed: {


### PR DESCRIPTION
This PR removes the link (and underline) from variation products to unify the look in product lists and not be forced to have links styled as links. Add a helper-script to make item-titles behave like label for inputs, that focus their inputs onclick.

To mimick current behaviour, clicking the variation-title not only focuses the variation button, but also opens the variations.