### PR TITLE
Exclude data-dir from code style checks

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -13,7 +13,7 @@ extra_standard_library = typing,enum,mimetypes
 multi_line_output = 5
 line_length = 79
 honor_noqa = true
-skip_glob = make_testdata.py,wsgi.py,bootstrap,celery_app.py,pretix/settings.py,tests/settings.py,pretix/testutils/settings.py,.eggs/**
+skip_glob = data/**,make_testdata.py,wsgi.py,bootstrap,celery_app.py,pretix/settings.py,tests/settings.py,pretix/testutils/settings.py,.eggs/**
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = tests.settings


### PR DESCRIPTION
Depending on the local dev-setup data can contain py-files, which get scanned by flake8 and isort.