### PR TITLE
Fix sneak-peek missing inert-attribute

### DIFF
--- a/src/pretix/static/pretixbase/js/details.js
+++ b/src/pretix/static/pretixbase/js/details.js
@@ -12,10 +12,12 @@ setup_collapsible_details = function (el) {
             return;
         }
         content.setAttribute('aria-hidden', 'true');
+        content.setAttribute('inert', true);
         button.setAttribute('aria-expanded', 'false');
         button.addEventListener('click', function (e) {
             button.setAttribute('aria-expanded', 'true');
             content.setAttribute('aria-hidden', 'false');
+            content.removeAttribute('inert');
 
             content.addEventListener('transitionend', function() {
                 content.classList.remove('sneak-peek-content');
@@ -47,6 +49,7 @@ setup_collapsible_details = function (el) {
                     container.removeEventListener("toggle", removeSneekPeakWhenClosed);
                     trigger.remove();
                     content.removeAttribute('aria-hidden');
+                    content.removeAttribute('inert');
                     content.classList.remove('sneak-peek-content');
                 }
             }


### PR DESCRIPTION
Since adding the renew-button to the sneak-peek we had an interactive element inside an aria-hidden element. This is not allowed, so this PR adds the inert-attribute to the container, so the button is not focusable any more.