### PR TITLE
Improve description for addons option count (Z#23219101)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -24,7 +24,7 @@
         {% elif c.min_count == 0 %}
             <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
                 {% blocktrans trimmed count max_count=c.max_count %}
-                    You can choose {{ max_count }} option from this category.
+                    You can choose one option from this category.
                 {% plural %}
                     You can choose up to {{ max_count }} options from this category.
                 {% endblocktrans %}


### PR DESCRIPTION
When merged, we need to adapt translations – at least for german: „Sie können eine Option aus dieser Kategorie wählen.“ Alternatively before merging this PR we need to merge all changes from pretix-translate and then update the po-files in this PR manually. 