### PR TITLE
Disable partitioned cookies for Safari due to WebKit bugs

### DIFF
--- a/src/pretix/helpers/cookies.py
+++ b/src/pretix/helpers/cookies.py
@@ -34,7 +34,10 @@ def set_cookie_without_samesite(request, response, key, *args, **kwargs):
     if not is_secure:
         # https://www.chromestatus.com/feature/5633521622188032
         return
-    if should_send_same_site_none(request.headers.get('User-Agent', '')):
+
+    useragent = request.headers.get('User-Agent', '')
+
+    if should_send_same_site_none(useragent):
         # Chromium is rolling out SameSite=Lax as a default
         # https://www.chromestatus.com/feature/5088147346030592
         # This however breaks all pretix-in-an-iframe things, such as the pretix Widget.
@@ -44,8 +47,29 @@ def set_cookie_without_samesite(request, response, key, *args, **kwargs):
         # This will only work on secure cookies as well
         # https://www.chromestatus.com/feature/5633521622188032
         response.cookies[key]['secure'] = is_secure
-        # CHIPS
-        response.cookies[key]['Partitioned'] = True
+
+        if can_send_partitioned_cookie(useragent):
+            # CHIPS
+            response.cookies[key]['Partitioned'] = True
+
+
+def can_send_partitioned_cookie(useragent):
+    # Safari currently exhibits a bug where Partitioned cookies (CHIPS) are not
+    # sent back to the originating site after multi-hop cross-site redirects,
+    # breaking SSO login flows in pretix.
+    #
+    # Partitioned cookies were initially introduced in Safari 18.4, removed
+    # again in 18.5 due to a bug, and reintroduced in Safari 26.2, where the
+    # current issue is present.
+    #
+    # Once the Safari issue is fixed, this check should be refined to be
+    # conditional on the affected versions only.
+    #
+    # WebKit issues:
+    #
+    #   - https://bugs.webkit.org/show_bug.cgi?id=292975
+    #   - https://bugs.webkit.org/show_bug.cgi?id=306194
+    return not is_safari(useragent)
 
 
 # Based on https://www.chromium.org/updates/same-site/incompatible-clients


### PR DESCRIPTION
Safari currently exhibits a bug where Partitioned cookies (CHIPS) are not sent back to the originating site after multi-hop cross-site redirects, breaking SSO login flows in pretix.

Partitioned cookies were initially introduced in Safari 18.4, removed again in 18.5 due to a bug, and reintroduced in Safari 26.2, where the current issue is present.

As a mitigation, disable sending the `Partitioned` attribute for Safari user agents. This is intentionally conservative; once the Safari issue is fixed, this check should be refined to be conditional on the affected versions only.

WebKit issues:

  - https://bugs.webkit.org/show_bug.cgi?id=292975
  - https://bugs.webkit.org/show_bug.cgi?id=306194

Fixes the primary cause of #5836.