### PR TITLE
Order change: Add setting for preventing users from removing positions

### DIFF
--- a/src/pretix/api/serializers/event.py
+++ b/src/pretix/api/serializers/event.py
@@ -848,6 +848,7 @@ class EventSettingsSerializer(SettingsSerializer):
         'cancel_terms_paid',
         'cancel_terms_unpaid',
         'change_allow_user_variation',
+        'change_allow_user_remove_positions',
         'change_allow_user_addons',
         'change_allow_user_until',
         'change_allow_user_price',

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1783,6 +1783,15 @@ DEFAULTS = {
             label=_("Customers can change their selected add-on products"),
         )
     },
+    'change_allow_user_remove_positions': {
+        'default': 'False',
+        'type': bool,
+        'form_class': forms.BooleanField,
+        'serializer_class': serializers.BooleanField,
+        'form_kwargs': dict(
+            label=_("Customers can remove positions from their order"),
+        )
+    },
     'change_allow_user_price': {
         'default': 'gte',
         'type': str,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -758,6 +758,7 @@ class CancelSettingsForm(SettingsForm):
         'change_allow_user_price',
         'change_allow_user_until',
         'change_allow_user_addons',
+        'change_allow_user_remove_positions',
         'change_allow_user_if_checked_in',
         'change_allow_attendee',
         'tax_rule_cancellation',

--- a/src/pretix/control/templates/pretixcontrol/event/cancel.html
+++ b/src/pretix/control/templates/pretixcontrol/event/cancel.html
@@ -68,6 +68,7 @@
                 </div>
                 {% bootstrap_field form.change_allow_user_variation layout="control" %}
                 {% bootstrap_field form.change_allow_user_addons layout="control" %}
+                {% bootstrap_field form.change_allow_user_remove_positions layout="control" %}
                 {% bootstrap_field form.change_allow_user_until layout="control" %}
                 {% bootstrap_field form.change_allow_user_price layout="control" %}
                 {% bootstrap_field form.change_allow_user_if_checked_in layout="control" %}

--- a/src/tests/presale/test_order_change.py
+++ b/src/tests/presale/test_order_change.py
@@ -373,7 +373,6 @@ class OrderChangeVariationTest(BaseOrdersTest):
         assert response.status_code == 200
         response = self.client.post(
             '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret), {
-                f'op-{self.ticket_pos.pk}-itemvar': f'{self.ticket.pk}',
             }, follow=True)
         assert response.status_code == 200
         assert 'alert-danger' in response.content.decode()
@@ -1038,7 +1037,6 @@ class OrderChangeAddonsTest(BaseOrdersTest):
         response = self.client.get(
             '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret),
             {
-                f'op-{self.ticket_pos.pk}-itemvar': f'{self.ticket.pk}',
             },
         )
         assert response.status_code == 200
@@ -1072,7 +1070,6 @@ class OrderChangeAddonsTest(BaseOrdersTest):
         response = self.client.get(
             '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret),
             {
-                f'op-{self.ticket_pos.pk}-itemvar': f'{self.ticket.pk}',
                 f'cp_{self.ticket_pos.pk}_item_{self.workshop1.pk}': '1'
             },
         )

--- a/src/tests/presale/test_order_change.py
+++ b/src/tests/presale/test_order_change.py
@@ -365,8 +365,11 @@ class OrderChangeVariationTest(BaseOrdersTest):
                 order=self.order,
                 item=self.shirt,
                 variation=self.shirt_blue,
+                addon_to=self.ticket_pos,
                 price=Decimal("12"),
             )
+            self.order.total += Decimal("12")
+            self.order.save()
         response = self.client.get(
             '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret)
         )
@@ -1035,6 +1038,15 @@ class OrderChangeAddonsTest(BaseOrdersTest):
             self.order.save()
 
         response = self.client.get(
+            '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret)
+        )
+        assert response.status_code == 200
+        assert 'Workshop 1' in response.content.decode()
+
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        assert doc.select(f'input[name=cp_{self.ticket_pos.pk}_item_{self.workshop1.pk}]')[0].attrs['checked']
+
+        response = self.client.post(
             '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret),
             {
             },
@@ -1068,6 +1080,12 @@ class OrderChangeAddonsTest(BaseOrdersTest):
             self.order.save()
 
         response = self.client.get(
+            '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret)
+        )
+        assert response.status_code == 200
+        assert 'Workshop 1' in response.content.decode()
+
+        response = self.client.post(
             '/%s/%s/order/%s/%s/change' % (self.orga.slug, self.event.slug, self.order.code, self.order.secret),
             {
                 f'cp_{self.ticket_pos.pk}_item_{self.workshop1.pk}': '1'

--- a/src/tests/presale/test_order_change.py
+++ b/src/tests/presale/test_order_change.py
@@ -1017,12 +1017,12 @@ class OrderChangeAddonsTest(BaseOrdersTest):
             assert a.canceled
             self.order.refresh_from_db()
             assert self.order.total == Decimal('23.00')
-            
+
     def test_remove_addon_disabled(self):
         self.event.settings.change_allow_user_remove_positions = False
         self.event.settings.change_allow_user_variation = True
         self.event.settings.change_allow_user_price = 'any'
-        
+
         with scopes_disabled():
             OrderPosition.objects.create(
                 order=self.order,
@@ -1043,12 +1043,12 @@ class OrderChangeAddonsTest(BaseOrdersTest):
         )
         assert response.status_code == 200
         assert 'alert-danger' in response.content.decode()
-        
+
     def test_remove_addon_disabled_multiple(self):
         self.event.settings.change_allow_user_remove_positions = False
         self.event.settings.change_allow_user_variation = True
         self.event.settings.change_allow_user_price = 'any'
-        
+
         with scopes_disabled():
             OrderPosition.objects.create(
                 order=self.order,


### PR DESCRIPTION
This PR adds a new option in the _Event > Settings > Cancellation > Order Changes_ to specifically disable users from removing positions from their order. This includes both item with variations and add-ons. I haven't found an existing setting to prevent this beside the price contraints which were flawed in some cases:

Let's say we have two addons for preordering items before an event: A shirt $S$ which costs 20€ and a mug $M$ which instead costs 5€ and it's personalized with the name of the owner of an order. Let's also define the price $p$ of the order, a user $u$ and an organization $o$. If:
- $u$ places an order with $M$ as an addon ($p'$ = $p$ + 5)
- $o$ physically buys a mug which should be given to $u$ at event time. The mug has $u$ name on it
- Now $u$ removes $M$ from its order but at the same time adds $S$ ($p''$ = $p'$ - 5 + 20 = $p'$ + 15)
- Since trivially $p'' > p'$ all of the options under _Event > Settings > Cancellation > Order Changes > Requirement for changed prices_ will allow this order change to proceed
- This means that now $o$ has an extra personalized mug which cannot give to someone else

With this new setting I aim to prevent this exact scenario, while still allowing order changes which instead add items (We want that $u$ can buy $S$ at any time)

This PR includes also unit tests. Like the previous PR I did (#5323) I'm still not sure if I've used the `with scopes_disabled():` directive correctly, so please review the unit tests I've added hahahha

Currently I've implemented the validation only on the backend side: Like for order changes price constraints, an user will still be able to deselect positions from the presale order change's page and will be stopped with an alert only after they clicked on _continue_. This can also be theoretically enforced on the frontend (maybe by disabling buttons for already selected max-1 items and by faking min-count=current-count for items with max-count > 1), but like for an old PR I did (and I still have to work on, #4662) I don't have a clever idea of how to properly implement it with a good UX