### PR TITLE
Fix program times having no item in clean

### DIFF
--- a/src/pretix/base/models/items.py
+++ b/src/pretix/base/models/items.py
@@ -2311,7 +2311,7 @@ class ItemProgramTime(models.Model):
     end = models.DateTimeField(verbose_name=_("End"))
 
     def clean(self):
-        if self.item.event.has_subevents:
+        if hasattr(self, 'item') and self.item and self.item.event.has_subevents:
             raise ValidationError(_("You cannot use program times on an event series."))
         self.clean_start_end(start=self.start, end=self.end)
         super().clean()


### PR DESCRIPTION
This error occurs only when adding a program-time form in the frontend and not saving it, but removing it again and then saving the item.