### PR TITLE
Remove autofocus from only button in cart-extend confirm-dialog

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -519,7 +519,7 @@
         <dialog role="alertdialog" id="cart-extend-confirmation-dialog" class="inline-dialog" aria-labelledby="cart-deadline">
             <form method="dialog">
                 <p>
-                    <button class="btn btn-success" autofocus value="OK">
+                    <button class="btn btn-success" value="OK">
                         <span role="img" aria-label="{% trans "OK" %}.">
                             {% icon "check" %}
                         </span>


### PR DESCRIPTION
autofocus is not needed here as it is the only button in the dialog and by default gets focus. It also caused warnings when running inside an iframe (e.g. when using the widget) – see Z#23221351