### PR TITLE
Waitinglist: lock entry while we create the voucher (Z#23220154)

### DIFF
--- a/src/pretix/base/models/waitinglist.py
+++ b/src/pretix/base/models/waitinglist.py
@@ -35,6 +35,7 @@ from pretix.base.email import get_email_context
 from pretix.base.i18n import language
 from pretix.base.models import User, Voucher
 from pretix.base.services.mail import SendMailException, mail, render_mail
+from pretix.helpers import OF_SELF
 
 from ...helpers.format import format_map
 from ...helpers.names import build_name


### PR DESCRIPTION
- moves the "has this waitinglist entry a voucher" check into the transaction 
- locks waitinglist entry for the duration of the voucher creation

