### PR TITLE
Turn attendee emails on by default for new events (Z#23213656)

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -715,6 +715,13 @@ class Event(EventMixin, LoggedModel):
         self.settings.name_scheme = 'given_family'
         self.settings.payment_banktransfer_invoice_immediately = True
         self.settings.low_availability_percentage = 10
+        self.settings.mail_send_order_free_attendee = True
+        self.settings.mail_send_order_placed_attendee = True
+        self.settings.mail_send_order_placed_attendee = True
+        self.settings.mail_send_order_paid_attendee = True
+        self.settings.mail_send_order_approved_attendee = True
+        self.settings.mail_send_order_approved_free_attendee = True
+        self.settings.mail_text_download_reminder_attendee = True
 
     @property
     def social_image(self):

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -717,7 +717,6 @@ class Event(EventMixin, LoggedModel):
         self.settings.low_availability_percentage = 10
         self.settings.mail_send_order_free_attendee = True
         self.settings.mail_send_order_placed_attendee = True
-        self.settings.mail_send_order_placed_attendee = True
         self.settings.mail_send_order_paid_attendee = True
         self.settings.mail_send_order_approved_attendee = True
         self.settings.mail_send_order_approved_free_attendee = True


### PR DESCRIPTION
I think the thing that makes me most unhappy is that *most* organizers will probably want to turn off mail_send_order_paid_attendee when they set ticket_download_pending and I don't think organizers will remember that, but it also seems complex and weird to create an automatism for it?