### PR TITLE
Price rounding: Make sum_by_net_keep_gross even more consumer-friendly (Z#23220106)

### DIFF
--- a/doc/development/algorithms/pricing.rst
+++ b/doc/development/algorithms/pricing.rst
@@ -286,6 +286,11 @@ gross prices stay the same.
 
 **This is less confusing to consumers and the end result is still compliant to EN 16931, so we recommend this for e-invoicing when (primarily) consumers are involved.**
 
+Some gross prices **cannot** stay the same. For example, it is impossible to represent €15.00 incl. 19%, since a net
+price of €12.60 would lead to €14.99 gross and a net price of €12.61 would lead to €15.01 gross. Since this algorithm
+is supposed to be consumer-friendly, it has a bias for choosing €14.99 in this case, even if €15.01 would be a little
+less of a difference.
+
 The main downside is that it might be confusing when selling to business customers, since the prices of the identical tickets appear to be different.
 Full computation for the example above:
 

--- a/src/pretix/base/services/pricing.py
+++ b/src/pretix/base/services/pricing.py
@@ -284,12 +284,27 @@ def apply_rounding(rounding_mode: Literal["line", "sum_by_net", "sum_by_net_keep
             # e.g. 99.99 at 19% is impossible since 84.03 + 19% = 100.00 and 84.02 + 19% = 99.98
             target_gross_total = round_decimal((target_net_total * (1 + tax_rate / 100)), currency)
 
+            if target_net_total and target_gross_total > gross_total:
+                target_net_total -= min((target_gross_total - gross_total), len(lines) * minimum_unit)
+                try_target_gross_total = round_decimal((target_net_total * (1 + tax_rate / 100)), currency)
+                if try_target_gross_total <= gross_total:
+                    target_gross_total = try_target_gross_total
+
             diff_gross = target_gross_total - gross_total
             diff_net = target_net_total - net_total
             diff_gross_sgn = -1 if diff_gross < 0 else 1
             diff_net_sgn = -1 if diff_net < 0 else 1
             for l in lines:
-                if diff_gross:
+                if diff_gross and diff_net:
+                    apply_diff = diff_gross_sgn * minimum_unit
+                    l.price = l.gross_price_before_rounding + apply_diff
+                    l.price_includes_rounding_correction = apply_diff
+                    l.tax_value = l.tax_value_before_rounding
+                    l.tax_value_includes_rounding_correction = Decimal("0.00")
+                    changed.append(l)
+                    diff_gross -= apply_diff
+                    diff_net -= apply_diff
+                elif diff_gross:
                     apply_diff = diff_gross_sgn * minimum_unit
                     l.price = l.gross_price_before_rounding + apply_diff
                     l.price_includes_rounding_correction = apply_diff
@@ -311,6 +326,11 @@ def apply_rounding(rounding_mode: Literal["line", "sum_by_net", "sum_by_net_keep
                     l.tax_value = l.tax_value_before_rounding
                     l.tax_value_includes_rounding_correction = Decimal("0.00")
                     changed.append(l)
+
+            # Double-check that result is consistent in computing gross from net
+            new_net_total = sum(l.price - l.tax_value for l in lines)
+            new_gross_total = sum(l.price for l in lines)
+            assert new_gross_total == round_decimal((new_net_total * (1 + tax_rate / 100)), currency)
 
     elif rounding_mode == "line":
         for l in lines:

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -871,7 +871,8 @@ class TaxSettingsForm(EventSettingsValidationMixin, SettingsForm):
                 "Recommended for e-invoicing when you primarily sell to consumers. "
                 "The gross or net price of some products may be changed automatically to ensure correct "
                 "rounding of the order total. The system attempts to keep gross prices as configured whenever "
-                "possible. Gross prices may still change if they are impossible to derive from a rounded net price."
+                "possible. Gross prices may still change if they are impossible to derive from a rounded net price, "
+                "but the system will prefer rounding them down instead of up."
             ),
         }
         self.fields["tax_rounding"].choices = (


### PR DESCRIPTION
The rounding mode sum_by_net_keep_gross is supposed to be the consumer-friendly algorithm. However, some consumer-friendly prices are still impossible, such as 15.00 incl. 19%.  Previously, the system would round to 15.01, because it's the gross price derived from the closest net price. With this PR, it rounds to 14.99 instead, because consumers like paying less more than they like paying more.