### PR TITLE
Vouchers: Fix field label inconsistency (Z#23222887)

### DIFF
--- a/src/pretix/base/modelimport_vouchers.py
+++ b/src/pretix/base/modelimport_vouchers.py
@@ -132,7 +132,7 @@ class AllowIgnoreQuotaColumn(BooleanColumnMixin, ImportColumn):
 
 class PriceModeColumn(ImportColumn):
     identifier = 'price_mode'
-    verbose_name = gettext_lazy('Price mode')
+    verbose_name = gettext_lazy('Price effect')
     default_value = None
     initial = 'static:none'
 
@@ -147,7 +147,7 @@ class PriceModeColumn(ImportColumn):
         elif value in reverse:
             return reverse[value]
         else:
-            raise ValidationError(_("Could not parse {value} as a price mode, use one of {options}.").format(
+            raise ValidationError(_("Could not parse {value} as a price effect, use one of {options}.").format(
                 value=value, options=', '.join(d.keys())
             ))
 
@@ -162,7 +162,7 @@ class ValueColumn(DecimalColumnMixin, ImportColumn):
     def clean(self, value, previous_values):
         value = super().clean(value, previous_values)
         if value and previous_values.get("price_mode") == "none":
-            raise ValidationError(_("It is pointless to set a value without a price mode."))
+            raise ValidationError(_("It is pointless to set a value without a price effect."))
         return value
 
     def assign(self, value, obj: Voucher, **kwargs):

--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -239,7 +239,7 @@ class Voucher(LoggedModel):
         )
     )
     price_mode = models.CharField(
-        verbose_name=_("Price mode"),
+        verbose_name=_("Price effect"),
         max_length=100,
         choices=PRICE_MODES,
         default='none'

--- a/src/tests/base/test_modelimport_vouchers.py
+++ b/src/tests/base/test_modelimport_vouchers.py
@@ -170,7 +170,7 @@ def test_price_mode_validation(event, item, user):
         import_vouchers.apply(
             args=(event.pk, inputfile_factory().id, settings, 'en', user.pk)
         ).get()
-    assert 'It is pointless to set a value without a price mode.' in str(excinfo.value)
+    assert 'It is pointless to set a value without a price effect.' in str(excinfo.value)
 
     settings['price_mode'] = 'static:percent'
     import_vouchers.apply(


### PR DESCRIPTION
The field Voucher.price_mode is sometimes called "Price mode" and sometimes "Price effect" in the UI, which is inconsistent. I think "price effect" is a little clearer, but I don't really care as long as it is consistent.