### PR TITLE
[A11y] change organizer page-titles based calendar-view

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -4,7 +4,11 @@
 {% load rich_text %}
 {% load eventurl %}
 {% load urlreplace %}
-{% block title %}{% trans "Event overview by month" %}{% endblock %}
+{% block title %}
+    {% blocktrans trimmed with month=date|date:"F Y" %}
+        Events in {{ month }}
+    {% endblocktrans %}
+{% endblock %}
 {% block content %}
     {% if organizer_homepage_text %}
         <div class="blank-after">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -4,7 +4,11 @@
 {% load rich_text %}
 {% load eventurl %}
 {% load urlreplace %}
-{% block title %}{% trans "Event overview by day" %}{% endblock %}
+{% block title %}
+    {% blocktrans trimmed with day=date|date:"DATE_FORMAT" %}
+        Events on {{ day }}
+    {% endblocktrans %}
+{% endblock %}
 {% block content %}
     {% if organizer_homepage_text %}
         <div class="blank-after">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -4,7 +4,11 @@
 {% load rich_text %}
 {% load eventurl %}
 {% load urlreplace %}
-{% block title %}{% trans "Event overview by week" %}{% endblock %}
+{% block title %}
+    {% blocktrans trimmed with week=date|date:week_format week_day_from=date|date:short_month_day_format week_day_to=date_to|date:short_month_day_format %}
+        Events in {{ week }} ({{ week_day_from }} – {{ week_day_to }})
+    {% endblocktrans %}
+{% endblock %}
 {% block content %}
     {% if organizer_homepage_text %}
         <div class="blank-after">
@@ -18,7 +22,7 @@
         <div class="panel-heading">
             <h2 class="panel-title">
                 <strong>
-                {% blocktrans trimmed with week=date|date:week_format week_day_from=date|date:short_month_day_format week_day_to=date|date:short_month_day_format %}
+                {% blocktrans trimmed with week=date|date:week_format week_day_from=date|date:short_month_day_format week_day_to=date_to|date:short_month_day_format %}
                     Events in {{ week }} ({{ week_day_from }} – {{ week_day_to }})
                 {% endblocktrans %}
                 </strong>

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -811,6 +811,7 @@ class WeekCalendarView(OrganizerViewMixin, EventListMixin, TemplateView):
         ) + timedelta(days=1)
 
         ctx['date'] = week.monday()
+        ctx['date_to'] = week.sunday()
         ctx['before'] = before
         ctx['after'] = after
 


### PR DESCRIPTION
The page-titles need to be different which helps AT users detect a change on the page.