### PR TITLE
Fix widget quantity prefill (Z#23223095)

### DIFF
--- a/src/pretix/static/pretixpresale/js/widget/widget.js
+++ b/src/pretix/static/pretixpresale/js/widget/widget.js
@@ -252,7 +252,7 @@ Vue.component('availbox', {
         variation: Object
     },
     mounted: function() {
-        if (this.$root.itemnum === 1 && (!this.$root.categories[0].items[0].has_variations || this.$root.categories[0].items[0].variations.length < 2) && !this.$root.has_seating_plan ? 1 : 0) {
+        if (!this.$root.cart_exists && this.$root.itemnum === 1 && (!this.$root.categories[0].items[0].has_variations || this.$root.categories[0].items[0].variations.length < 2) && !this.$root.has_seating_plan ? 1 : 0) {
             this.$refs.quantity.value = 1;    
             if (this.order_max === 1) {
                 this.$refs.quantity.checked = true;


### PR DESCRIPTION
When only one product can be bought and existing cart existed, quantity was pre-filled with 1, but the submit-button still read „Resume checkout“ and clicking on it caused the quantity to be reset to 0 and not item added to the cart. This PR fixes it by not prefilling quantity when a cart exists.