### PR TITLE
Exclude cancelled orders from paid orders graph

### DIFF
--- a/src/pretix/plugins/statistics/templates/pretixplugins/statistics/index.html
+++ b/src/pretix/plugins/statistics/templates/pretixplugins/statistics/index.html
@@ -24,6 +24,8 @@
                     <small>
                         {% blocktrans trimmed %}
                             Orders paid in multiple payments are shown with the date of their last payment.
+                            Placed orders include all orders (pending, paid, cancelled, and expired);
+                            paid orders include only paid orders and exclude all cancelled orders.
                         {% endblocktrans %}
                     </small>
                 </p>

--- a/src/pretix/plugins/statistics/views.py
+++ b/src/pretix/plugins/statistics/views.py
@@ -103,7 +103,10 @@ class IndexView(EventPermissionRequiredMixin, ChartContainingView, TemplateView)
                 day = o['datetime'].astimezone(tz).date()
                 ordered_by_day[day] = ordered_by_day.get(day, 0) + 1
             paid_by_day = {}
-            for o in oqs.filter(event=self.request.event, payment_date__isnull=False).values('payment_date'):
+            for o in oqs.filter(
+                event=self.request.event, payment_date__isnull=False,
+                status=Order.STATUS_PAID, all_positions__canceled=False
+            ).distinct().values('payment_date'):
                 day = o['payment_date'].astimezone(tz).date()
                 paid_by_day[day] = paid_by_day.get(day, 0) + 1
 


### PR DESCRIPTION
The 'paid orders' time series on the statistics page currently counts orders that were paid and later cancelled.

Filter the paid-by-day queryset to `Order.STATUS_PAID` with at least one non-cancelled position, leaving the placed orders series unchanged, and update the help text to clarify this behaviour.

Discussion: https://github.com/pretix/pretix/discussions/5774