### PR TITLE
Remove back link from 404 error page (#23222967)

### DIFF
--- a/src/pretix/base/templates/404.html
+++ b/src/pretix/base/templates/404.html
@@ -8,9 +8,6 @@
         <h1>{% trans "Not found" %}</h1>
         <p>{% trans "I'm afraid we could not find the the resource you requested." %}</p>
         <p>{{ exception }}</p>
-        <p class="links">
-            <a id='goback' href='#'>{% trans "Take a step back" %}</a>
-        </p>
         {% if request.user.is_staff and not staff_session %}
             <form action="{% url 'control:user.sudo' %}?next={{ request.path|add:"?"|add:request.GET.urlencode|urlencode }}" method="post">
                 <p>


### PR DESCRIPTION
I've kept it for 400/403/500/csrffail for now, because they also have a "try again" link. Yes, both things have browser buttons, but they make it a *little* clearer to technical users what one could to next, and especially on csrffail, "step back" is always possible and possibly actually helpful.