### PR TITLE
Add option to show confirmation texts on order detail page

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2168,6 +2168,16 @@ DEFAULTS = {
         'serializer_class': serializers.ListField,
         'serializer_kwargs': lambda: dict(child=I18nField()),
     },
+    'show_confirm_texts_on_order_detail': {
+        'default': 'False',
+        'type': bool,
+        'form_class': forms.BooleanField,
+        'serializer_class': serializers.BooleanField,
+        'form_kwargs': dict(
+            label=_("Show on order details page"),
+            help_text=_("If enabled, the confirmation texts will be displayed on the order detail page after purchase.")
+        )
+    },
     'mail_html_renderer': {
         'default': 'classic',
         'type': str

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -603,6 +603,7 @@ class EventSettingsForm(EventSettingsValidationMixin, FormPlaceholderMixin, Sett
         'logo_image_large',
         'logo_show_title',
         'og_image',
+        'show_confirm_texts_on_order_detail'
     ]
 
     base_context = {

--- a/src/pretix/control/templates/pretixcontrol/event/settings.html
+++ b/src/pretix/control/templates/pretixcontrol/event/settings.html
@@ -201,6 +201,7 @@
                             </p>
                         </div>
                     </div>
+                    {% bootstrap_field sform.show_confirm_texts_on_order_detail layout="control" %}
                 </div>
 
                 {% bootstrap_field sform.checkout_success_text layout="control" %}

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_confirm.html
@@ -164,25 +164,7 @@
                 </div>
             </div>
         </div>
-        {% if confirm_messages %}
-            <div class="panel panel-primary panel-confirm" role="group" aria-labelledby="confirm_heading">
-                <div class="panel-heading">
-                    <h3 class="panel-title" id="confirm_heading">
-                        {% trans "Confirmations" %}
-                    </h3>
-                </div>
-                <div class="panel-body">
-                    {% for key, desc in confirm_messages.items %}
-                        <div class="checkbox">
-                            <label for="input_confirm_{{ key }}">
-                                <input type="checkbox" class="checkbox" value="yes" name="confirm_{{ key }}" id="input_confirm_{{ key }}" required>
-                                {{ desc|safe }}
-                            </label>
-                        </div>
-                    {% endfor %}
-                </div>
-            </div>
-        {% endif %}
+        {% include "pretixpresale/event/fragment_confirm_text.html" %}
         {% if require_approval %}
             <div class="alert alert-warning">
                 <strong>

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_confirm_text.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_confirm_text.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% if confirm_messages %}
+<div class="panel panel-primary panel-confirm" role="group" aria-labelledby="confirm_heading">
+    <div class="panel-heading">
+        <h3 class="panel-title" id="confirm_heading">
+            {% trans "Confirmations" %}
+        </h3>
+    </div>
+    <div class="panel-body">
+        {% for key, desc in confirm_messages.items %}
+        <div class="checkbox">
+            <label for="input_confirm_{{ key }}">
+                <input type="checkbox" value="yes" name="confirm_{{ key }}" id="input_confirm_{{ key }}"
+                {% if show_only %} checked disabled aria-disabled="true" {% else %} required {% endif %}>
+                {{ desc|safe }}
+            </label>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -226,6 +226,9 @@
             {% endif %}
         </div>
     </div>
+    {% if show_confirm_texts %}
+        {% include "pretixpresale/event/fragment_confirm_text.html" with show_only=True %}
+    {% endif %}
     {% eventsignal event "pretix.presale.signals.order_info" order=order request=request %}
     <div class="row">
         {% if invoices %}

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -92,7 +92,10 @@ from pretix.helpers.safedownload import check_token
 from pretix.multidomain.urlreverse import build_absolute_uri, eventreverse
 from pretix.presale.forms.checkout import InvoiceAddressForm, QuestionsForm
 from pretix.presale.forms.order import OrderPositionChangeForm
-from pretix.presale.signals import question_form_fields_overrides
+from pretix.presale.signals import (
+    checkout_all_optional, checkout_confirm_messages,
+    question_form_fields_overrides,
+)
 from pretix.presale.views import (
     CartMixin, EventViewMixin, iframe_entry_view_wrapper,
 )
@@ -237,6 +240,23 @@ class TicketPageMixin:
 class OrderDetails(EventViewMixin, OrderDetailMixin, CartMixin, TicketPageMixin, TemplateView):
     template_name = "pretixpresale/event/order.html"
 
+    @cached_property
+    def all_optional(self):
+        for recv, resp in checkout_all_optional.send(sender=self.request.event, request=self.request):
+            if resp:
+                return True
+        return False
+
+    @cached_property
+    def confirm_messages(self):
+        if self.all_optional:
+            return {}
+        msgs = {}
+        responses = checkout_confirm_messages.send(self.request.event)
+        for receiver, response in responses:
+            msgs.update(response)
+        return msgs
+
     def get(self, request, *args, **kwargs):
         self.kwargs = kwargs
         if not self.order:
@@ -257,6 +277,8 @@ class OrderDetails(EventViewMixin, OrderDetailMixin, CartMixin, TicketPageMixin,
         )
         ctx = super().get_context_data(**kwargs)
 
+        ctx['confirm_messages'] = self.confirm_messages
+        ctx['show_confirm_texts'] = self.request.event.settings.show_confirm_texts_on_order_detail
         ctx['can_download_multi'] = any([b['multi'] for b in self.download_buttons]) and (
             [p.generate_ticket for p in ctx['cart']['positions']].count(True) > 1
         )

--- a/src/pretix/presale/views/order.py
+++ b/src/pretix/presale/views/order.py
@@ -92,10 +92,7 @@ from pretix.helpers.safedownload import check_token
 from pretix.multidomain.urlreverse import build_absolute_uri, eventreverse
 from pretix.presale.forms.checkout import InvoiceAddressForm, QuestionsForm
 from pretix.presale.forms.order import OrderPositionChangeForm
-from pretix.presale.signals import (
-    checkout_all_optional, checkout_confirm_messages,
-    question_form_fields_overrides,
-)
+from pretix.presale.signals import question_form_fields_overrides
 from pretix.presale.views import (
     CartMixin, EventViewMixin, iframe_entry_view_wrapper,
 )
@@ -240,23 +237,6 @@ class TicketPageMixin:
 class OrderDetails(EventViewMixin, OrderDetailMixin, CartMixin, TicketPageMixin, TemplateView):
     template_name = "pretixpresale/event/order.html"
 
-    @cached_property
-    def all_optional(self):
-        for recv, resp in checkout_all_optional.send(sender=self.request.event, request=self.request):
-            if resp:
-                return True
-        return False
-
-    @cached_property
-    def confirm_messages(self):
-        if self.all_optional:
-            return {}
-        msgs = {}
-        responses = checkout_confirm_messages.send(self.request.event)
-        for receiver, response in responses:
-            msgs.update(response)
-        return msgs
-
     def get(self, request, *args, **kwargs):
         self.kwargs = kwargs
         if not self.order:
@@ -277,8 +257,9 @@ class OrderDetails(EventViewMixin, OrderDetailMixin, CartMixin, TicketPageMixin,
         )
         ctx = super().get_context_data(**kwargs)
 
-        ctx['confirm_messages'] = self.confirm_messages
-        ctx['show_confirm_texts'] = self.request.event.settings.show_confirm_texts_on_order_detail
+        if self.request.event.settings.show_confirm_texts_on_order_detail:
+            ctx['confirm_messages'] = {f'confirmed_text_{n}': text for n, text in enumerate(self.order.meta_info_data['confirm_messages'])}
+            ctx['show_confirm_texts'] = True
         ctx['can_download_multi'] = any([b['multi'] for b in self.download_buttons]) and (
             [p.generate_ticket for p in ctx['cart']['positions']].count(True) > 1
         )


### PR DESCRIPTION
Implements [showing confirmation texts on order details page](https://github.com/pretix/pretix/discussions/5023)