### PR TITLE
Show event title consistently

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2951,7 +2951,7 @@ Your {organizer} team"""))  # noqa: W291
         'serializer_class': serializers.BooleanField,
         'form_kwargs': dict(
             label=_('Show event title even if a header image is present'),
-            help_text=_('The title will only be shown on the event front page. If no header image is uploaded for the event, but the header image '
+            help_text=_('If no header image is uploaded for the event, but the header image '
                         'from the organizer profile is used, this option will be ignored and the event title will always be shown.'),
         )
     },

--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -123,6 +123,15 @@
         {% endif %}
         <div class="clearfix"></div>
     </div>
+        {% if event_logo and event_logo_show_title %}
+            <h2 class="content-header">
+                {{ event.name }}
+                {% if request.event.settings.show_dates_on_frontpage %}
+                    <small>{{ event.get_date_range_display_as_html }}</small>
+                {% endif %}
+            </h2>
+            <hr>
+        {% endif %}
     {% if request.event.testmode %}
         {% if request.sales_channel.type_instance.testmode_supported %}
             <div class="alert alert-warning">
@@ -168,9 +177,8 @@
                 </strong></p>
             </div>
         {% endif %}
-
-
     {% endif %}
+
     {% if messages %}
         {% for message in messages %}
             <div class="alert {{ message.tags }}"{% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %} id="error-message"{% endif %}>

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -54,11 +54,6 @@
 
     {% if request.event.has_subevents %}
         {% if not subevent %}
-            {% if event_logo and event_logo_show_title %}
-                <h2 class="content-header">
-                    {{ event.name }}
-                </h2>
-            {% endif %}
             {% if frontpage_text %}
                 <div>
                     {{ frontpage_text|rich_text }}
@@ -131,14 +126,6 @@
             {% endif %}
         {% endif %}
     {% else %}
-        {% if event_logo and event_logo_show_title %}
-            <h2 class="content-header">
-                {{ event.name }}
-                {% if request.event.settings.show_dates_on_frontpage %}
-                    <small>{{ event.get_date_range_display_as_html }}</small>
-                {% endif %}
-            </h2>
-        {% endif %}
         {% if frontpage_text %}
             <div>
                 {{ frontpage_text|rich_text }}


### PR DESCRIPTION
If the event has a logo, but the event title is configured to be visible anyway, it should be visible on all presale pages instead of on the front page only.

TODO:
- [ ] improve design on non-frontpage (make subtitles smaller? and/or make the event title look more like part of a separate header area?)
- [ ] link event title on non-frontpage
- [ ] should we keep the existing style on frontpage? (no line below title)
