### PR TITLE
 Widget: Make table stripe colors background-agnostic 

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -3,6 +3,9 @@
 @import "../../bootstrap/scss/bootstrap/variables";
 @import "../../bootstrap/scss/bootstrap/mixins";
 
+// Equivalent of our usual #f9f9f9, but in a way that works on other background colors
+$table-bg-accent: rgba(128, 128, 128, 0.05);
+
 .pretix-widget-hidden {
   display: none;
 }


### PR DESCRIPTION
The v2 widget breaks the calendars property to "look decent on dark backgrounds by default". This PR fixes that by at least no longer making it look unreadable, even if it makes the stripes barely visible on black.

Before:

![Screenshot 2025-06-27 at 14-50-51 ](https://github.com/user-attachments/assets/657567b0-4fb3-4de3-9c9b-cbee50bac2f2)

After:

![Screenshot 2025-06-27 at 14-54-59 ](https://github.com/user-attachments/assets/75ab75d8-f2e7-46e7-a9dd-bd71087e7cff)
