### PR TITLE
Fix required label for multi-checkbox form-groups (Z#23211551)

### DIFF
--- a/src/pretix/static/pretixpresale/scss/_forms.scss
+++ b/src/pretix/static/pretixpresale/scss/_forms.scss
@@ -173,7 +173,7 @@ output {
   }
 }
 @media (min-width: $screen-md-min) {
-  .form-group:not(:has(.checkbox)) {
+  .form-group:not(:has(.checkbox)), .form-group:has(.checkbox + .checkbox) {
     .label-required {
       display: block;
     }


### PR DESCRIPTION
For questions with multiple checkboxes as answers, the „required“-label was not correctly placed underneath the label, but in parentheses on the same line with the label.

Before:

<img width="431" height="97" alt="Bildschirmfoto 2025-10-23 um 16 18 54" src="https://github.com/user-attachments/assets/249aae6e-4b4d-4abd-85c7-4b329bf19339" />

After:

<img width="336" height="106" alt="Bildschirmfoto 2025-10-23 um 16 18 17" src="https://github.com/user-attachments/assets/6ccd0b29-bd1b-4cf9-9a07-4edd5e3ec28f" />
