### PR TITLE
API: Make case insensitive boolean query params

### DIFF
--- a/src/pretix/api/views/checkin.py
+++ b/src/pretix/api/views/checkin.py
@@ -818,7 +818,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
         ctx = super().get_serializer_context()
         ctx['event'] = self.request.event
         ctx['expand'] = self.request.query_params.getlist('expand')
-        ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false') == 'true'
+        ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false').lower() == 'true'
         return ctx
 
     def get_filterset_kwargs(self):
@@ -837,9 +837,9 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self, ignore_status=False, ignore_products=False):
         qs = _checkin_list_position_queryset(
             [self.checkinlist],
-            ignore_status=self.request.query_params.get('ignore_status', 'false') == 'true' or ignore_status,
+            ignore_status=self.request.query_params.get('ignore_status', 'false').lower() == 'true' or ignore_status,
             ignore_products=ignore_products,
-            pdf_data=self.request.query_params.get('pdf_data', 'false') == 'true',
+            pdf_data=self.request.query_params.get('pdf_data', 'false').lower() == 'true',
             expand=self.request.query_params.getlist('expand'),
         )
 
@@ -881,7 +881,7 @@ class CheckinListPositionViewSet(viewsets.ReadOnlyModelViewSet):
             user=self.request.user,
             auth=self.request.auth,
             expand=self.request.query_params.getlist('expand'),
-            pdf_data=self.request.query_params.get('pdf_data', 'false') == 'true',
+            pdf_data=self.request.query_params.get('pdf_data', 'false').lower() == 'true',
             questions_supported=self.request.data.get('questions_supported', True),
             canceled_supported=self.request.data.get('canceled_supported', False),
             request=self.request,  # this is not clean, but we need it in the serializers for URL generation
@@ -916,7 +916,7 @@ class CheckinRPCRedeemView(views.APIView):
             user=self.request.user,
             auth=self.request.auth,
             expand=self.request.query_params.getlist('expand'),
-            pdf_data=self.request.query_params.get('pdf_data', 'false') == 'true',
+            pdf_data=self.request.query_params.get('pdf_data', 'false').lower() == 'true',
             questions_supported=s.validated_data['questions_supported'],
             use_order_locale=s.validated_data['use_order_locale'],
             canceled_supported=True,
@@ -994,9 +994,9 @@ class CheckinRPCSearchView(ListAPIView):
     def get_queryset(self, ignore_status=False, ignore_products=False):
         qs = _checkin_list_position_queryset(
             self.lists,
-            ignore_status=self.request.query_params.get('ignore_status', 'false') == 'true' or ignore_status,
+            ignore_status=self.request.query_params.get('ignore_status', 'false').lower() == 'true' or ignore_status,
             ignore_products=ignore_products,
-            pdf_data=self.request.query_params.get('pdf_data', 'false') == 'true',
+            pdf_data=self.request.query_params.get('pdf_data', 'false').lower() == 'true',
             expand=self.request.query_params.getlist('expand'),
         )
 

--- a/src/pretix/api/views/order.py
+++ b/src/pretix/api/views/order.py
@@ -228,7 +228,7 @@ class OrderViewSetMixin:
     def get_queryset(self):
         qs = self.get_base_queryset()
         if 'fees' not in self.request.GET.getlist('exclude'):
-            if self.request.query_params.get('include_canceled_fees', 'false') == 'true':
+            if self.request.query_params.get('include_canceled_fees', 'false').lower() == 'true':
                 fqs = OrderFee.all
             else:
                 fqs = OrderFee.objects
@@ -246,11 +246,11 @@ class OrderViewSetMixin:
         return qs
 
     def _positions_prefetch(self, request):
-        if request.query_params.get('include_canceled_positions', 'false') == 'true':
+        if request.query_params.get('include_canceled_positions', 'false').lower() == 'true':
             opq = OrderPosition.all
         else:
             opq = OrderPosition.objects
-        if request.query_params.get('pdf_data', 'false') == 'true' and getattr(request, 'event', None):
+        if request.query_params.get('pdf_data', 'false'),lower() == 'true' and getattr(request, 'event', None):
             prefetch_related_objects([request.organizer], 'meta_properties')
             prefetch_related_objects(
                 [request.event],
@@ -344,7 +344,7 @@ class EventOrderViewSet(OrderViewSetMixin, viewsets.ModelViewSet):
     def get_serializer_context(self):
         ctx = super().get_serializer_context()
         ctx['event'] = self.request.event
-        ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false') == 'true'
+        ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false').lower() == 'true'
         return ctx
 
     def get_base_queryset(self):
@@ -943,7 +943,7 @@ class EventOrderViewSet(OrderViewSetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=['POST'])
     def change(self, request, **kwargs):
         order = self.get_object()
-        check_quotas = self.request.query_params.get('check_quotas', 'true') == 'true'
+        check_quotas = self.request.query_params.get('check_quotas', 'true').lower() == 'true'
 
         serializer = OrderChangeOperationSerializer(
             context={'order': order, **self.get_serializer_context()},
@@ -1087,18 +1087,18 @@ class OrderPositionViewSet(viewsets.ModelViewSet):
     def get_serializer_context(self):
         ctx = super().get_serializer_context()
         ctx['event'] = self.request.event
-        ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false') == 'true'
+        ctx['pdf_data'] = self.request.query_params.get('pdf_data', 'false').lower() == 'true'
         ctx['check_quotas'] = self.request.query_params.get('check_quotas', 'true').lower() == 'true'
         return ctx
 
     def get_queryset(self):
-        if self.request.query_params.get('include_canceled_positions', 'false') == 'true':
+        if self.request.query_params.get('include_canceled_positions', 'false').lower() == 'true':
             qs = OrderPosition.all
         else:
             qs = OrderPosition.objects
 
         qs = qs.filter(order__event=self.request.event)
-        if self.request.query_params.get('pdf_data', 'false') == 'true':
+        if self.request.query_params.get('pdf_data', 'false').lower() == 'true':
             prefetch_related_objects([self.request.organizer], 'meta_properties')
             prefetch_related_objects(
                 [self.request.event],


### PR DESCRIPTION
As discussed in #5323, I've added a .lower() to all Boolean query params present in the Rest APIs to make them case insensitive. To find all cases I used the regex `\.get\(.*,\s*['"](?i:true|false)['"]\)` including all files in `src/pretix/api/**`

I don't know if there are any other query param which should be made case insensitive as well. I have took a look by simply searching all `query_params` usage still under the api folder, but I haven't noticed anything that could benefit from this