### PR TITLE
[A11y] fix color contrast on hover for .active default-buttons

### DIFF
--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -170,6 +170,10 @@ input:focus, .form-control:focus {
 .btn-checkbox input:focus, .input-item-count-group input:focus, .input-group-price input:focus {
     outline: none;
 }
+/* bootstrap sets dark background for active elements with hover/focus, we need to match specifity of selector */
+.btn-default:active:hover, .btn-default:active:focus, .btn-default:active.focus, .btn-default.active:hover, .btn-default.active:focus, .btn-default.active.focus, .open > .btn-default.dropdown-toggle:hover, .open > .btn-default.dropdown-toggle:focus, .open > .btn-default.dropdown-toggle.focus {
+    background-color: inherit;
+}
 /* border-radius on these containers is needed for correctly rounded focus-outlines */
 .input-item-count-group, .input-group-price {
     border-radius: var(--pretix-border-radius-base);


### PR DESCRIPTION
The calendar-view navigation uses .active for showing the current link. When hovering this link, the default styling makes the background way to dark due to $border-hover being darker to meet other contrast requirements.

![Bildschirmfoto 2025-06-02 um 13 31 30](https://github.com/user-attachments/assets/54dac74b-3f23-478d-a065-9c1d33e435c4)

Focus/hover before:
![Bildschirmfoto 2025-06-02 um 13 31 56](https://github.com/user-attachments/assets/333fb93e-036d-4308-934e-5f010c5ccaa5)

Focus/hover after:
![Bildschirmfoto 2025-06-02 um 13 31 38](https://github.com/user-attachments/assets/c5c82697-5841-4d52-8373-ebaf84570864)
