### PR TITLE
Fix missing payment provider "banktransfer" on export

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -107,11 +107,16 @@ def get_all_payment_providers():
             return Event
 
     with rolledback_transaction():
+        plugins = ",".join([app.name for app in apps.get_app_configs()])
+        organizer=Organizer.objects.create(
+            name="INTERNAL",
+            plugins=plugins,
+        )
         event = Event.objects.create(
-            plugins=",".join([app.name for app in apps.get_app_configs()]),
+            plugins=plugins,
             name="INTERNAL",
             date_from=now(),
-            organizer=Organizer.objects.create(name="INTERNAL")
+            organizer=organizer,
         )
         event = FakeEvent(event)
         provs = register_payment_providers.send(

--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -108,7 +108,7 @@ def get_all_payment_providers():
 
     with rolledback_transaction():
         plugins = ",".join([app.name for app in apps.get_app_configs()])
-        organizer=Organizer.objects.create(
+        organizer = Organizer.objects.create(
             name="INTERNAL",
             plugins=plugins,
         )


### PR DESCRIPTION
With the move to a hybrid plugin instead of event level, payment provder banktransfer failed to register as a payment provider on order export.