### PR TITLE
Use transparent padding when resizing images with alpha support

### DIFF
--- a/src/pretix/helpers/thumb.py
+++ b/src/pretix/helpers/thumb.py
@@ -152,8 +152,8 @@ def resize_image(image, size):
     if min_width > new_size[0] or min_height > new_size[1]:
         padding = math.ceil(max(min_width - new_size[0], min_height - new_size[1]) / 2)
         if image.mode not in ("RGB", "RGBA"):
-            image = image.convert('RGB')
-        image = ImageOps.expand(image, border=padding, fill="white")
+            image = image.convert('RGBA')
+        image = ImageOps.expand(image, border=padding, fill=(255, 255, 255, 0))
 
         new_width = max(min_width, new_size[0])
         new_height = max(min_height, new_size[1])


### PR DESCRIPTION
Resized images that required padding were always padded with solid white. This caused visible bars around images with transparent elements when rendered on non-white backgrounds (e.g., [emails in dark mode](https://github.com/user-attachments/assets/5b8eca62-4c1a-453a-a026-412a045e76c6)).

Update the padding logic to:

- Prefer RGBA when an image is not already RGB/RGBA
- Use fully transparent padding instead of white

Images without an alpha channel continue to render with white padding, while images with transparency now preserve it correctly.