### PR TITLE
Sort answers according to questions (Z#23212280)

### DIFF
--- a/src/pretix/base/services/invoices.py
+++ b/src/pretix/base/services/invoices.py
@@ -258,9 +258,15 @@ def build_invoice(invoice: Invoice) -> Invoice:
                 if resp:
                     desc += "<br/>" + resp
 
-            for answ in p.answers.all():
-                if not answ.question.print_on_invoice:
-                    continue
+            answers_qs = p.answers.filter(
+                question__print_on_invoice=True
+            ).select_related(
+                'question'
+            ).order_by(
+                'question__position',
+                'question__id'
+            )
+            for answ in answers_qs:
                 desc += "<br />{}{} {}".format(
                     answ.question.question,
                     "" if str(answ.question.question).endswith("?") else ":",


### PR DESCRIPTION
This adds default ordering to answers based on questions. Not sure this is necessary or even harmful as a default as it probably adds a JOIN to every query on answers. So maybe we just add the ordering to https://github.com/pretix/pretix/blob/master/src/pretix/base/services/invoices.py#L261? 