### PR TITLE
Fix export missing banktransfer with fake organizer

### DIFF
--- a/src/pretix/control/forms/filter.py
+++ b/src/pretix/control/forms/filter.py
@@ -91,6 +91,21 @@ def get_all_payment_providers():
         def __getattr__(self, item):
             return getattr(self.orig_settings, item)
 
+    class FakeOrganizer:
+        def __init__(self, orig_organizer):
+            self.orig_organizer = orig_organizer
+
+        @property
+        def settings(self):
+            return FakeSettings(self.orig_organizer.settings)
+
+        def __getattr__(self, item):
+            return getattr(self.orig_organizer, item)
+
+        @property
+        def __class__(self):  # hackhack
+            return Organizer
+
     class FakeEvent:
         def __init__(self, orig_event):
             self.orig_event = orig_event
@@ -116,7 +131,7 @@ def get_all_payment_providers():
             plugins=plugins,
             name="INTERNAL",
             date_from=now(),
-            organizer=organizer,
+            organizer=FakeOrganizer(organizer),
         )
         event = FakeEvent(event)
         provs = register_payment_providers.send(


### PR DESCRIPTION
To be honest, I can only guess that on our production servers this needs a FakeOrganizer as in my local dev setup, everything works with the organizer directly (and even without the FakeEvent), might be because of settings. So take this PR with a grain of salt and more as a kind of exploration/attempt to fix a bug on production, which I cannot replicate on my local dev setup. Not really satisfying though …