### PR TITLE
Orders API: Add check_quotas to orders/change and PATCH/POST orderpositions query params

### DIFF
--- a/doc/api/resources/orders.rst
+++ b/doc/api/resources/orders.rst
@@ -1926,6 +1926,7 @@ Manipulating individual positions
 
       (Full order position resource, see above.)
 
+   :query boolean check_quotas: Whether to check quotas before committing item changes, default is ``true``
    :param organizer: The ``slug`` field of the organizer of the event
    :param event: The ``slug`` field of the event
    :param id: The ``id`` field of the order position to update
@@ -2005,6 +2006,7 @@ Manipulating individual positions
 
       (Full order position resource, see above.)
 
+   :query boolean check_quotas: Whether to check quotas before creating the new position, default is ``true``
    :param organizer: The ``slug`` field of the organizer of the event
    :param event: The ``slug`` field of the event
 
@@ -2291,6 +2293,7 @@ otherwise, such as splitting an order or changing fees.
 
       (Full order position resource, see above.)
 
+   :query boolean check_quotas: Whether to check quotas before patching or creating positions, default is ``true``
    :param organizer: The ``slug`` field of the organizer of the event
    :param event: The ``slug`` field of the event
    :param code: The ``code`` field of the order to update

--- a/src/pretix/api/serializers/orderchange.py
+++ b/src/pretix/api/serializers/orderchange.py
@@ -83,7 +83,7 @@ class OrderPositionCreateForExistingOrderSerializer(OrderPositionCreateSerialize
 
     def create(self, validated_data):
         ocm = self.context['ocm']
-        check_quotas = self.context['check_quotas'] if 'check_quotas' in self.context else True
+        check_quotas = self.context.get('check_quotas', True)
 
         try:
             ocm.add_position(
@@ -311,7 +311,7 @@ class OrderPositionChangeSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         ocm = self.context['ocm']
-        check_quotas = self.context['check_quotas'] if 'check_quotas' in self.context else True
+        check_quotas = self.context.get('check_quotas', True)
         current_seat = {'seat_guid': instance.seat.seat_guid} if instance.seat else None
         item = validated_data.get('item', instance.item)
         variation = validated_data.get('variation', instance.variation)

--- a/src/pretix/api/serializers/orderchange.py
+++ b/src/pretix/api/serializers/orderchange.py
@@ -83,6 +83,7 @@ class OrderPositionCreateForExistingOrderSerializer(OrderPositionCreateSerialize
 
     def create(self, validated_data):
         ocm = self.context['ocm']
+        check_quotas = self.context['check_quotas'] if 'check_quotas' in self.context else True
 
         try:
             ocm.add_position(
@@ -96,7 +97,7 @@ class OrderPositionCreateForExistingOrderSerializer(OrderPositionCreateSerialize
                 valid_until=validated_data.get('valid_until'),
             )
             if self.context.get('commit', True):
-                ocm.commit()
+                ocm.commit(check_quotas=check_quotas)
                 return validated_data['order'].positions.order_by('-positionid').first()
             else:
                 return OrderPosition()  # fake to appease DRF
@@ -310,6 +311,7 @@ class OrderPositionChangeSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         ocm = self.context['ocm']
+        check_quotas = self.context['check_quotas'] if 'check_quotas' in self.context else True
         current_seat = {'seat_guid': instance.seat.seat_guid} if instance.seat else None
         item = validated_data.get('item', instance.item)
         variation = validated_data.get('variation', instance.variation)
@@ -356,7 +358,7 @@ class OrderPositionChangeSerializer(serializers.ModelSerializer):
                 ocm.change_ticket_secret(instance, secret)
 
             if self.context.get('commit', True):
-                ocm.commit()
+                ocm.commit(check_quotas=check_quotas)
                 instance.refresh_from_db()
         except OrderError as e:
             raise ValidationError(str(e))

--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -943,6 +943,7 @@ class EventOrderViewSet(OrderViewSetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=['POST'])
     def change(self, request, **kwargs):
         order = self.get_object()
+        check_quotas = self.request.query_params.get('check_quotas', 'true') == 'true'
 
         serializer = OrderChangeOperationSerializer(
             context={'order': order, **self.get_serializer_context()},
@@ -1008,7 +1009,7 @@ class EventOrderViewSet(OrderViewSetMixin, viewsets.ModelViewSet):
             elif serializer.validated_data.get('recalculate_taxes') == 'keep_gross':
                 ocm.recalculate_taxes(keep='gross')
 
-            ocm.commit()
+            ocm.commit(check_quotas=check_quotas)
         except OrderError as e:
             raise ValidationError(str(e))
 
@@ -1087,6 +1088,7 @@ class OrderPositionViewSet(viewsets.ModelViewSet):
         ctx = super().get_serializer_context()
         ctx['event'] = self.request.event
         ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false') == 'true'
+        ctx['check_quotas'] = self.request.query_params.get('check_quotas', 'true') == 'true'
         return ctx
 
     def get_queryset(self):

--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -1088,7 +1088,7 @@ class OrderPositionViewSet(viewsets.ModelViewSet):
         ctx = super().get_serializer_context()
         ctx['event'] = self.request.event
         ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false') == 'true'
-        ctx['check_quotas'] = self.request.query_params.get('check_quotas', 'true') == 'true'
+        ctx['check_quotas'] = self.request.query_params.get('check_quotas', 'true').lower() == 'true'
         return ctx
 
     def get_queryset(self):

--- a/src/tests/api/test_order_change.py
+++ b/src/tests/api/test_order_change.py
@@ -1202,7 +1202,8 @@ def test_position_update_change_item_no_quota(token_client, organizer, event, or
     )
     assert resp.status_code == 400
     assert 'quota' in str(resp.data)
-    
+
+
 @pytest.mark.django_db
 def test_position_update_change_item_no_quota_check_quota_false(token_client, organizer, event, order):
     with scopes_disabled():
@@ -1220,7 +1221,8 @@ def test_position_update_change_item_no_quota_check_quota_false(token_client, or
     assert resp.status_code == 200
     op.refresh_from_db()
     assert op.item == item2
-    
+
+
 @pytest.mark.django_db
 def test_position_update_change_item_no_quota_check_quota_true(token_client, organizer, event, order):
     with scopes_disabled():
@@ -1351,7 +1353,8 @@ def test_position_update_change_subevent_quota_empty(token_client, organizer, ev
     )
     assert resp.status_code == 400
     assert 'quota' in str(resp.data)
-    
+
+
 @pytest.mark.django_db
 def test_position_update_change_subevent_quota_empty_check_quota_false(token_client, organizer, event, order, quota, item, subevent):
     with scopes_disabled():
@@ -1654,7 +1657,8 @@ def test_position_add_quota_empty(token_client, organizer, event, order, quota, 
     )
     assert resp.status_code == 400
     assert 'quota' in str(resp.data)
-    
+
+
 @pytest.mark.django_db
 def test_position_add_quota_empty_check_quota_false(token_client, organizer, event, order, quota, item):
     with scopes_disabled():
@@ -1880,7 +1884,8 @@ def test_order_change_patch(token_client, organizer, event, order, quota):
         assert f.value == Decimal('10.00')
         order.refresh_from_db()
         assert order.total == Decimal('109.44')
-        
+
+
 @pytest.mark.django_db
 def test_order_change_patch_no_quota(token_client, organizer, event, order, quota):
     with scopes_disabled():
@@ -1904,6 +1909,7 @@ def test_order_change_patch_no_quota(token_client, organizer, event, order, quot
     )
     assert resp.status_code == 400
     assert 'quota' in str(resp.data)
+
 
 @pytest.mark.django_db
 def test_order_change_patch_no_quota_check_quota_false(token_client, organizer, event, order, quota):
@@ -1931,7 +1937,8 @@ def test_order_change_patch_no_quota_check_quota_false(token_client, organizer, 
         p.refresh_from_db()
         assert p.price == Decimal('99.44')
         assert p.item == item2
-        
+
+
 @pytest.mark.django_db
 def test_order_change_cancel_and_create(token_client, organizer, event, order, quota, item):
     with scopes_disabled():

--- a/src/tests/api/test_order_change.py
+++ b/src/tests/api/test_order_change.py
@@ -1205,9 +1205,51 @@ def test_position_update_change_item_no_quota(token_client, organizer, event, or
 
 
 @pytest.mark.django_db
+def test_position_update_change_item_empty_quota(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
+        op = order.positions.first()
+    payload = {
+        'item': item2.pk,
+    }
+    assert op.item != item2
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/orderpositions/{}/'.format(
+            organizer.slug, event.slug, op.pk
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
 def test_position_update_change_item_no_quota_check_quota_false(token_client, organizer, event, order):
     with scopes_disabled():
         item2 = event.items.create(name="Budget Ticket", default_price=23)
+        op = order.positions.first()
+    payload = {
+        'item': item2.pk,
+    }
+    assert op.item != item2
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/orderpositions/{}/?check_quotas=false'.format(
+            organizer.slug, event.slug, op.pk
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_position_update_change_item_empty_quota_check_quota_false(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
         op = order.positions.first()
     payload = {
         'item': item2.pk,
@@ -1227,6 +1269,27 @@ def test_position_update_change_item_no_quota_check_quota_false(token_client, or
 def test_position_update_change_item_no_quota_check_quota_true(token_client, organizer, event, order):
     with scopes_disabled():
         item2 = event.items.create(name="Budget Ticket", default_price=23)
+        op = order.positions.first()
+    payload = {
+        'item': item2.pk,
+    }
+    assert op.item != item2
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/orderpositions/{}/?check_quotas=true'.format(
+            organizer.slug, event.slug, op.pk
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_position_update_change_item_empty_quota_check_quota_true(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
         op = order.positions.first()
     payload = {
         'item': item2.pk,
@@ -1375,6 +1438,27 @@ def test_position_update_change_subevent_quota_empty_check_quota_false(token_cli
     assert resp.status_code == 200
     op.refresh_from_db()
     assert op.subevent == se2
+
+
+@pytest.mark.django_db
+def test_position_update_change_subevent_quota_empty_check_quota_true(token_client, organizer, event, order, quota, item, subevent):
+    with scopes_disabled():
+        se2 = event.subevents.create(name="Foobar", date_from=datetime.datetime(2017, 12, 27, 10, 0, 0, tzinfo=datetime.timezone.utc))
+        q2 = se2.quotas.create(name="foo", size=0, event=event)
+        q2.items.add(item)
+        op = order.positions.first()
+        op.subevent = subevent
+        op.save()
+    payload = {
+        'subevent': se2.pk,
+    }
+    resp = token_client.patch(
+        '/api/v1/organizers/{}/events/{}/orderpositions/{}/?check_quotas=true'.format(
+            organizer.slug, event.slug, op.pk
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
 
 
 @pytest.mark.django_db
@@ -1660,6 +1744,42 @@ def test_position_add_quota_empty(token_client, organizer, event, order, quota, 
 
 
 @pytest.mark.django_db
+def test_position_add_no_quota(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        assert order.positions.count() == 1
+    payload = {
+        'order': order.code,
+        'item': item2.pk,
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orderpositions/'.format(
+            organizer.slug, event.slug,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_position_add_no_quota_check_quota_false(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        assert order.positions.count() == 1
+    payload = {
+        'order': order.code,
+        'item': item2.pk,
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orderpositions/?check_quotas=false'.format(
+            organizer.slug, event.slug,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
 def test_position_add_quota_empty_check_quota_false(token_client, organizer, event, order, quota, item):
     with scopes_disabled():
         assert order.positions.count() == 1
@@ -1681,6 +1801,25 @@ def test_position_add_quota_empty_check_quota_false(token_client, organizer, eve
         assert op.item == item
         assert op.price == item.default_price
         assert op.positionid == 3
+
+
+@pytest.mark.django_db
+def test_position_add_quota_empty_check_quota_true(token_client, organizer, event, order, quota, item):
+    with scopes_disabled():
+        assert order.positions.count() == 1
+        quota.size = 1
+        quota.save()
+    payload = {
+        'order': order.code,
+        'item': item.pk,
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orderpositions/?check_quotas=true'.format(
+            organizer.slug, event.slug,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
 
 
 @pytest.mark.django_db
@@ -1887,7 +2026,7 @@ def test_order_change_patch(token_client, organizer, event, order, quota):
 
 
 @pytest.mark.django_db
-def test_order_change_patch_no_quota(token_client, organizer, event, order, quota):
+def test_order_change_patch_no_quota(token_client, organizer, event, order):
     with scopes_disabled():
         item2 = event.items.create(name="Budget Ticket", default_price=23)
         p = order.positions.first()
@@ -1912,9 +2051,65 @@ def test_order_change_patch_no_quota(token_client, organizer, event, order, quot
 
 
 @pytest.mark.django_db
-def test_order_change_patch_no_quota_check_quota_false(token_client, organizer, event, order, quota):
+def test_order_change_patch_no_quota_check_quota_false(token_client, organizer, event, order):
     with scopes_disabled():
         item2 = event.items.create(name="Budget Ticket", default_price=23)
+        p = order.positions.first()
+    payload = {
+        'patch_positions': [
+            {
+                'position': p.pk,
+                'body': {
+                    'item': item2.pk,
+                    'price': '99.44',
+                },
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/?check_quotas=false'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_order_change_patch_quota_empty(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
+        p = order.positions.first()
+    payload = {
+        'patch_positions': [
+            {
+                'position': p.pk,
+                'body': {
+                    'item': item2.pk,
+                    'price': '99.44',
+                },
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_order_change_patch_quota_empty_check_quota_false(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
         p = order.positions.first()
     payload = {
         'patch_positions': [
@@ -1937,6 +2132,174 @@ def test_order_change_patch_no_quota_check_quota_false(token_client, organizer, 
         p.refresh_from_db()
         assert p.price == Decimal('99.44')
         assert p.item == item2
+
+
+@pytest.mark.django_db
+def test_order_change_patch_quota_empty_check_quota_true(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
+        p = order.positions.first()
+    payload = {
+        'patch_positions': [
+            {
+                'position': p.pk,
+                'body': {
+                    'item': item2.pk,
+                    'price': '99.44',
+                },
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/?check_quotas=true'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_order_change_create_position(token_client, organizer, event, order, quota, item):
+    with scopes_disabled():
+        assert order.positions.count() == 1
+    payload = {
+        'create_positions': [
+            {
+                'item': item.pk,
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 200
+    with scopes_disabled():
+        assert order.positions.count() == 2
+        op = order.positions.last()
+        assert op.item == item
+        assert op.price == item.default_price
+        assert op.positionid == 3
+
+
+@pytest.mark.django_db
+def test_order_change_create_position_no_quota(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+    payload = {
+        'create_positions': [
+            {
+                'item': item2.pk,
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_order_change_create_position_no_quota_check_quota_false(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+    payload = {
+        'create_positions': [
+            {
+                'item': item2.pk,
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/?check_quotas=false'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_order_change_create_position_quota_empty(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
+    payload = {
+        'create_positions': [
+            {
+                'item': item2.pk,
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
+
+
+@pytest.mark.django_db
+def test_order_change_create_position_quota_empty_check_quota_false(token_client, organizer, event, order):
+    with scopes_disabled():
+        assert order.positions.count() == 1
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
+    payload = {
+        'create_positions': [
+            {
+                'item': item2.pk,
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/?check_quotas=false'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 200
+    with scopes_disabled():
+        assert order.positions.count() == 2
+        op = order.positions.last()
+        assert op.item == item2
+        assert op.price == item2.default_price
+        assert op.positionid == 3
+
+
+@pytest.mark.django_db
+def test_order_change_create_position_quota_empty_check_quota_true(token_client, organizer, event, order):
+    with scopes_disabled():
+        item2 = event.items.create(name="Budget Ticket", default_price=23)
+        q = event.quotas.create(name="No Quota", size=0)
+        q.items.add(item2)
+        q.save()
+    payload = {
+        'create_positions': [
+            {
+                'item': item2.pk,
+            },
+        ]
+    }
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/change/?check_quotas=true'.format(
+            organizer.slug, event.slug, order.code,
+        ), format='json', data=payload
+    )
+    assert resp.status_code == 400
+    assert 'quota' in str(resp.data)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
While there's an option to ignore quota when adding/updating orderpositions from the /control/ pages in the UI, there is not via the REST API. This commit adds a `check_quota` boolean query parameter on the following endpoints:
- PATCH `/orderpositions/{id}/`
- POST `/orderpositions/`
- POST `/orders/{orderCode}/change/` (both on `patch_positions` and `create_positions`)

For the first two endpoints, with this PR we now add the `check_quota` variable to the context of the `OrderPositionViewSet` (in `get_serializer_context()`) which is later used inside the `OrderPositionChangeSerializer` and the `OrderPositionCreateForExistingOrderSerializer` by passing that value to the `OrderChangeManager.commit()` method.  
For the last one it's instead trivially used at the end of the `EventOrderViewSet.change()` method, again by passing it to the `commit()` call.  
I hope I got the implementation right! :D

I have also updated the docs and added some unit tests. I don't have a lot of experience with django, so I'm not sure I've used the `with scopes_disabled():` directive correctly in the unit tests I have written. I kindly ask to review them :)