### PR TITLE
[A11y] Widget: move dialog-focus to close-button (Z#23196339)

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -903,6 +903,14 @@ Vue.component('pretix-overlay', {
                 }
             }
         },
+        '$root.frame_shown': function (newValue) {
+            if (newValue) {
+                var btn = this.$el?.querySelector('.pretix-widget-frame-close button');
+                this.$nextTick(function() {
+                    btn.focus();
+                });
+            }
+        },
     },
     computed: {
         frameClasses: function () {


### PR DESCRIPTION
Instead of moving focus to the dialog, move it to the close-button once the checkout has been loaded, so we avoid the big focus-outline.