### PR TITLE
Move request.GET.items to ctx

### DIFF
--- a/src/pretix/presale/context.py
+++ b/src/pretix/presale/context.py
@@ -179,6 +179,7 @@ def _default_context(request):
     ctx['html_page_header'] = "".join(h for h in _html_page_header if h)
     ctx['footer'] = _footer
     ctx['site_url'] = settings.SITE_URL
+    ctx['request_get_items'] = request.GET.items()
 
     ctx['js_datetime_format'] = get_javascript_format_without_seconds('DATETIME_INPUT_FORMATS')
     ctx['js_date_format'] = get_javascript_format_without_seconds('DATE_INPUT_FORMATS')

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
@@ -15,7 +15,7 @@
         </li>
         <li class="text-center">
             <form class="form-inline" method="get" id="monthselform" action="{% eventurl event "presale:event.index" cart_namespace=cart_namespace %}">
-                {% for f, v in request.GET.items %}
+                {% for f, v in request_get_items %}
                     {% if f != "date" %}
                         <input type="hidden" name="{{ f }}" value="{{ v }}">
                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar_week.html
@@ -15,7 +15,7 @@
         </li>
         <li class="text-center">
             <form class="form-inline" method="get" id="monthselform" action="{% eventurl event "presale:event.index" cart_namespace=cart_namespace %}">
-                {% for f, v in request.GET.items %}
+                {% for f, v in request_get_items %}
                     {% if f != "date" %}
                         <input type="hidden" name="{{ f }}" value="{{ v }}">
                     {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/fragment_event_list_filter.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_event_list_filter.html
@@ -7,7 +7,7 @@
 {% if filter_form.fields %}
     <form class="event-list-filter-form" method="get" data-save-scrollpos>
         <input type="hidden" name="filtered" value="1">
-        {% for f, v in request.GET.items %}
+        {% for f, v in request_get_items %}
             {% if f not in filter_form.fields and f != "page" %}
                 <input type="hidden" name="{{ f }}" value="{{ v }}">
             {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -47,7 +47,7 @@
                     </li>
                     <li class="text-center">
                         <form class="form-inline" method="get" id="monthselform" action="{% eventurl request.organizer "presale:organizer.index" %}">
-                            {% for f, v in request.GET.items %}
+                            {% for f, v in request_get_items %}
                                 {% if f != "date" %}
                                     <input type="hidden" name="{{ f }}" value="{{ v }}">
                                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_day.html
@@ -47,7 +47,7 @@
                     </li>
                     <li class="text-center">
                         <form class="form-inline" method="get" id="monthselform" action="{% eventurl request.organizer "presale:organizer.index" %}">
-                            {% for f, v in request.GET.items %}
+                            {% for f, v in request_get_items %}
                                 {% if f != "date" %}
                                     <input type="hidden" name="{{ f }}" value="{{ v }}">
                                 {% endif %}

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar_week.html
@@ -47,7 +47,7 @@
                     </li>
                     <li class="text-center">
                         <form class="form-inline" method="get" id="monthselform" action="{% eventurl request.organizer "presale:organizer.index" %}">
-                            {% for f, v in request.GET.items %}
+                            {% for f, v in request_get_items %}
                                 {% if f != "date" %}
                                     <input type="hidden" name="{{ f }}" value="{{ v }}">
                                 {% endif %}


### PR DESCRIPTION
It happens every now and then that we get requests with `items` as a GET-parameter (maybe some misinterpretation from the widget-docs?) and the page fails to build. One could argue it’s a good thing to fail building the page as we do not support filtering items the way the widget does or adding to the cart onload like pretix-button, but I think it should not fail.

Note: pretix-control templates sometimes use request.POST.items, which has the same problems, but as they are not public facing I guess it is okay to fail with a 500? Although a 400 might be better, but well …