### PR TITLE
Fix address-helper wrong locale (Z#23223920)

### DIFF
--- a/src/pretix/base/views/js_helpers.py
+++ b/src/pretix/base/views/js_helpers.py
@@ -164,16 +164,7 @@ def _address_form(request):
 
 def address_form(request):
     locale = request.GET.get('locale')
-    allowed_languages = dict(settings.LANGUAGES)
-    if locale and locale not in allowed_languages and '-' in locale:
-        locale = locale.split('-')[0]
-        if locale not in allowed_languages:
-            for lang in allowed_languages:
-                if lang.startswith(locale + '-'):
-                    locale = lang
-                    break
-
-    if locale in allowed_languages:
+    if locale in dict(settings.LANGUAGES):
         with language(locale):
             info = _address_form(request)
     else:

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_questions.html
@@ -42,7 +42,7 @@
                     {% endif %}
                     <div id="invoice" class="profile-scope"
                          data-profiles-id="addresses_json"
-                         data-address-information-url="{% url "js_helpers.address_form" %}?invoice=true&amp;organizer={{ event.organizer.slug|urlencode }}&amp;event={{ event.slug|urlencode }}&amp;locale={{ html_locale }}">
+                         data-address-information-url="{% url "js_helpers.address_form" %}?invoice=true&amp;organizer={{ event.organizer.slug|urlencode }}&amp;event={{ event.slug|urlencode }}&amp;locale={{ request.LANGUAGE_CODE }}">
                         <div class="panel-body">
                             {% if addresses_data %}
                                 <div class="form-group profile-select-container js-do-not-copy-answers">

--- a/src/pretix/presale/templates/pretixpresale/event/order_modify.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order_modify.html
@@ -36,7 +36,7 @@
                         </h4>
                     </summary>
                     <div id="invoice" class="panel-collapse"
-                         data-address-information-url="{% url "js_helpers.address_form" %}?invoice=true&amp;organizer={{ event.organizer.slug|urlencode }}&amp;event={{ event.slug|urlencode }}&amp;locale={{ html_locale }}">
+                         data-address-information-url="{% url "js_helpers.address_form" %}?invoice=true&amp;organizer={{ event.organizer.slug|urlencode }}&amp;event={{ event.slug|urlencode }}&amp;locale={{ request.LANGUAGE_CODE }}">
                         <div class="panel-body">
                             {% if event.settings.invoice_address_explanation_text %}
                                 <div>


### PR DESCRIPTION
This PR adds a locale-URL-param to the address-helper. This is needed if the event has a different language as default than what the browser suggests in its request-header. If the event is in one language only or the user does not switch languages, then there is no cookie for language. Even if the user has a language-cookie, but in a language not supported by the event, the global address-helper-enpoint responded with the wrong locale applied.

I planned on using `get_supported_language` from middleware, but that falls back to the first allowed language. This PR falls back to the middleware’s language, which could differ. Or should it return 404 if the language is unknown?