### PR TITLE
Enable email send task rate limits

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -371,7 +371,7 @@ class CustomEmail(EmailMultiAlternatives):
         return super()._create_mime_attachment(content, mimetype)
 
 
-@app.task(base=TransactionAwareTask, bind=True, acks_late=True)
+@app.task(base=TransactionAwareTask, bind=True, acks_late=True, rate_limit=settings.EMAIL_TASK_RATE_LIMIT)
 def mail_send_task(self, **kwargs) -> bool:
     if "outgoing_mail" in kwargs:
         outgoing_mail = kwargs.get("outgoing_mail")

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -246,6 +246,7 @@ EMAIL_USE_SSL = config.getboolean('mail', 'ssl', fallback=False)
 EMAIL_SUBJECT_PREFIX = '[pretix] '
 EMAIL_BACKEND = EMAIL_CUSTOM_SMTP_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_TIMEOUT = 60
+EMAIL_TASK_RATE_LIMIT = config.get('mail', 'task_rate_limit', fallback=None)
 
 ADMINS = [('Admin', n) for n in config.get('mail', 'admins', fallback='').split(",") if n]
 


### PR DESCRIPTION
This PR makes it possible to set task rate limits for the the email send task via env variables.

This is especially relevant to prevent ticket selling peaks from getting flagged by your email provider (e.g. most providers have a hourly or daily limit).

**Sample usage**

```bash
PRETIX_MAIL_TASK_RATE_LIMIT=10/m
```