### PR TITLE
[A11y] add inline alertidalog to confirm successful cart renewal

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -513,10 +513,12 @@
         </form>
         <dialog role="alertdialog" id="cart-extend-feedback-dialog" aria-labelledby="cart-extend-feedback">
             <form method="dialog">
-                <span id="cart-extend-feedback" class="text-muted"></span>
-                <button class="btn btn-default" autofocus value="OK">
-                    {% icon "check" %} {% trans "OK" %}
-                </button>
+                <p>
+                    <span id="cart-extend-feedback" class="text-muted sr-only"></span>
+                    <button class="btn btn-default" autofocus value="OK">
+                        {% icon "check" %} {% trans "Reservation renewed" %}
+                    </button>
+                </p>
             </form>
         </dialog>
     {% else %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -507,7 +507,7 @@
             </p>
             <p>
                 <button class="btn btn-default" type="submit" id="cart-extend-button" aria-describedby="cart-deadline">
-                    <i class="fa fa-refresh" aria-hidden="true"></i> {% trans "Renew reservation" %}
+                    {% icon "refresh" %} {% trans "Renew reservation" %}
                 </button>
             </p>
         </form>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -516,7 +516,10 @@
                 <p>
                     <span id="cart-extend-feedback" class="text-muted sr-only"></span>
                     <button class="btn btn-default" autofocus value="OK">
-                        {% icon "check" %} {% trans "Reservation renewed" %}
+                        <span role="img" aria-label="{% trans "OK" %}">
+                            {% icon "check" %}
+                        </span>
+                        {% trans "Reservation renewed" %}
                     </button>
                 </p>
             </form>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -511,10 +511,9 @@
                 </button>
             </p>
         </form>
-        <dialog role="alertdialog" id="cart-extend-feedback-dialog" class="inline-dialog" aria-labelledby="cart-extend-feedback cart-deadline">
+        <dialog role="alertdialog" id="cart-extend-feedback-dialog" class="inline-dialog" aria-labelledby="cart-deadline">
             <form method="dialog">
                 <p>
-                    <span id="cart-extend-feedback" class="text-muted sr-only"></span>
                     <button class="btn btn-default" autofocus value="OK">
                         <span role="img" aria-label="{% trans "OK" %}">
                             {% icon "check" %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -511,7 +511,7 @@
                 </button>
             </p>
         </form>
-        <dialog role="alertdialog" id="cart-extend-feedback-dialog" aria-labelledby="cart-extend-feedback">
+        <dialog role="alertdialog" id="cart-extend-feedback-dialog" class="inline-dialog" aria-labelledby="cart-extend-feedback">
             <form method="dialog">
                 <p>
                     <span id="cart-extend-feedback" class="text-muted sr-only"></span>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load icon %}
 {% load eventurl %}
 {% load daterange %}
 {% load safelink %}
@@ -510,6 +511,14 @@
                 </button>
             </p>
         </form>
+        <dialog role="alertdialog" id="cart-extend-feedback-dialog" aria-labelledby="cart-extend-feedback">
+            <form method="dialog">
+                <span id="cart-extend-feedback" class="text-muted"></span>
+                <button class="btn btn-default" autofocus value="OK">
+                    {% icon "check" %} {% trans "OK" %}
+                </button>
+            </form>
+        </dialog>
     {% else %}
         <p class="sr-only" id="cart-description">{% trans "Overview of your ordered products." %}</p>
     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -511,7 +511,7 @@
                 </button>
             </p>
         </form>
-        <dialog role="alertdialog" id="cart-extend-feedback-dialog" class="inline-dialog" aria-labelledby="cart-extend-feedback">
+        <dialog role="alertdialog" id="cart-extend-feedback-dialog" class="inline-dialog" aria-labelledby="cart-extend-feedback cart-deadline">
             <form method="dialog">
                 <p>
                     <span id="cart-extend-feedback" class="text-muted sr-only"></span>

--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -11,11 +11,18 @@ setup_collapsible_details = function (el) {
             content.classList.remove('sneak-peek-content');
             return;
         }
+        function openSneekPeakOnSubmit() {
+            $(button).trigger("click");
+        }
+        var $buttons = $("button:enabled", content).prop("disabled", true);
+        var $forms = $("form", content).on("submit", openSneekPeakOnSubmit);
         content.setAttribute('aria-hidden', 'true');
         button.setAttribute('aria-expanded', 'false');
         button.addEventListener('click', function (e) {
             button.setAttribute('aria-expanded', 'true');
             content.setAttribute('aria-hidden', 'false');
+            $buttons.prop("disabled", false);
+            $forms.off("submit", openSneekPeakOnSubmit);
 
             content.addEventListener('transitionend', function() {
                 content.classList.remove('sneak-peek-content');
@@ -29,8 +36,14 @@ setup_collapsible_details = function (el) {
                 // this will be called by screenreader users if they kept focus on the button after expanding
                 // we need to keep the trigger/button in the DOM to not irritate screenreaders toggling visibility
                 var expanded = button.getAttribute('aria-expanded') == 'true';
-                button.setAttribute('aria-expanded', !expanded);
-                content.setAttribute('aria-hidden', expanded);
+                button.setAttribute('aria-expanded', !expanded ? 'true' : 'false');
+                content.setAttribute('aria-hidden', expanded ? 'true' : 'false');
+                $buttons.prop("disabled", expanded);
+                if (expanded) {
+                    $forms.on("submit", openSneekPeakOnSubmit);
+                } else {
+                    $forms.off("submit", openSneekPeakOnSubmit);
+                }
             });
             button.addEventListener('blur', function (e) {
                 // if content is visible and the user leaves the button, we can safely remove the trigger/button
@@ -48,6 +61,8 @@ setup_collapsible_details = function (el) {
                     trigger.remove();
                     content.removeAttribute('aria-hidden');
                     content.classList.remove('sneak-peek-content');
+                    $buttons.prop("disabled", false);
+                    $forms.off("submit", openSneekPeakOnSubmit);
                 }
             }
             container.addEventListener("toggle", removeSneekPeakWhenClosed);

--- a/src/pretix/static/pretixbase/scss/_dialogs.scss
+++ b/src/pretix/static/pretixbase/scss/_dialogs.scss
@@ -1,3 +1,10 @@
+dialog.inline-dialog {
+  position: static;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
 /* Modal dialogs using HTML5 dialog tags for accessibility */
 dialog.modal-card {
   border: none;

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -107,6 +107,7 @@ var cart = {
             $("#cart-deadline").attr("data-max-expiry-extend")
         );
         $("#cart-extend-feedback-dialog").on("close", function () {
+            if (this.returnValue) { // OK-Button has been pressed, nothing else has received focus
                 var cart_panel_heading = $(this).closest(".panel").find(".panel-heading").get(0);
                 if (cart_panel_heading) {
                     window.setTimeout(function () {
@@ -117,6 +118,7 @@ var cart = {
         }).find("button").on("blur", function() {
             var dialog = this.closest("dialog");
             if (dialog.open) {
+                dialog.close();
             }
         });
     },

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -59,7 +59,6 @@ var cart = {
                     $("#cart-deadline").text(gettext("Your cart is about to expire."))
                 } else {
                     $("#cart-deadline").text(
-                        cart._renewed_message + " " +
                         ngettext(
                             "The items in your cart are reserved for you for one minute.",
                             "The items in your cart are reserved for you for {num} minutes.",
@@ -67,6 +66,12 @@ var cart = {
                         ).replace(/\{num\}/g, diff_minutes)
                     );
                 }
+                $("#cart-extend-feedback").text(cart._renewed_message);
+                var dialog = $("#cart-extend-feedback-dialog").get(0);
+                if (cart._renewed_message) {
+                    dialog.show();
+                }
+
                 cart._prev_diff_minutes = diff_minutes;
             }
 
@@ -101,6 +106,19 @@ var cart = {
             $("#cart-deadline").attr("data-expires"),
             $("#cart-deadline").attr("data-max-expiry-extend")
         );
+        $("#cart-extend-feedback-dialog").on("close", function () {
+                var cart_panel_heading = $(this).closest(".panel").find(".panel-heading").get(0);
+                if (cart_panel_heading) {
+                    window.setTimeout(function () {
+                        cart_panel_heading.focus();
+                    }, 50);
+                }
+            }
+        }).find("button").on("blur", function() {
+            var dialog = this.closest("dialog");
+            if (dialog.open) {
+            }
+        });
     },
 
     set_deadline: function (expiry, max_extend, renewed_message) {
@@ -127,10 +145,6 @@ $(function () {
     $("#cart-extend-form").on("pretix:async-task-success", function(e, data) {
         if (data.success) {
             cart.set_deadline(data.expiry, data.max_expiry_extend, data.message);
-            var cart_panel_heading = $(this).closest(".panel").find(".panel-heading").get(0);
-            if (cart_panel_heading) {
-                cart_panel_heading.focus();
-            }
         } else {
             alert(data.message);
         }

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -137,6 +137,7 @@ $(function () {
     });
 
     $("#dialog-cart-extend form").submit(function() {
+        $("#cart-extend-form").closest("details:not([open])").find("summary").trigger("click");
         $("#cart-extend-form").submit();
     });
 

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -5,7 +5,6 @@ var cart = {
     _deadline_call: 0,
     _time_offset: 0,
     _prev_diff_minutes: 0,
-    _renewed_message: "",
 
     _get_now: function () {
         return moment().add(cart._time_offset, 'ms');
@@ -66,11 +65,6 @@ var cart = {
                         ).replace(/\{num\}/g, diff_minutes)
                     );
                 }
-                $("#cart-extend-feedback").text(cart._renewed_message);
-                var dialog = $("#cart-extend-feedback-dialog").get(0);
-                if (cart._renewed_message) {
-                    dialog.show();
-                }
 
                 cart._prev_diff_minutes = diff_minutes;
             }
@@ -106,15 +100,9 @@ var cart = {
             $("#cart-deadline").attr("data-expires"),
             $("#cart-deadline").attr("data-max-expiry-extend")
         );
-        $("#cart-extend-feedback-dialog").on("keydown", function (e) {
-            // prevent enter or space-bar from bubbling up and closing the cart-panel
-            e.stopPropagation();
-        }).find("button").on("blur", function() {
-            this.closest("dialog").close();
-        });
     },
 
-    set_deadline: function (expiry, max_extend, renewed_message) {
+    set_deadline: function (expiry, max_extend) {
         "use strict";
         cart._expiry_notified = false;
         cart._deadline = moment(expiry);
@@ -123,7 +111,6 @@ var cart = {
         }
         cart._deadline_timeout = null;
         cart._max_extend = moment(max_extend);
-        cart._renewed_message = renewed_message || "";
         cart.draw_deadline();
     }
 };
@@ -135,9 +122,17 @@ $(function () {
         cart.init();
     }
 
+    $("#cart-extend-feedback-dialog").on("keydown", function (e) {
+        // prevent enter or space-bar from bubbling up and closing the cart-panel
+        e.stopPropagation();
+    }).find("button").on("blur", function() {
+        this.closest("dialog").close();
+    });
+
     $("#cart-extend-form").on("pretix:async-task-success", function(e, data) {
         if (data.success) {
-            cart.set_deadline(data.expiry, data.max_expiry_extend, data.message);
+            cart.set_deadline(data.expiry, data.max_expiry_extend);
+            $("#cart-extend-feedback-dialog").get(0).show();
         } else {
             alert(data.message);
         }

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -106,20 +106,11 @@ var cart = {
             $("#cart-deadline").attr("data-expires"),
             $("#cart-deadline").attr("data-max-expiry-extend")
         );
-        $("#cart-extend-feedback-dialog").on("close", function () {
-            if (this.returnValue) { // OK-Button has been pressed, nothing else has received focus
-                var cart_panel_heading = $(this).closest(".panel").find(".panel-heading").get(0);
-                if (cart_panel_heading) {
-                    window.setTimeout(function () {
-                        cart_panel_heading.focus();
-                    }, 50);
-                }
-            }
+        $("#cart-extend-feedback-dialog").on("keydown", function (e) {
+            // prevent enter or space-bar from bubbling up and closing the cart-panel
+            e.stopPropagation();
         }).find("button").on("blur", function() {
-            var dialog = this.closest("dialog");
-            if (dialog.open) {
-                dialog.close();
-            }
+            this.closest("dialog").close();
         });
     },
 

--- a/src/pretix/static/pretixpresale/js/ui/cart.js
+++ b/src/pretix/static/pretixpresale/js/ui/cart.js
@@ -65,7 +65,6 @@ var cart = {
                         ).replace(/\{num\}/g, diff_minutes)
                     );
                 }
-
                 cart._prev_diff_minutes = diff_minutes;
             }
 
@@ -73,7 +72,6 @@ var cart = {
                 pad(diff_minutes.toString(), 2) + ':' + pad(diff_seconds.toString(), 2)
             );
 
-            cart._renewed_message = "";
             cart._deadline_timeout = window.setTimeout(cart.draw_deadline, 500);
         }
         var already_expired = diff_total_seconds <= 0;

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -254,12 +254,6 @@
 #cart-deadline-short {
     font-variant-numeric: tabular-nums;
 }
-#cart-extend-feedback-dialog {
-    position: static;
-    padding: 0;
-    margin: 0;
-    border: none;
-}
 .btn-invisible {
     opacity: 0 !important;
 }

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -254,6 +254,12 @@
 #cart-deadline-short {
     font-variant-numeric: tabular-nums;
 }
+#cart-extend-feedback-dialog {
+    position: static;
+    padding: 0;
+    margin: 0;
+    border: none;
+}
 .btn-invisible {
     opacity: 0 !important;
 }


### PR DESCRIPTION
When the cart reservation is renewed, we need to give feedback. This was originally done through a `role=alert` on `#cart-deadline`, but that did not work as intended – when the „renew reservation“-button was removed, focus moved to the focusable parent element and its aria-label and -description was read out. The confirmation message – although being `role=alert` was not read aloud. So then we added the renewal-confirmation message to the aria-describedby on the parent element, that received focus, when the „renew reservation“-button was removed. In my tests with VoiceOver on Safari, the message was read as the description, but after the label „Your cart“ – according to external a11y-tests this was not sufficient.

This PR adds an inline alertdialog with a confirmation button „reservation renewed“. That dialog/button gets focus on successfully renewing the reservation. Once it is confirmed (clicked) or loses focus, the dialog is closed.