### PR TITLE
Fix html-based form errors not being scrolled to in iOS/Safari

### DIFF
--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -225,6 +225,16 @@ var form_handlers = function (el) {
 };
 
 function setup_basics(el) {
+    el.find("form").attr("novalidate", true).on("submit", function (e) {
+        if (!this.checkValidity()) {
+            var input = this.querySelector(":invalid:not(fieldset)");
+            (input.labels[0] || input).scrollIntoView();
+            // only use reportValidity, which usually sets focus on element
+            // input.focus() opens dropdowns, which is not what we want
+            input.reportValidity();
+            e.preventDefault();
+        }
+    });
     el.find("input[data-toggle=radiocollapse]").change(function () {
         $($(this).attr("data-parent")).find(".collapse.in").collapse('hide');
         $($(this).attr("data-target")).collapse('show');


### PR DESCRIPTION
Fixes #5446 

To actually make it work, we need to disable automatic form validation and call it ourselves and look for invalid inputs and scroll them (or its label) into view.