### PR TITLE
Fix subtotal rendering on mobile

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -437,7 +437,7 @@
     {% if not hide_prices %}
         <div role="rowgroup" class="cart-rowgroup-total">
         {% if event.settings.display_net_prices and cart.tax_total %}
-            <div role="row" class="row cart-row">
+            <div role="row" class="row cart-row subtotal">
                 <div role="cell" class="product">
                     <strong>{% trans "Net total" %}</strong>
                 </div>
@@ -448,7 +448,7 @@
                 </div>
                 <div class="clearfix"></div>
             </div>
-            <div role="row" class="row cart-row">
+            <div role="row" class="row cart-row subtotal">
                 <div role="cell" class="product">
                     <strong>{% trans "Taxes" %}</strong>
                 </div>

--- a/src/pretix/static/pretixpresale/scss/_cart.scss
+++ b/src/pretix/static/pretixpresale/scss/_cart.scss
@@ -221,7 +221,7 @@
         &.has-downloads.hide-prices .download-desktop {
             margin-left: 50%;
         }
-        &.total .product {
+        &.subtotal .product, &.total .product {
             width: 50%;
         }
         .count {


### PR DESCRIPTION
Before:

<img width="698" height="424" alt="image" src="https://github.com/user-attachments/assets/f8b428e1-656b-4612-ab5a-1880359cfae7" />


After:

<img width="698" height="388" alt="image" src="https://github.com/user-attachments/assets/6bc43add-948d-4f82-9a2b-c813557f3dad" />
