### PR TITLE
Include fee-cancelled positions in placed orders by product graph

### DIFF
--- a/src/pretix/plugins/statistics/templates/pretixplugins/statistics/index.html
+++ b/src/pretix/plugins/statistics/templates/pretixplugins/statistics/index.html
@@ -59,6 +59,14 @@
             </div>
             <div class="panel-body">
                 <div id="obp_chart" class="chart"></div>
+                <p class="help-block">
+                    <small>
+                        {% blocktrans trimmed %}
+                            Placed orders include all orders (pending, paid, cancelled, and expired);
+                            paid orders include only paid orders and exclude all cancelled orders.
+                        {% endblocktrans %}
+                    </small>
+                </p>
             </div>
         </div>
         {% if seats %}

--- a/src/pretix/plugins/statistics/views.py
+++ b/src/pretix/plugins/statistics/views.py
@@ -128,7 +128,7 @@ class IndexView(EventPermissionRequiredMixin, ChartContainingView, TemplateView)
         # Orders by product
         ctx['obp_data'] = cache.get('statistics_obp_data' + ckey)
         if not ctx['obp_data']:
-            opqs = OrderPosition.objects
+            opqs = OrderPosition.all
             if subevent:
                 opqs = opqs.filter(subevent=subevent)
             num_ordered = {
@@ -141,7 +141,7 @@ class IndexView(EventPermissionRequiredMixin, ChartContainingView, TemplateView)
             num_paid = {
                 p['item']: p['cnt']
                 for p in (opqs
-                          .filter(order__event=self.request.event, order__status=Order.STATUS_PAID)
+                          .filter(order__event=self.request.event, order__status=Order.STATUS_PAID, canceled=False)
                           .values('item')
                           .annotate(cnt=Count('id')).order_by())
             }


### PR DESCRIPTION
The 'placed orders by product' graph already includes orders that are pending, expired, or fully cancelled without a fee. However, items cancelled with a fee are omitted. This change ensures all placed orders are included in the graph, including those cancelled with a fee.