### PR TITLE
Stripe: Update Revolut Pay presentment currency list

### DIFF
--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -423,7 +423,7 @@ class StripeSettingsHolder(BasePaymentProvider):
                 ('method_revolut_pay',
                  forms.BooleanField(
                      label='Revolut Pay',
-                     disabled=self.event.currency not in ['EUR', 'GBP'],
+                     disabled=self.event.currency not in ['EUR', 'GBP', 'RON', 'HUF', 'PLN', 'DKK'],
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
                                  'before they work properly.'),
                      required=False,


### PR DESCRIPTION
Updates the list of currencies that enable the Revolut Pay checkbox in the Stripe plugin settings to include RON, HUF, PLN, DKK as per https://docs.stripe.com/payments/revolut-pay