### PR TITLE
Fix info-row img not being scaled correctly

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_event_info.html
@@ -4,7 +4,7 @@
 {% if ev.location and show_location %}
     <div class="info-row">
         <div class="info-row-icon" role="img" aria-label="{% trans "Where does the event happen?" %}">
-            {% icon "map-marker fa-fw" %}
+            {% icon "map-marker" %}
         </div>
         <p>
             {{ ev.location|linebreaksbr }}
@@ -14,7 +14,7 @@
 {% if ev.settings.show_dates_on_frontpage %}
     <div class="info-row">
         <div class="info-row-icon" role="img" aria-label="{% trans "When does the event happen?" %}">
-            {% icon "clock-o fa-fw" %}
+            {% icon "clock-o" %}
         </div>
         <p>
             {{ ev.get_date_range_display_as_html }}

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -298,16 +298,18 @@ a:hover .panel-primary > .panel-heading {
     .info-row-icon,
     & > img {
         position: absolute;
-        top: -5px;
-        left: 0;
+        top: -6px;
+        left: 3px;
         font-size: 26px;
+        text-align: center;
         color: $brand-primary;
         margin-top: 3px;
         width: 26px;
         height: auto;
-        .fa {
-            vertical-align: top;
-        }
+    }
+    .info-row-icon .fa {
+        vertical-align: top;
+        width: auto;
     }
     p {
         margin-left: 40px;


### PR DESCRIPTION
There might be plugins using .info-row with an image where the image was not scaled correctly due to a missing CSS selector. This PR fixes the css-selector so that e.g. kulturpass-info is correctly shown.