### PR TITLE
Remove browserconfig.xml

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/auth/base.html
+++ b/src/pretix/control/templates/pretixcontrol/auth/base.html
@@ -22,8 +22,6 @@
     <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
     <link rel="manifest" href="{% url "site.webmanifest" %}">
     <link rel="mask-icon" href="{% static "pretixbase/img/icons/safari-pinned-tab.svg" %}" color="#3b1c4a">
-    <meta name="msapplication-TileColor" content="#3b1c4a">
-    <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">
     <meta name="theme-color" content="#3b1c4a">
 </head>
 <body>

--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -81,8 +81,6 @@
         <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
         <link rel="manifest" href="{% url "site.webmanifest" %}">
         <link rel="mask-icon" href="{% static "pretixbase/img/icons/safari-pinned-tab.svg" %}" color="#3b1c4a">
-        <meta name="msapplication-TileColor" content="#3b1c4a">
-        <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">
         <meta name="theme-color" content="#3b1c4a">
         <meta name="referrer" content="origin">
 

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -37,8 +37,6 @@
         <link rel="icon" type="image/png" sizes="192x192" href="{% static "pretixbase/img/icons/android-chrome-192x192.png" %}">
         <link rel="apple-touch-icon" sizes="180x180" href="{% static "pretixbase/img/icons/apple-touch-icon.png" %}">
     {% endif %}
-    <meta name="msapplication-TileColor" content="{{ settings.primary_color|default:"#3b1c4a" }}">
-    <meta name="msapplication-config" content="{% url "presale:browserconfig.xml" %}">
     <meta name="theme-color" content="{{ settings.primary_color|default:"#3b1c4a" }}">
 </head>
 <body class="nojs" data-locale="{{ request.LANGUAGE_CODE }}" data-now="{% now "U.u" %}" data-datetimeformat="{{ js_datetime_format }}" data-timeformat="{{ js_time_format }}" data-dateformat="{{ js_date_format }}" data-datetimelocale="{{ js_locale }}" data-currency="{{ request.event.currency }}">

--- a/src/pretix/presale/urls.py
+++ b/src/pretix/presale/urls.py
@@ -235,6 +235,5 @@ organizer_patterns = [
 locale_patterns = [
     re_path(r'^locale/set$', pretix.presale.views.locale.LocaleSet.as_view(), name='locale.set'),
     re_path(r'^robots.txt$', pretix.presale.views.robots.robots_txt, name='robots.txt'),
-    re_path(r'^browserconfig.xml$', pretix.presale.views.theme.browserconfig_xml, name='browserconfig.xml'),
     path('widget/v<int:version>.<slug:lang>.js', pretix.presale.views.widget.widget_js, name='widget.js'),
 ]

--- a/src/pretix/presale/views/theme.py
+++ b/src/pretix/presale/views/theme.py
@@ -24,9 +24,7 @@ import time
 
 from django.contrib.staticfiles import finders
 from django.http import HttpResponse
-from django.templatetags.static import static
 from django.utils.http import http_date
-from django.views.decorators.cache import cache_page
 from django.views.decorators.gzip import gzip_page
 from django.views.decorators.http import condition
 
@@ -42,25 +40,6 @@ def _get_source_cache_key():
         with open(finders.find("pretixbase/scss/_theme_variables.scss"), "r") as f:
             _source_cache_key = hashlib.sha256(f.read().encode()).hexdigest()[:12]
     return _source_cache_key
-
-
-@cache_page(3600)
-def browserconfig_xml(request):
-    return HttpResponse(
-        """<?xml version="1.0" encoding="utf-8"?>
-<browserconfig>
-    <msapplication>
-        <tile>
-            <square150x150logo src="{}"/>
-            <square310x310logo src="{}"/>
-            <TileColor>#3b1c4a</TileColor>
-        </tile>
-    </msapplication>
-</browserconfig>""".format(
-            static('pretixbase/img/icons/mstile-150x150.png'),
-            static('pretixbase/img/icons/mstile-310x310.png'),
-        ), content_type='text/xml'
-    )
 
 
 @gzip_page


### PR DESCRIPTION
Window 10 still uses browserconfig.xml for pinned Websites on the start-screen. Windows 10 EOL is mid October 2025. We might consider, removing all meta-tags from HTML, but keep the URL-route still available for now.