### PR TITLE
Add legacy-cgi dependency for Python 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
   "redis==6.4.*",
   "reportlab==4.4.*",
   "requests==2.32.*",
+  "legacy-cgi; python_version >= \"3.13\"",
   "sentry-sdk==2.46.*",
   "sepaxml==2.7.*",
   "stripe==7.9.*",


### PR DESCRIPTION
**Version:** 2261951b15f9aa12e226849be04db4a8b745434e

**Steps that will reproduce the problem:**

1. Read https://docs.pretix.eu/dev/development/setup.html
2. git clone git@github.com:pretix/pretix.git && cd pretix
3. python3 -m venv env && source env/bin/activate
4. pip3 install -e ".[dev]"
5. cd src && python3 manage.py collectstatic --noinput


**What is the expected result:**

No error


**What happens instead:**

ModuleNotFoundError: No module named 'cgi'


**Possible workaround:**

Add legacy-cgi


**Any additional information:**

Tested with Python 3.14.0 on macOS 26.1 (25B78)
