### PR TITLE
Organizer plugins: Do not show plugins as active if they are not on org-level

### DIFF
--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -638,10 +638,12 @@ class OrganizerPlugins(OrganizerDetailViewMixin, OrganizerPermissionRequiredMixi
 
         active_counter = Counter()
         events_total = 0
+        org_plugins = self.object.get_plugins()
         for e in self.object.events.only("plugins").iterator():
             events_total += 1
             for p in e.get_plugins():
-                active_counter[p] += 1
+                if p in org_plugins:
+                    active_counter[p] += 1
         plugins_grouped = groupby(
             sorted(
                 plugins,


### PR DESCRIPTION
We have prevented this situation from happening for now, but still wanted to fix it.