### PR TITLE
Widget: fix loading spinner not showing on API-request

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -2182,7 +2182,6 @@ var create_overlay = function (app) {
                 // show loading spinner only when previously no frame_src was set
                 if (newValue && !oldValue) {
                     this.frame_loading = true;
-                    this.$el?.querySelector('dialog.pretix-widget-frame-holder').showModal();
                 }
                 // to close and unload the iframe, frame_src can be empty -> make it valid HTML with about:blank
                 this.$el.querySelector("iframe").src = newValue || "about:blank";

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -2187,6 +2187,18 @@ var create_overlay = function (app) {
                 // to close and unload the iframe, frame_src can be empty -> make it valid HTML with about:blank
                 this.$el.querySelector("iframe").src = newValue || "about:blank";
             },
+            frame_loading: function (newValue) {
+                var dialog = this.$el?.querySelector('dialog.pretix-widget-frame-holder');
+                if (newValue) {
+                    if (!dialog.open) {
+                        dialog.showModal();
+                    }
+                } else {
+                    if (!this.frame_src) {// finished loading, but no iframe to display => close
+                        dialog.close();
+                    }
+                }
+            },
         }
     });
     app.$root.overlay = framechild;

--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -2193,7 +2193,7 @@ var create_overlay = function (app) {
                         dialog.showModal();
                     }
                 } else {
-                    if (!this.frame_src) {// finished loading, but no iframe to display => close
+                    if (!this.frame_src && dialog.open) {// finished loading, but no iframe to display => close
                         dialog.close();
                     }
                 }


### PR DESCRIPTION
showDialog of iframe-dialog (with loading spinner) only reacted on frame_src instead of frame_loading – which did not trigger the loading-spinner while API-request to add to cart was running.