### PR TITLE
Do not use partitioned cookies for Safari

### DIFF
--- a/src/pretix/helpers/cookies.py
+++ b/src/pretix/helpers/cookies.py
@@ -49,11 +49,11 @@ def set_cookie_without_samesite(request, response, key, *args, **kwargs):
         response.cookies[key]['Partitioned'] = True
 
         if has_safari_partitioned_bug(useragent):
-            # There may be partitioned cookies set from previous sessions, which override 
+            # There may be partitioned cookies set from previous sessions, which override
             # these non-partitioned ones. Delete these partitioned cookies.
             response.delete_cookie(key)
-            response.cookies[key+":Partitioned"] = response.cookies[key]
-            del(response.cookies[key])
+            response.cookies[key + ":Partitioned"] = response.cookies[key]
+            del response.cookies[key]
 
             # re-set the cookie without Partitioned
             response.set_cookie(key, *args, **kwargs)


### PR DESCRIPTION
#5843 fixed a bug in multi-hop-cross-site SSO-login steps in Safari, but introduced issues for users with exisiting session-cookies. The problem with the original code was, existing partitioned cookies were not deleted and took precedence over the newly introduced non-partitioned cookies. As long as the partitioned cookies contained a valid session, it works fine. But as soon as the session turned invalid, Safari users could not log in as long as the cookie was still in the browser.

This PR deletes any partitioned cookies before setting new non-partitioned cookies. As django does not allow to set cookies with the same key, this PR is kind of a hack sadly.

To reproduce you need to have a dev-setup with HTTPS and a current version of Safari.

1. Log into pretix-control before checking out this PR/branch. You should see your session-cookie with a Partition-Key. 
2. Checkout this PR/branch
3. To imitate an expired session, change the value in Safaris Session-Cookie to something else
4. Reload pretix-control => Login
5. Login - you now should not have any partitioned session-cookie