### PR TITLE
Fix widget-css etag version limit

### DIFF
--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -108,7 +108,10 @@ def indent(s):
 
 
 def widget_css_etag(request, version, **kwargs):
-    version = max(min(version, version_max), version_min)
+    if version > version_max:
+        return None
+    if version < version_min:
+        version = version_min
     # This makes sure a new version of the theme is loaded whenever settings or the source files have changed
     if hasattr(request, 'event'):
         return (f'{_get_source_cache_key(version)}-'


### PR DESCRIPTION
When requesting widget-CSS-files with a version larger than version_max, generating the etag failed – the actual widget-css raises a 404, but still the etag needs to be generated.