### PR TITLE
Fix ticket-pdf export layout selection by saleschannel

### DIFF
--- a/src/pretix/plugins/ticketoutputpdf/exporters.py
+++ b/src/pretix/plugins/ticketoutputpdf/exporters.py
@@ -223,7 +223,7 @@ class AllTicketsPDF(BaseExporter):
 
                 with language(op.order.locale, o.event.settings.region):
                     layout = o.layout_map.get(
-                        (op.item_id, op.order.sales_channel_id),
+                        (op.item_id, op.order.sales_channel.identifier),
                         o.layout_map.get(
                             (op.item_id, 'web'),
                             o.default_layout


### PR DESCRIPTION
When exporting all tickets as pdf, the wrong layout was chosen for tickets from a different sales-channel than "web".