### PR TITLE
Show warning on incompatible waiting list options

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -247,6 +247,17 @@
                 {% bootstrap_field sform.show_variations_expanded layout="control" %}
                 {% bootstrap_field sform.hide_sold_out layout="control" %}
 
+                <div data-display-dependency="#id_settings-waiting_list_enabled">
+                    <div data-display-dependency="#id_settings-hide_sold_out">
+                        <div class="alert alert-danger dynamic">
+                            <h4>{% trans "Incompatible settings" %}</h4>
+                            {% blocktrans trimmed %}
+                                Customers won't be able to add themselves to the waiting list, because "Hide all products that are sold out" is enabled.
+                            {% endblocktrans %}
+                        </div>
+                    </div>
+                </div>
+
                 <h4>{% trans "Calendar and list views" context "subevents" %}</h4>
                 {% if sform.frontpage_subevent_ordering %}
                     {% bootstrap_field sform.frontpage_subevent_ordering layout="control" %}
@@ -372,6 +383,16 @@
                     </strong>
                 </div>
                 {% bootstrap_field sform.waiting_list_enabled layout="control" %}
+                <div data-display-dependency="#id_settings-hide_sold_out">
+                    <div data-display-dependency="#id_settings-waiting_list_enabled">
+                        <div class="alert alert-danger dynamic">
+                            <h4>{% trans "Incompatible settings" %}</h4>
+                            {% blocktrans trimmed %}
+                                Customers won't be able to add themselves to the waiting list, because "Hide all products that are sold out" is enabled.
+                            {% endblocktrans %}
+                        </div>
+                    </div>
+                </div>
                 {% bootstrap_field sform.waiting_list_auto layout="control" %}
                 <div class="form-group">
                     <label class="control-label col-md-3">

--- a/src/pretix/static/pretixcontrol/js/ui/tabs.js
+++ b/src/pretix/static/pretixcontrol/js/ui/tabs.js
@@ -20,7 +20,7 @@ $(function () {
                 .attr("href", "#" + tid)
                 .text($fieldset.find("legend").text())
                 .appendTo($tabli);
-            if ($fieldset.find(".has-error, .alert-danger").length > 0) {
+            if ($fieldset.find(".has-error, .alert-danger:not(.dynamic)").length > 0) {
                 $tablink.append(" ");
                 $tablink.append($("<span>").addClass("fa fa-warning text-danger"));
                 if (preselect === null) {


### PR DESCRIPTION
If "Hide all products that are sold out" is enabled, the waiting list won't work.

Resolves issue #5188