### PR TITLE
API/Organizer: Allow Device-Token access to Organizer settings; expose mf0aes_random_uid

### DIFF
--- a/src/pretix/api/serializers/organizer.py
+++ b/src/pretix/api/serializers/organizer.py
@@ -484,6 +484,7 @@ class OrganizerSettingsSerializer(SettingsSerializer):
         'reusable_media_type_nfc_mf0aes',
         'reusable_media_type_nfc_mf0aes_autocreate_giftcard',
         'reusable_media_type_nfc_mf0aes_autocreate_giftcard_currency',
+        'reusable_media_type_nfc_mf0aes_random_uid',
     ]
 
     def __init__(self, *args, **kwargs):

--- a/src/pretix/api/views/organizer.py
+++ b/src/pretix/api/views/organizer.py
@@ -546,7 +546,8 @@ class DeviceViewSet(mixins.CreateModelMixin,
 
 
 class OrganizerSettingsView(views.APIView):
-    permission = 'can_change_organizer_settings'
+    permission = None
+    write_permission = 'can_change_organizer_settings'
 
     def get(self, request, *args, **kwargs):
         s = OrganizerSettingsSerializer(instance=request.organizer.settings, organizer=request.organizer, context={

--- a/src/tests/api/test_permissions.py
+++ b/src/tests/api/test_permissions.py
@@ -205,7 +205,6 @@ event_permission_sub_urls = [
 
 org_permission_sub_urls = [
     ('patch', 'can_change_organizer_settings', '', 200),
-    ('get', 'can_change_organizer_settings', 'settings/', 200),
     ('patch', 'can_change_organizer_settings', 'settings/', 200),
     ('get', 'can_change_organizer_settings', 'webhooks/', 200),
     ('post', 'can_change_organizer_settings', 'webhooks/', 400),


### PR DESCRIPTION
:exclamation: Check for security implications of this change

As of right now, none of our apps would be using this endpoint - but I feel like exposing it to the unrestricted SecurityProfile shouldn't do any harm.