### PR TITLE
[A11y] Widget: change calendar table aria-label to labelledby

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -1563,14 +1563,14 @@ Vue.component('pretix-widget-event-calendar', {
         + '<a class="pretix-widget-event-calendar-previous-month" href="#" @click.prevent.stop="prevmonth">&laquo; '
         + strings['previous_month']
         + '</a> '
-        + '<strong>{{ monthname }}</strong> '
+        + '<strong :id="aria_labelledby">{{ monthname }}</strong> '
         + '<a class="pretix-widget-event-calendar-next-month" href="#" @click.prevent.stop="nextmonth">'
         + strings['next_month']
         + ' &raquo;</a>'
         + '</div>'
 
         // Calendar
-        + '<table class="pretix-widget-event-calendar-table" :id="id" tabindex="0" v-bind:aria-label="monthname">'
+        + '<table class="pretix-widget-event-calendar-table" :id="id" tabindex="0" v-bind:aria-labelledby="aria_labelledby">'
         + '<thead>'
         + '<tr>'
         + '<th aria-label="' + strings['days']['MONDAY'] + '">' + strings['days']['MO'] + '</th>'
@@ -1596,6 +1596,9 @@ Vue.component('pretix-widget-event-calendar', {
         },
         id: function () {
             return this.$root.html_id + "-event-calendar-table";
+        },
+        aria_labelledby: function () {
+            return this.$root.html_id + "-event-calendar-table-label";
         },
     },
     methods: {


### PR DESCRIPTION
Suggestion from external a11y-test to use the visual available description, that is the same as the previous aria-label