### PR TITLE
Do not attach text/uri-list ticket formats if multi_download_enabled set

### DIFF
--- a/src/pretix/base/services/tickets.py
+++ b/src/pretix/base/services/tickets.py
@@ -161,6 +161,10 @@ def get_tickets_for_order(order, base_position=None):
                     if not retval:
                         continue
                     ct = CachedCombinedTicket.objects.get(pk=retval)
+
+                if ct.type == 'text/uri-list':
+                    continue
+
                 tickets.append((
                     "{}-{}-{}{}".format(
                         order.event.slug.upper(), order.code, ct.provider, ct.extension,


### PR DESCRIPTION
The `get_tickets_for_order` function only checked if the ticket output format was `text/uri-list` if the format field `multi_download_enabled` wasn't set.