### PR TITLE
feat: add transparency option and EXIF rotation support for badge images

### DIFF
--- a/src/pretix/base/pdf.py
+++ b/src/pretix/base/pdf.py
@@ -975,17 +975,18 @@ class Renderer:
                 )
                 canvas.restoreState()
         else:
-            canvas.saveState()
-            canvas.setFillColorRGB(.8, .8, .8, alpha=1)
-            canvas.rect(
-                x=float(o['left']) * mm,
-                y=float(o['bottom']) * mm,
-                width=float(o['width']) * mm,
-                height=float(o['height']) * mm,
-                stroke=0,
-                fill=1,
-            )
-            canvas.restoreState()
+            if not o.get('missing_image_transparent', False):
+                canvas.saveState()
+                canvas.setFillColorRGB(.8, .8, .8, alpha=1)
+                canvas.rect(
+                    x=float(o['left']) * mm,
+                    y=float(o['bottom']) * mm,
+                    width=float(o['width']) * mm,
+                    height=float(o['height']) * mm,
+                    stroke=0,
+                    fill=1,
+                )
+                canvas.restoreState()
 
     def _text_paragraph(self, op: OrderPosition, order: Order, o: dict, legacy_lineheight=False, override_fontsize=None):
         font = o['fontfamily']

--- a/src/pretix/control/templates/pretixcontrol/pdf/index.html
+++ b/src/pretix/control/templates/pretixcontrol/pdf/index.html
@@ -327,6 +327,12 @@
                                     <option value="{{ varname }}">{{ var.label }}</option>
                                 {% endfor %}
                             </select>
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" id="toolbox-image-transparent">
+                                    {% trans "Transparent if missing" %}
+                                </label>
+                            </div>
                         </div>
                     </div>
                     <div class="row control-group text textcontent">

--- a/src/pretix/helpers/reportlab.py
+++ b/src/pretix/helpers/reportlab.py
@@ -24,7 +24,7 @@ import logging
 from arabic_reshaper import ArabicReshaper
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
-from PIL import Image
+from PIL import Image, ImageOps
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfbase import pdfmetrics
@@ -61,7 +61,9 @@ class ThumbnailingImageReader(ImageReader):
         return None
 
     def _read_image(self, fp):
-        return Image.open(fp, formats=settings.PILLOW_FORMATS_IMAGE)
+        img = Image.open(fp, formats=settings.PILLOW_FORMATS_IMAGE)
+        ImageOps.exif_transpose(img, in_place=True)
+        return img
 
 
 reshaper = SimpleLazyObject(lambda: ArabicReshaper(configuration={

--- a/src/pretix/static/pretixcontrol/js/ui/editor.js
+++ b/src/pretix/static/pretixcontrol/js/ui/editor.js
@@ -29,10 +29,11 @@ fabric.Imagearea = fabric.util.createClass(fabric.Rect, {
 
         this.callSuper('initialize', text, options);
         this.set('label', options.label || '');
+        this.set('missing_image_transparent', options.missing_image_transparent || false);
     },
 
     toObject: function () {
-        return fabric.util.object.extend(this.callSuper('toObject'), {});
+        return fabric.util.object.extend(this.callSuper('toObject'), {missing_image_transparent: this.missing_image_transparent});
     },
 
     _render: function (ctx) {
@@ -311,6 +312,7 @@ var editor = {
                     height: editor._px2mm(o.height * o.scaleY).toFixed(2),
                     width: editor._px2mm(o.width * o.scaleX).toFixed(2),
                     content: o.content,
+                    missing_image_transparent: o.missing_image_transparent || false,
                 });
             } else  if (o.type === "barcodearea") {
                 col = (new fabric.Color(o.fill))._source;
@@ -367,6 +369,7 @@ var editor = {
             o.set('width', editor._mm2px(d.width));
             o.set('scaleX', 1);
             o.set('scaleY', 1);
+            o.missing_image_transparent = d.missing_image_transparent || false;
         } else if (d.type === "poweredby") {
             o = editor._add_poweredby(d.content);
             o.content = d.content;
@@ -654,6 +657,7 @@ var editor = {
             $("#toolbox-height").val(editor._px2mm(o.height * o.scaleY).toFixed(2));
             $("#toolbox-width").val(editor._px2mm(o.width * o.scaleX).toFixed(2));
             $("#toolbox-imagecontent").val(o.content);
+            $("#toolbox-image-transparent").prop("checked", o.missing_image_transparent || false);
         } else if (o.type === "poweredby") {
             $("#toolbox-squaresize").val(editor._px2mm(o.height * o.scaleY).toFixed(2));
             $("#toolbox-poweredby-style").val(o.content);
@@ -784,7 +788,9 @@ var editor = {
             o.set('scaleX', 1);
             o.set('scaleY', 1);
             o.set('top', new_top)
+            o.set('top', new_top)
             o.content = $("#toolbox-imagecontent").val();
+            o.missing_image_transparent = $("#toolbox-image-transparent").prop("checked");
         } else if (o.type === "poweredby") {
             var new_h = Math.max(1, editor._mm2px($("#toolbox-squaresize").val()));
             new_top += o.height * o.scaleY - new_h;


### PR DESCRIPTION
This PR adds an option to make the background transparent when no image is present, instead of displaying the grey box. The grey box option remains available, and the new behavior can be enabled optionally by checking the corresponding checkbox. Additionally, the image rotation is now respected based on its EXIF data.

<img width="370" height="362" alt="image" src="https://github.com/user-attachments/assets/34611a47-dafe-453b-8c3a-f036d95db780" />
