### PR TITLE
Invoicing: Allow types to add text and watermarks

### DIFF
--- a/src/pretix/base/invoicing/national.py
+++ b/src/pretix/base/invoicing/national.py
@@ -22,7 +22,7 @@
 
 from django import forms
 from django.core.validators import RegexValidator
-from django.utils.translation import pgettext_lazy
+from django.utils.translation import pgettext, pgettext_lazy
 from django_countries.fields import Country
 from localflavor.it.forms import ITSocialSecurityNumberField
 
@@ -73,3 +73,12 @@ class ItalianSdITransmissionType(TransmissionType):
         if is_business:
             return base | {"company", "vat_id", "transmission_it_sdi_pec", "transmission_it_sdi_recipient_code"}
         return base | {"transmission_it_sdi_codice_fiscale"}
+
+    def pdf_info_text(self) -> str:
+        # Watermark is not necessary as this is a usual precaution in Italy
+        return pgettext(
+            "italian_invoice",
+            "This PDF document is a visual copy of the invoice and does not constitute an invoice for VAT "
+            "purposes. The invoice is issued in XML format, transmitted in accordance with the procedures and terms "
+            "set forth in No. 89757/2018 of April 30, 2018, issued by the Director of the Revenue Agency."
+        )

--- a/src/pretix/base/invoicing/peppol.py
+++ b/src/pretix/base/invoicing/peppol.py
@@ -23,7 +23,7 @@ import re
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, pgettext
 from django_countries.fields import Country
 
 from pretix.base.invoicing.transmission import (
@@ -165,3 +165,13 @@ class PeppolTransmissionType(TransmissionType):
             "company", "street", "zipcode", "city", "country",
         }
         return base | {"transmission_peppol_participant_id"}
+
+    def pdf_watermark(self) -> str:
+        return pgettext("peppol_invoice", "Visual copy")
+
+    def pdf_info_text(self) -> str:
+        return pgettext(
+            "peppol_invoice",
+            "This PDF document is a visual copy of the invoice and does not constitute an invoice for VAT "
+            "purposes. The original invoice is issued in XML format and transmitted through the Peppol network."
+        )

--- a/src/pretix/base/invoicing/transmission.py
+++ b/src/pretix/base/invoicing/transmission.py
@@ -104,6 +104,18 @@ class TransmissionType:
     def transmission_info_to_form_data(self, transmission_info: dict) -> dict:
         return transmission_info
 
+    def pdf_watermark(self) -> Optional[str]:
+        """
+        Return a watermark that should be rendered across the PDF file.
+        """
+        return None
+
+    def pdf_info_text(self) -> Optional[str]:
+        """
+        Return an info text that should be rendered on the PDF file.
+        """
+        return None
+
 
 class TransmissionProvider:
     """


### PR DESCRIPTION
When using Italian SdI or Peppol, our PDF becomes merely a preview, not a legal invoice, and should be clearly marked as such on the PDF.

<img width="992" height="1148" alt="image" src="https://github.com/user-attachments/assets/5a037403-0457-4cf3-bc84-f3879f1aa175" />
