### PR TITLE
Get the Organizer of organizer-level plugin log entries directly

### DIFF
--- a/src/pretix/control/logdisplay.py
+++ b/src/pretix/control/logdisplay.py
@@ -814,7 +814,7 @@ class OrganizerPluginStateLogEntryType(LogEntryType):
             if app and hasattr(app, 'PretixPluginMeta'):
                 return {
                     'href': reverse('control:organizer.settings.plugins', kwargs={
-                        'organizer': logentry.event.organizer.slug,
+                        'organizer': logentry.organizer.slug,
                     }) + '#plugin_' + logentry.parsed_data['plugin'],
                     'val': app.PretixPluginMeta.name
                 }


### PR DESCRIPTION
The enabled and disabled log types for this handler are written by the Organizer object so there is no event to call on, and since this is for organizer-level plugins an event doesn't make sense to add.