### PR TITLE
Fix PayPal2 payment creation for free cart

### DIFF
--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -565,7 +565,7 @@ class PaypalMethod(BasePaymentProvider):
             )
             request.session['payment_paypal_payment'] = None
         else:
-            pass
+            return None
 
         try:
             paymentreq = OrdersCreateRequest()


### PR DESCRIPTION
`pass` IMHO does the wrong thing here. Returning None is probably the next best thing and looking at the code using `_create_paypal_order` is what is expected. The edge-case here being a cart_total of 0 – not sure how it got there in the first place, maybe a double-click race-condition, but this shouldn’t be unhandled.

Alternatively we could use `assert` to make clear, that either payment or cart_total is expected – which then needs some code changes in pretix/plugins/paypal2/views.py::180 to not try to create a payment for a zero-value.