### PR TITLE
Remove unnecessary translation for daterange (Z#23205453)

### DIFF
--- a/src/pretix/helpers/daterange.py
+++ b/src/pretix/helpers/daterange.py
@@ -34,9 +34,7 @@
 
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import (
-    get_language, pgettext_lazy,
-)
+from django.utils.translation import get_language, pgettext_lazy
 
 from pretix.helpers.templatetags.date_fast import date_fast as _date
 


### PR DESCRIPTION
The french translation for the default daterange template string introduces a double hyphen. IMHO we should not use a translation here at all – we do not use one on the HTML-variant either.