### PR TITLE
[A11y] Widget: pass doc title in overlay to iframe.title

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/iframe.js
+++ b/src/pretix/static/pretixpresale/js/ui/iframe.js
@@ -7,4 +7,12 @@ var inIframe = function () {
 };
 if (inIframe()) {
     document.documentElement.classList.add('in-iframe');
+    try {
+        window.parent.postMessage({
+            type: "pretix:widget:title",
+            title: document.title,
+        }, "*");
+    } catch (e) {
+        console.error("Could not post message to parent.", e);
+    }
 }

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -931,7 +931,18 @@ Vue.component('pretix-overlay', {
             }  
         },
     },
+    mounted () {
+        window.addEventListener('message', this.onMessage, false);
+    },
+    unmounted () {
+        window.removeEventListener('message', this.onMessage, false);
+    },
     methods: {
+        onMessage: function(e) {
+            if (e.data.type && e.data.type == "pretix:widget:title") {
+                this.$el.querySelector("iframe").title = e.data.title;
+            }
+        },
         lightboxClose: function () {
             this.$root.lightbox = null;
         },


### PR DESCRIPTION
According to external A11y-testing the title of the iframe needs to update with the content for it to be meaningful enough. This PR adds a postMessage-mechanism if the presale-page is inside an iframe. Note though, that the label of the dialog stays the same „Checkout“.

This PR adds a very specifc event. We as well think about using a different name (pretix:widget:page) and e.g. add more info such as what type of page (shop, checkout – maybe even with steps –  and order-confirm) – this would give embedding pages the option to redirect to their own confirmation page, if they wish so.