### PR TITLE
Fix n+1-programtimes-query in item lists (PRETIXEU-CMN)

### DIFF
--- a/src/pretix/api/views/item.py
+++ b/src/pretix/api/views/item.py
@@ -106,7 +106,7 @@ class ItemViewSet(ConditionalListView, viewsets.ModelViewSet):
             'variations', 'addons', 'bundles', 'meta_values', 'meta_values__property',
             'variations__meta_values', 'variations__meta_values__property',
             'require_membership_types', 'variations__require_membership_types',
-            'limit_sales_channels', 'variations__limit_sales_channels',
+            'limit_sales_channels', 'variations__limit_sales_channels', 'program_times'
         ).all()
 
     def perform_create(self, serializer):

--- a/src/tests/api/test_items.py
+++ b/src/tests/api/test_items.py
@@ -50,6 +50,7 @@ from pretix.base.models import (
     QuestionOption, Quota,
 )
 from pretix.base.models.orders import OrderFee
+from pretix.testutils.queries import assert_num_queries
 
 
 @pytest.fixture
@@ -420,6 +421,13 @@ def test_item_list(token_client, organizer, event, team, item):
     resp = token_client.get('/api/v1/organizers/{}/events/{}/items/?search=Free'.format(organizer.slug, event.slug))
     assert resp.status_code == 200
     assert [] == resp.data['results']
+
+
+@pytest.mark.django_db
+def test_item_list_queries(token_client, organizer, event, team, item, item3):
+    with assert_num_queries(18):
+        resp = token_client.get('/api/v1/organizers/{}/events/{}/items/'.format(organizer.slug, event.slug))
+        assert resp.status_code == 200
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Prefetches program times and adds a test-case for the expected (smaller) query amount