### PR TITLE
Cart extension: Fix bundled product being removed from cart when sold out (Z#23216811)

### DIFF
--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -1361,6 +1361,11 @@ class CartManager:
                         deleted_positions.add(op.position.pk)
                         addons.delete()
                         op.position.delete()
+                        if op.position.is_bundled:
+                            deleted_positions |= {a.pk for a in op.position.addon_to.addons.all()}
+                            deleted_positions.add(op.position.addon_to.pk)
+                            op.position.addon_to.addons.all().delete()
+                            op.position.addon_to.delete()
                     else:
                         raise AssertionError("ExtendOperation cannot affect more than one item")
             elif isinstance(op, self.VoucherOperation):


### PR DESCRIPTION
Instead, the entire bundle must be removed as it may not be sold individually.