### PR TITLE
PDF: fix handling empty qr-codes

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -819,7 +819,7 @@ class Renderer:
             # and does not deal with our default value here properly
             content = op.secret
         else:
-            content = self._get_text_content(op, order, o)
+            content = self._get_text_content(op, order, o).strip()
 
         if len(content) == 0:
             return


### PR DESCRIPTION
When using unknown placeholders and combining them with newlines, it could happen that the content that is to be encoded in the QR-code is newlines only. This PR strips all newlines. If we want to keep the possibility to end a QR-code with a newline (although AFAIK this should better be enabled in the barcode-scanner to add a return/line-feed after the scan), then we should move the `.strip()` into the if-check two lines below.