### PR TITLE
Outgoing mail: Decode unicode in From headers

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/organizers/outgoing_mail.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/outgoing_mail.html
@@ -19,7 +19,7 @@
 
                     <dl class="dl-horizontal">
                         <dt>{% trans "From" context "email" %}</dt>
-                        <dd>{{ mail.sender }}</dd>
+                        <dd>{{ sender }}</dd>
                         <dt>{% trans "To" context "email" %}</dt>
                         <dd>{{ mail.to|join:", " }}</dd>
                         {% if mail.cc %}

--- a/src/pretix/control/views/mail.py
+++ b/src/pretix/control/views/mail.py
@@ -21,6 +21,8 @@
 #
 import base64
 import logging
+from email.header import decode_header, make_header
+from email.utils import parseaddr
 
 from django.conf import settings
 from django.contrib import messages
@@ -124,6 +126,12 @@ class OutgoingMailDetailView(OrganizerDetailViewMixin, OrganizerPermissionRequir
         ctx = super().get_context_data(**kwargs)
         if self.object.body_html:
             ctx['data_url'] = "data:text/html;charset=utf-8;base64," + base64.b64encode(self.object.body_html.encode()).decode()
+
+        from_name, from_email = parseaddr(self.object.sender)
+        if from_name:
+            from_name = make_header(decode_header(from_name))
+        ctx['sender'] = "{} <{}>".format(from_name, from_email) if from_name else from_email
+
         return ctx
 
 


### PR DESCRIPTION
Before:
<img width="2213" height="190" alt="Screenshot 2026-01-30 at 13-40-28 Veranstalter pretix eu" src="https://github.com/user-attachments/assets/4d86153f-98c4-4fe7-ac2a-8ac9f24c5119" />

After:
<img width="2213" height="190" alt="image" src="https://github.com/user-attachments/assets/c5ed50dd-2ac8-41cc-9e90-e80d426606e2" />
