### PR TITLE
Remove infinite loop when output plugin provides a URI for a whole order

### DIFF
--- a/src/pretix/base/services/tickets.py
+++ b/src/pretix/base/services/tickets.py
@@ -69,9 +69,6 @@ def generate_order(order: int, provider: str):
             prov = response(order.event)
             if prov.identifier == provider:
                 filename, ttype, data = prov.generate_order(order)
-                if ttype == 'text/uri-list':
-                    continue
-
                 path, ext = os.path.splitext(filename)
                 for ct in CachedCombinedTicket.objects.filter(order=order, provider=provider):
                     ct.delete()

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -711,11 +711,15 @@ class OrderDownload(AsyncAction, OrderView):
                 )
                 return resp
         elif isinstance(value, CachedCombinedTicket):
-            resp = FileResponse(value.file.file, content_type=value.type)
-            resp['Content-Disposition'] = 'attachment; filename="{}-{}-{}{}"'.format(
-                self.request.event.slug.upper(), self.order.code, self.output.identifier, value.extension
-            )
-            return resp
+            if value.type == 'text/uri-list':
+                resp = HttpResponseRedirect(value.file.file.read())
+                return resp
+            else:
+                resp = FileResponse(value.file.file, content_type=value.type)
+                resp['Content-Disposition'] = 'attachment; filename="{}-{}-{}{}"'.format(
+                    self.request.event.slug.upper(), self.order.code, self.output.identifier, value.extension
+                )
+                return resp
         else:
             return redirect(self.get_self_url())
 

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -1146,11 +1146,15 @@ class OrderDownloadMixin:
                     )
                 return resp
         elif isinstance(value, CachedCombinedTicket):
-            resp = FileResponse(value.file.file, content_type=value.type)
-            resp['Content-Disposition'] = 'attachment; filename="{}-{}-{}{}"'.format(
-                self.request.event.slug.upper(), self.order.code, self.output.identifier, value.extension
-            )
-            return resp
+            if value.type == 'text/uri-list':
+                resp = HttpResponseRedirect(value.file.file.read())
+                return resp
+            else:
+                resp = FileResponse(value.file.file, content_type=value.type)
+                resp['Content-Disposition'] = 'attachment; filename="{}-{}-{}{}"'.format(
+                    self.request.event.slug.upper(), self.order.code, self.output.identifier, value.extension
+                )
+                return resp
         else:
             return redirect(self.get_self_url())
 


### PR DESCRIPTION
Currently, if a ticket ouput provider outputs a `text/uri-list` from its `generate_order` method, this is entirely ignored.
This results in Pretix entering an infinite loop of constantly regenerating the ticket and displaying "We are processing your request …" to the user.