### PR TITLE
Fix select2 config typo

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -594,7 +594,7 @@ var form_handlers = function (el) {
                     }
                 }
             },
-            placeholder: $(this).attr("data-placeholder") | "",
+            placeholder: $(this).attr("data-placeholder") || "",
             templateResult: function (res) {
                 if (!res.id) {
                     return res.text;


### PR DESCRIPTION
IMHO the bitwise OR operator here is logically wrong. Although it still works thanks to same falsiness of `""` and `0`.