### PR TITLE
Fix race conditions in OrderChange API serializer

### DIFF
--- a/src/pretix/api/serializers/orderchange.py
+++ b/src/pretix/api/serializers/orderchange.py
@@ -33,7 +33,7 @@ from pretix.api.serializers.order import (
     OrderFeeCreateSerializer, OrderPositionCreateSerializer,
 )
 from pretix.base.models import ItemVariation, Order, OrderFee, OrderPosition
-from pretix.base.services.orders import OrderError, OrderChangeManager
+from pretix.base.services.orders import OrderChangeManager, OrderError
 from pretix.base.settings import COUNTRIES_WITH_STATE_IN_ADDRESS
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
As commented in issue #5548, there was a small and not critical race condition in the retrieval of newly created Order Positions. The first commit of this PR fixes it. 

While looking at the code I've noticed a similar pattern which is still prone to races in the creation of Fees. I've also updated the code to fix this as well by simply returning the same OrderFee object we pass to the OCM. Internally the OCM doesn't copy the object around, so the instance we create in the serializer is the one where we effectively call `.save()` in the commit phase of the ocm

I've also looked around in the codebase (by searching for `('-` usages) and it doesn't look like there are similar cases of this happening around