### PR TITLE
Add event's location to order confirmation mail (Z#23185285)

### DIFF
--- a/src/pretix/base/templates/pretixbase/email/order_details.html
+++ b/src/pretix/base/templates/pretixbase/email/order_details.html
@@ -60,11 +60,17 @@
             </td>
             <td>
                 {{ event.name }}
-                {% if not event.has_subevents and event.settings.show_dates_on_frontpage %}
-                    <br>
-                    {{ event.get_date_range_display }}
-                    {% if event.settings.show_times %}
-                        {{ event.date_from|date:"TIME_FORMAT" }}
+                {% if not event.has_subevents %}
+                    {% if event.settings.show_dates_on_frontpage %}
+                        <br>
+                        {{ event.get_date_range_display }}
+                        {% if event.settings.show_times %}
+                            {{ event.date_from|date:"TIME_FORMAT" }}
+                        {% endif %}
+                    {% endif %}
+                    {% if event.location %}
+                        <br>
+                        {{ event.location }}
                     {% endif %}
                 {% endif %}
             </td>

--- a/src/pretix/base/templates/pretixbase/email/order_details.html
+++ b/src/pretix/base/templates/pretixbase/email/order_details.html
@@ -70,7 +70,7 @@
                     {% endif %}
                     {% if event.location %}
                         <br>
-                        {{ event.location }}
+                        {{ event.location|oneline }}
                     {% endif %}
                 {% endif %}
             </td>


### PR DESCRIPTION
In order confirmation emails, subevents already list the location. This PR adds the location for a „normal“ event as well.