### PR TITLE
Allow to unlock a payment method and redeem a voucher at the same time

### DIFF
--- a/src/pretix/presale/views/user.py
+++ b/src/pretix/presale/views/user.py
@@ -107,4 +107,10 @@ class UnlockHashView(EventViewMixin, View):
         hashes = request.session.get('pretix_unlock_hashes', [])
         hashes.append(kwargs.get('hash'))
         request.session['pretix_unlock_hashes'] = hashes
+
+        if 'voucher' in request.GET:
+            return redirect_to_url(
+                eventreverse(self.request.event, 'presale:event.redeem') + f'?{request.META["QUERY_STRING"]}'
+            )
+
         return redirect_to_url(eventreverse(self.request.event, 'presale:event.index'))


### PR DESCRIPTION
Through the magic of adding `?voucher=foobar` to the unlock-URL