### PR TITLE
Invoice-PDF: split line.description into multiple rows so table can pagebreak

### DIFF
--- a/src/pretix/base/invoicing/pdf.py
+++ b/src/pretix/base/invoicing/pdf.py
@@ -903,7 +903,7 @@ class ClassicInvoiceRenderer(BaseReportlabInvoiceRenderer):
                     )
                     description_p_list.append(FontFallbackParagraph(
                         single_price_line,
-                        self.stylesheet['Normal']
+                        self.stylesheet['Fineprint']
                     ))
                 tdata.append((
                     description_p_list.pop(0),


### PR DESCRIPTION
When including questions/answers on the invoice, this can cause a failure to create the PDF when the description of a line inside the invoice-table’s cell exceeds the page size. ~This PR adds a basic char-limit on setting the description, so it always fits on the default renderers page (tested with hundreds of letter M as a question).~

UPDATE: This PR splits the description into chunks which then can be pagebroken by reportlab. It also lets the additional description (everything except the first line) span multiple columns.

<img width="996" height="1003" alt="Bildschirmfoto 2025-10-16 um 16 29 23" src="https://github.com/user-attachments/assets/5764ca23-c6f5-4649-bc82-fe78c33e8374" />
