### PR TITLE
Display SSO popup login errors inline instead of using JS alert

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/checkout_customer.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_customer.html
@@ -40,6 +40,7 @@
                             </dd>
                         </dl>
                     {% else %}
+                        <div class="alert alert-danger hidden"></div>
                         <p>
                             {% blocktrans trimmed with org=request.organizer.name %}
                                 If you created a customer account at {{ org }} before, you can log in now and connect

--- a/src/pretix/static/pretixpresale/js/ui/sso.js
+++ b/src/pretix/static/pretixpresale/js/ui/sso.js
@@ -39,10 +39,12 @@ $(function () {
             return
         if (event.data && event.data.__process === "customer_sso_popup") {
             if (event.data.status === "ok") {
+                $("#customer_login .alert.alert-danger").addClass("hidden");
                 $("#login_sso_data").val(event.data.value)
                 $("#login_sso_data").closest("form").get(0).submit()
             } else {
-                alert(event.data.value)  // todo
+                $("#customer_login .alert.alert-danger").html(event.data.value);
+                $("#customer_login .alert.alert-danger").removeClass("hidden");
             }
             event.source.postMessage({'__process': 'popup_close'}, "*")
         }


### PR DESCRIPTION
Replace the JavaScript alert used for SSO popup login errors during the checkout flow with an inline HTML error message.