### PR TITLE
OrderChangeManager: add_position() returns a handle to the newly created position

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1671,19 +1671,15 @@ class OrderChangeManager:
     RemoveBlockOperation = namedtuple('RemoveBlockOperation', ('position', 'block_name', 'ignore_from_quota_while_blocked'))
 
     class AddPositionResult:
-        operation: 'OrderChangeManager.AddOperation'
-        original_order_change_manager: 'OrderChangeManager'
         _position: Optional[OrderPosition]
 
-        def __init__(self, order_change_manager: 'OrderChangeManager'):
-            self.original_order_change_manager = order_change_manager
-            self.operation = None
+        def __init__(self):
             self._position = None
 
         @property
         def position(self) -> OrderPosition:
             if self._position is None:
-                raise ValueError("OrderPosition has not been created yet. Call commit() first on the original OrderChangeManager")
+                raise RuntimeError("Order position has not been created yet. Call commit() first on OrderChangeManager.")
             return self._position
 
     def __init__(self, order: Order, user=None, auth=None, notify=True, reissue_invoice=True, allow_blocked_seats=False):
@@ -1950,10 +1946,9 @@ class OrderChangeManager:
         if seat:
             self._seatdiff.update([seat])
 
-        result = self.AddPositionResult(self)
-        op = self.AddOperation(item, variation, price, addon_to, subevent, seat, membership, valid_from, valid_until, is_bundled, result)
-        result.operation = op
-        self._operations.append(op)
+        result = self.AddPositionResult()
+        self._operations.append(self.AddOperation(item, variation, price, addon_to, subevent, seat, membership,
+                                                  valid_from, valid_until, is_bundled, result))
         return result
 
     def split(self, position: OrderPosition):

--- a/src/tests/base/test_orders.py
+++ b/src/tests/base/test_orders.py
@@ -2469,9 +2469,7 @@ class OrderChangeManagerTests(TestCase):
     def test_add_item_result_value(self):
         res_shirt = self.ocm.add_position(self.shirt, None, None, None)
         res_ticket2 = self.ocm.add_position(self.ticket2, None, None, None)
-        assert res_shirt.original_order_change_manager == self.ocm
-        assert res_shirt.operation.item == self.shirt
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             _ = res_ticket2.position
         self.ocm.commit()
         assert res_shirt.position.item == self.shirt


### PR DESCRIPTION
This PR changes OrdereChangeManager in two ways:
- It adds an abstract class for custom operations. In this way plugins which extend OrderChangeManager have the chance of implementing their own operations. I've originally planned of allowing this by creating a single `Operation` abstract class extended by all of the existing operations (+ the eventual custom operations implemented by plugins) and moving their logic from the `_perform_operations()` method to their own class. In this way the `_perform_operations()` method would become a simple `for op in self._operations: op.execute(...)`. However this way required "major" code changes and dismissing the use of `namedtuple` (which may (? I honestly have no idea tbf, I'm saying what docs say) be more lightweight than standard classes annotated with `@dataclass`), so I opted to essentially add a new case to the switch of that method. If the way I suggested is preferred I can change my PR without problems
- It adds a callback argument for `add_position()` which will be called at the end of the related `AddOperation` with the original operation and the newly created `OrderPosition`. This is a way for the OCM's caller to do operations on the exact created position in case there are multiple `add_position()` in a single commit. This could also help solving #5548: Instead of retrieving the last `OrderPosition` of the order (which allows for race conditions), we can do something like `created_pos = []; ocm.add_position(item=item, ..., callback=lambda op, pos: created_pos.append(pos)); return created_pos[0];`