### PR TITLE
Improve SSO one-time token error message

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
@@ -1,0 +1,64 @@
+{% load i18n %}
+
+<h4 class="alert-heading">{% trans "Login could not be completed" %}</h4>
+
+<p>
+    {% blocktrans %}
+        We couldn't complete your login because something interrupted the process.
+    {% endblocktrans %}
+</p>
+
+<h5 class="alert-heading"><b>{% trans "This can happen if:" %}</b></h5>
+
+<ul>
+    <li>
+        {% blocktrans %}
+            you start logging in from a link opened inside an app (such as Instagram
+            or an email app), and then continue the login in your main browser;
+        {% endblocktrans %}
+    </li>
+    <li>
+        {% blocktrans %}
+            you refresh the page or use the back button during login;
+        {% endblocktrans %}
+    </li>
+    <li>
+        {% blocktrans %}
+            the site is opened in more than one tab or window at the same time;
+        {% endblocktrans %}
+    </li>
+    <li>
+        {% blocktrans %}
+            there is a long delay between starting and completing the login process.
+        {% endblocktrans %}
+    </li>
+</ul>
+
+<h5 class="alert-heading font-weight-bold"><strong>{% trans "How to fix this:" %}</strong></h5>
+
+<ol>
+    <li>
+        {% trans "Close this page." %}
+    </li>
+    <li>
+        {% blocktrans %}
+            Open this website again directly in your main browser (for example
+            Safari or Chrome).
+        {% endblocktrans %}
+    </li>
+    <li>
+        {% blocktrans %}
+            Begin the checkout or login process again and complete it in the same
+            browser window, without refreshing the page, opening new tabs, or
+            switching apps part-way through.
+        {% endblocktrans %}
+    </li>
+</ol>
+
+<p>
+    {% blocktrans %}
+        If the problem continues, closing all browser windows and clearing cookies
+        before retrying can help. As a last step, try using a different browser or
+        another device (for example, a desktop or laptop computer).
+    {% endblocktrans %}
+</p>

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<h4 class="alert-heading">{% trans "Login could not be completed" %}</h4>
+<h4>{% trans "Login could not be completed" %}</h4>
 
 <p>
     {% blocktrans %}
@@ -8,7 +8,7 @@
     {% endblocktrans %}
 </p>
 
-<h5 class="alert-heading"><b>{% trans "This can happen if:" %}</b></h5>
+<h5><b>{% trans "This can happen if:" %}</b></h5>
 
 <ul>
     <li>
@@ -34,7 +34,7 @@
     </li>
 </ul>
 
-<h5 class="alert-heading font-weight-bold"><strong>{% trans "How to fix this:" %}</strong></h5>
+<h5><strong>{% trans "How to fix this:" %}</strong></h5>
 
 <ol>
     <li>

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
@@ -12,23 +12,23 @@
 
 <ul>
     <li>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             you start logging in from a link opened inside an app (such as Instagram
             or an email app), and then continue the login in your main browser;
         {% endblocktrans %}
     </li>
     <li>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             you refresh the page or use the back button during login;
         {% endblocktrans %}
     </li>
     <li>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             the site is opened in more than one tab or window at the same time;
         {% endblocktrans %}
     </li>
     <li>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             there is a long delay between starting and completing the login process.
         {% endblocktrans %}
     </li>
@@ -41,13 +41,13 @@
         {% trans "Close this page." %}
     </li>
     <li>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             Open this website again directly in your main browser (for example
             Safari or Chrome).
         {% endblocktrans %}
     </li>
     <li>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             Begin the checkout or login process again and complete it in the same
             browser window, without refreshing the page, opening new tabs, or
             switching apps part-way through.
@@ -56,7 +56,7 @@
 </ol>
 
 <p>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
         If the problem continues, closing all browser windows and clearing cookies
         before retrying can help. As a last step, try using a different browser or
         another device (for example, a desktop or laptop computer).

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_login_interrupted_message.html
@@ -8,28 +8,28 @@
     {% endblocktrans %}
 </p>
 
-<h5><b>{% trans "This can happen if:" %}</b></h5>
+<h5><b>{% trans "Possible reasons for this:" %}</b></h5>
 
 <ul>
     <li>
         {% blocktrans trimmed %}
-            you start logging in from a link opened inside an app (such as Instagram
-            or an email app), and then continue the login in your main browser;
+            You started logging in from a link opened inside an app (such as Instagram
+            or an email app), and then continued the login in your main browser.
         {% endblocktrans %}
     </li>
     <li>
         {% blocktrans trimmed %}
-            you refresh the page or use the back button during login;
+            You refreshed the page or used the back button during login.
         {% endblocktrans %}
     </li>
     <li>
         {% blocktrans trimmed %}
-            the site is opened in more than one tab or window at the same time;
+            The site was opened in more than one tab or window at the same time.
         {% endblocktrans %}
     </li>
     <li>
         {% blocktrans trimmed %}
-            there is a long delay between starting and completing the login process.
+            There was a long delay between starting and completing the login process.
         {% endblocktrans %}
     </li>
 </ul>

--- a/src/pretix/presale/views/customer.py
+++ b/src/pretix/presale/views/customer.py
@@ -36,10 +36,12 @@ from django.db.models import (
 )
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
+from django.template.loader import render_to_string
 from django.utils.crypto import get_random_string
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
@@ -765,9 +767,7 @@ class SSOLoginReturnView(RedirectBackMixin, View):
 
             if nonce != request.session.get(f'pretix_customerauth_{self.provider.pk}_nonce'):
                 return self._fail(
-                    _('Login was not successful. Error message: "{error}".').format(
-                        error='invalid one-time token',
-                    ),
+                    mark_safe(render_to_string("pretixpresale/organizers/customer_login_interrupted_message.html")),
                     popup_origin,
                 )
             redirect_uri = build_absolute_uri(


### PR DESCRIPTION
Replace the generic 'invalid one-time token' message shown after failed SSO login attempts with a clearer, user-facing explanation of what went wrong and how to recover.

Requires #5840 before merging.

Mitigates one of the issues in #5836.

Screenshot of the new error message (_this screenshot is outdated_):

<img width="1820" height="598" src="https://github.com/user-attachments/assets/ab3fa409-2f56-4e41-b265-28f5d20fc380" />