### PR TITLE
include acceptor slug in log/webhook event (Z#23224691)

### DIFF
--- a/src/pretix/api/views/organizer.py
+++ b/src/pretix/api/views/organizer.py
@@ -259,7 +259,14 @@ class GiftCardViewSet(viewsets.ModelViewSet):
             action='pretix.giftcards.transaction.manual',
             user=self.request.user,
             auth=self.request.auth,
-            data=merge_dicts(self.request.data, {'id': inst.pk, 'acceptor_id': self.request.organizer.id})
+            data=merge_dicts(
+                self.request.data,
+                {
+                    'id': inst.pk,
+                    'acceptor_id': self.request.organizer.id,
+                    'acceptor_slug': self.request.organizer.slug
+                }
+            )
         )
 
     @transaction.atomic()
@@ -290,7 +297,11 @@ class GiftCardViewSet(viewsets.ModelViewSet):
                 action='pretix.giftcards.transaction.manual',
                 user=self.request.user,
                 auth=self.request.auth,
-                data={'value': diff, 'acceptor_id': self.request.organizer.id}
+                data={
+                    'value': diff,
+                    'acceptor_id': self.request.organizer.id,
+                    'acceptor_slug': self.request.organizer.slug
+                }
             )
 
         return inst
@@ -320,7 +331,8 @@ class GiftCardViewSet(viewsets.ModelViewSet):
             data={
                 'value': value,
                 'text': text,
-                'acceptor_id': self.request.organizer.id
+                'acceptor_id': self.request.organizer.id,
+                'acceptor_slug': self.request.organizer.slug
             }
         )
         return Response(GiftCardSerializer(gc, context=self.get_serializer_context()).data, status=status.HTTP_200_OK)

--- a/src/pretix/api/webhooks.py
+++ b/src/pretix/api/webhooks.py
@@ -198,6 +198,7 @@ class ParametrizedGiftcardTransactionWebhookEvent(ParametrizedWebhookEvent):
             'notification_id': logentry.pk,
             'issuer_id': logentry.organizer_id,
             'acceptor_id': logentry.parsed_data.get('acceptor_id'),
+            'acceptor_slug': logentry.parsed_data.get('acceptor_slug'),
             'giftcard': giftcard.pk,
             'action': logentry.action_type,
         }

--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -1650,7 +1650,8 @@ class GiftCardPayment(BasePaymentProvider):
                     action='pretix.giftcards.transaction.payment',
                     data={
                         'value': trans.value,
-                        'acceptor_id': self.event.organizer.id
+                        'acceptor_id': self.event.organizer.id,
+                        'acceptor_slug': self.event.organizer.slug
                     }
                 )
         except PaymentException as e:
@@ -1682,6 +1683,7 @@ class GiftCardPayment(BasePaymentProvider):
             data={
                 'value': refund.amount,
                 'acceptor_id': self.event.organizer.id,
+                'acceptor_slug': self.event.organizer.slug,
                 'text': refund.comment,
             }
         )

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -253,7 +253,8 @@ def reactivate_order(order: Order, force: bool=False, user: User=None, auth=None
                         auth=auth,
                         data={
                             'value': position.price,
-                            'acceptor_id': order.event.organizer.id
+                            'acceptor_id': order.event.organizer.id,
+                            'acceptor_slug': order.event.organizer.slug
                         }
                     )
                     break
@@ -563,6 +564,7 @@ def _cancel_order(order, user=None, send_mail: bool=True, api_token=None, device
                         data={
                             'value': -position.price,
                             'acceptor_id': order.event.organizer.id,
+                            'acceptor_slug': order.event.organizer.slug
                         }
                     )
 
@@ -2457,7 +2459,8 @@ class OrderChangeManager:
                             auth=self.auth,
                             data={
                                 'value': -position.price,
-                                'acceptor_id': self.order.event.organizer.id
+                                'acceptor_id': self.order.event.organizer.id,
+                                'acceptor_slug': self.order.event.organizer.slug
                             }
                         )
 
@@ -2483,7 +2486,8 @@ class OrderChangeManager:
                                 auth=self.auth,
                                 data={
                                     'value': -opa.position.price,
-                                    'acceptor_id': self.order.event.organizer.id
+                                    'acceptor_id': self.order.event.organizer.id,
+                                    'acceptor_slug': self.order.event.organizer.slug
                                 }
                             )
 
@@ -3453,6 +3457,7 @@ def signal_listener_issue_giftcards(sender: Event, order: Order, **kwargs):
                     data={
                         'value': trans.value,
                         'acceptor_id': order.event.organizer.id,
+                        'acceptor_slug': order.event.organizer.slug
                     }
                 )
                 any_giftcards = True

--- a/src/pretix/control/views/organizer.py
+++ b/src/pretix/control/views/organizer.py
@@ -1850,7 +1850,8 @@ class GiftCardDetailView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMi
                         data={
                             'value': value,
                             'text': request.POST.get('text'),
-                            'acceptor_id': self.request.organizer.id
+                            'acceptor_id': self.request.organizer.id,
+                            'acceptor_slug': self.request.organizer.slug
                         },
                         user=self.request.user,
                     )
@@ -1913,7 +1914,8 @@ class GiftCardCreateView(OrganizerDetailViewMixin, OrganizerPermissionRequiredMi
                 user=self.request.user,
                 data={
                     'value': form.cleaned_data['value'],
-                    'acceptor_id': self.request.organizer.id
+                    'acceptor_id': self.request.organizer.id,
+                    'acceptor_slug': self.request.organizer.slug
                 }
             )
         return redirect(reverse(


### PR DESCRIPTION
includes acceptor_slug alongside the acceptor_id to have both a stable internal reference for the audit log as well as a meaningful public identifier