### PR TITLE
Add data-article-id to reference cart-item in product-list

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -25,7 +25,7 @@
     </div>
     <div role="rowgroup" class="firstchild-in-panel">
     {% for line in cart.positions %}
-        <div role="row" class="row cart-row {% if hide_prices %}hide-prices{% endif %} {% if download %}has-downloads{% endif %}{% if editable %}editable{% endif %}">
+        <div role="row" class="row cart-row {% if hide_prices %}hide-prices{% endif %} {% if download %}has-downloads{% endif %}{% if editable %}editable{% endif %}" data-article-id="item-{{ line.item.id }}{% if line.variation %}-{{ line.variation.id }}{% endif %}">
             <div role="cell" class="product">
                 <p>
                 {% if line.addon_to %}


### PR DESCRIPTION
This is a helper-id on the cart-row object to enable tracking of cart-interactions. Previously only add-operations were possible to track as remove-operations only had the op.id instead of the op.item.id