### PR TITLE
Clarify checkout success message

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -53,11 +53,12 @@
                 {{ request.event.settings.checkout_success_text|rich_text }}
             {% endif %}
             <p class="iframe-hidden">{% blocktrans trimmed %}
-                Please bookmark or save the link to this exact page if you want to access your order later. We also sent you an email containing the link to the address you specified.
+                Please bookmark or save the link to this exact page if you want to access your order later.
+                We also sent you an email to the address you specified containing the link to this page.
             {% endblocktrans %}</p>
             <p class="iframe-only">{% blocktrans trimmed %}
-                Please save the following link if you want to access your order later. We
-                also sent you an email containing the link to the address you specified.
+                Please save the following link if you want to access your order later.
+                We also sent you an email to the address you specified containing the link.
             {% endblocktrans %}<br>
                 <code>{{ url }}</code></p>
         </div>


### PR DESCRIPTION
Since both emails and links can be said to have addresses, the previous formulation of these messages could be confusing and cause a bit of a mental hiccup. Specifically, the previous construct could be interpreted as "we sent you [...] the link to the address you specified" (i.e. "address" could be interpreted as an URL).

By swapping the order of the phrasing, the sentence structure becomes less ambiguous. With the proposed order, it is clear that we mean "sent you an email to the [email] address you specified".