### PR TITLE
Limit organizer ical to 1000 entries (Z#23221651)

### DIFF
--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -1350,8 +1350,9 @@ class OrganizerIcalDownload(OrganizerViewMixin, View):
                 'date_from'
             )[:limit]
         )
-        events.sort(key=lambda e: e.date_from)
-        events = events[:limit]
+        if len(events) > limit:
+            events.sort(key=lambda e: e.date_from)
+            events = events[:limit]
 
         if 'locale' in request.GET and request.GET.get('locale') in dict(settings.LANGUAGES):
             with language(request.GET.get('locale'), self.request.organizer.settings.region):


### PR DESCRIPTION
THis PR adds a limit of 1000 entries to the organizer ical-download due to limits on ics-files in some calendar tools (e.g. Google’s calendar). This also fixes a timeout issue when a huge number of events is exported.

I tried to union the querysets and sort by date_from in the database, but could not get it to work. So this PR limits each class of events (event or subevent) to 1000 and, if the limit is exceeded, sorts in Python and limits to 1000 again to get the upcoming 1000 entries mixed between event and subevent.