### PR TITLE
Presale: remove webmanifest

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -37,7 +37,6 @@
         <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
         <link rel="apple-touch-icon" sizes="180x180" href="{% static "pretixbase/img/icons/apple-touch-icon.png" %}">
     {% endif %}
-    <link rel="manifest" href="{% url "presale:site.webmanifest" %}">
     <meta name="msapplication-TileColor" content="{{ settings.primary_color|default:"#3b1c4a" }}">
     <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">
     <meta name="theme-color" content="{{ settings.primary_color|default:"#3b1c4a" }}">


### PR DESCRIPTION
Mobile Chrome opens an installation prompt for presale pages, probably due to the webmanifest. As presale is not really a webapp, remove webmanifest for presale completely.