### PR TITLE
[A11y] add main-landmark to all presale pages

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -65,8 +65,10 @@
 {% endblock %}
 </header>
 <div class="container main-box">
+    <main id="content">
     {% block page %}
     {% endblock %}
+    </main>
     <footer>
         {% block footer %}
         {% endblock %}

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_base.html
@@ -53,10 +53,8 @@
         </a>
     {% endif %}
 </aside>
-<main aria-label="{% trans "Checkout" %}">
     <h2>{% trans "Checkout" %}</h2>
     {% include "pretixpresale/event/fragment_checkoutflow.html" %}
     {% block inner %}
     {% endblock %}
-</main>
 {% endblock %}

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -7,7 +7,6 @@
 {% load getitem %}
 {% block title %}{% trans "Review order" %}{% endblock %}
 {% block content %}
-<main aria-label="{% trans "Review order" %}">
     <h2>{% trans "Review order" %}</h2>
     {% include "pretixpresale/event/fragment_checkoutflow.html" %}
     <p>{% trans "Please review the details below and confirm your order." %}</p>
@@ -214,5 +213,4 @@
             <div class="clearfix"></div>
         </div>
     </form>
-</main>
 {% endblock %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -47,7 +47,6 @@
             {{ ev.event_microdata }}
         </script>
     {% endautoescape %}
-    <main aria-label="{% if show_cart %}{% trans "Your cart, general information, add products to your cart" %}{% else %}{% trans "General information, add products to your cart" %}{% endif %}">
     {% if show_cart %}
         {% include "pretixpresale/event/fragment_cart_box.html" with open=1 %}
     {% endif %}
@@ -243,7 +242,6 @@
             </form>
         {% endif %}
     {% endif %}
-    </main>
     {% if show_vouchers %}
         <aside class="front-page" aria-labelledby="redeem-a-voucher">
             <h3 id="redeem-a-voucher">{% trans "Redeem a voucher" %}</h3>

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -22,7 +22,6 @@
     {% trans "Order details" %}
 {% endblock %}
 {% block content %}
-<main>
     {% if "thanks" in request.GET or "paid" in request.GET %}
         <div class="thank-you">
             <span class="fa fa-check-circle" aria-hidden="true"></span>
@@ -484,5 +483,4 @@
             </ul>
         </div>
     {% endif %}
-</main>
 {% endblock %}


### PR DESCRIPTION
This PR adds the `<main>`-landmark to all presale-pages through the base-template. As there is only one `<main>`-landmark, it does not need a label. Also `<aside>`-landmarks can be nested inside `<main>`.

We might not need https://github.com/pretix/pretix/blob/master/src/pretix/static/pretixpresale/js/ui/main.js#L244-L247 anymore as it is provided through this PRs main-landmark. I am not sure, I tested all presale-pages, but I have not found one where the base-template isn’t used.

Fixes #5261 