### PR TITLE
[A11y] improve questions step

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
@@ -80,9 +80,7 @@
                     <div>
                         <div class="panel-body questions-form">
                             {% if event.settings.attendee_data_explanation_text and pos.item.ask_attendee_data %}
-                                <div>
-                                    {{ event.settings.attendee_data_explanation_text|rich_text }}
-                                </div>
+                                {{ event.settings.attendee_data_explanation_text|rich_text }}
                             {% endif %}
                             {% if forloop.counter > 1 and event.settings.checkout_show_copy_answers_button %}
                                 <div class="form-group">


### PR DESCRIPTION
This PR improves:

- removes the copy-answers button from the interactive summary-element (one cannot nest interactive elements) and puts it inside the panel-body
- adds a fieldset for already existing legend-elements for addons-questions groups
- indents explanation texts to match the indent of all other elements in the panel

![Bildschirmfoto 2025-06-02 um 19 25 09](https://github.com/user-attachments/assets/d315a190-d1b3-4898-af72-60275ffd03db)
