### PR TITLE
[A11y] Widget: make inputs min-height instead of fixed height

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -113,7 +113,7 @@
     line-height: normal;
     border: 1px solid $input-border;
     border-radius: $input-border-radius;
-    height: $input-height-base;
+    min-height: $input-height-base;
     padding: $padding-base-vertical $padding-base-horizontal;
     color: $input-color;
     background-color: $input-bg;


### PR DESCRIPTION
When changing the default fontsize in the browser, the fixed height for inputs breaks. This is a somewhat backwards-breaking change in CSS, but IMHO not really a reason for a v3-release.