### PR TITLE
[A11y] add group labelling to single input name-widget

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -184,8 +184,7 @@ class NamePartsWidget(forms.MultiWidget):
                     these_attrs.pop('data-no-required-attr', None)
                 these_attrs['autocomplete'] = (self.attrs.get('autocomplete', '') + ' ' + self.autofill_map.get(self.scheme['fields'][i][0], 'off')).strip()
                 these_attrs['data-size'] = self.scheme['fields'][i][2]
-                if len(self.widgets) > 1:
-                    these_attrs['aria-label'] = self.scheme['fields'][i][1]
+                these_attrs['aria-label'] = self.scheme['fields'][i][1]
             else:
                 these_attrs = final_attrs
             output.append(widget.render(name + '_%s' % i, widget_value, these_attrs, renderer=renderer))

--- a/src/pretix/presale/forms/renderers.py
+++ b/src/pretix/presale/forms/renderers.py
@@ -79,7 +79,7 @@ class CheckoutFieldRenderer(FieldRenderer):
     def __init__(self, *args, **kwargs):
         kwargs['layout'] = 'horizontal'
         super().__init__(*args, **kwargs)
-        self.is_group_widget = isinstance(self.widget, (CheckboxSelectMultiple, RadioSelect, )) or (self.is_multi_widget and len(self.widget.widgets) > 1)
+        self.is_group_widget = isinstance(self.widget, (CheckboxSelectMultiple, RadioSelect, )) or self.is_multi_widget
 
     def get_form_group_class(self):
         form_group_class = self.form_group_class


### PR DESCRIPTION
Ideally single-input name-schemes should have a properly marked up `<label for="…">`, but due to input-ids being only available on render, we cannot easily create the correct HTML-label. This PR changes the behaviour so that for single input name-schemes we still create a fieldset (ie. role=group) with a proper legend and aria-label for the single input. Not perfect, but at least accessible and better than before (inaccessible).