### PR TITLE
Bank transfer: Reorder fields for pending bank details

### DIFF
--- a/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/pending.html
+++ b/src/pretix/plugins/banktransfer/templates/pretixplugins/banktransfer/pending.html
@@ -27,7 +27,7 @@
                     <dt>{% trans "BIC" %}:</dt><dd>{{ settings.bank_details_sepa_bic }}</dt>
                     <dt>{% trans "Bank" %}:</dt><dd>{{ settings.bank_details_sepa_bank }}</dt>
                 {% endif %}
-              </dl>
+            </dl>
             {% if details %}
                 {{ details | rich_text }}
             {% endif %}


### PR DESCRIPTION
Before:

<img width="1118" height="404" alt="image" src="https://github.com/user-attachments/assets/99dd577d-29d4-46db-a13a-3f271f256ef2" />


After:

<img width="1118" height="384" alt="image" src="https://github.com/user-attachments/assets/91bae9e7-14e6-4f1b-860a-c54ec0dd11e1" />

Makes the bank address or additional data less prominent, but it just looked weird having it in between the other stuff.
