### PR TITLE
Email rate limits using sliding windows

### DIFF
--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -91,6 +91,7 @@ from pretix.presale.ical import get_private_icals
 
 logger = logging.getLogger('pretix.base.mail')
 INVALID_ADDRESS = 'invalid-pretix-mail-address'
+MIN_RATE_LIMIT_RETRY_AFTER = 5  # Minimum seconds before retrying a rate-limited email
 
 
 class TolerantDict(dict):
@@ -1044,49 +1045,62 @@ def _wrap_plain_body(content_plain, signature, event, order, position, no_order_
 
 def _check_rate_limit(backend, outgoing_mail):
     """
-    Fixed-window Redis counter keyed by SMTP identity + time bucket.
-    Returns (is_limited: bool, retry_after_seconds: int).
+    Check whether sending this email would exceed the configured rate limit
+    for the SMTP identity used by the event/organizer. Multiple events sharing
+    the same SMTP credentials share a single counter.
+    Returns (is_limited, retry_after_seconds).
     """
     if not settings.HAS_REDIS:
         return False, 0
 
-    # Resolve rate limit settings via hierarkey (event → organizer → global)
     event = getattr(outgoing_mail, 'event', None)
-    if event:
-        count = event.settings.get('smtp_rate_limit_count', as_type=int)
-        window = event.settings.get('smtp_rate_limit_window', as_type=int)
-    elif outgoing_mail.organizer:
-        count = outgoing_mail.organizer.settings.get('smtp_rate_limit_count', as_type=int)
-        window = outgoing_mail.organizer.settings.get('smtp_rate_limit_window', as_type=int)
+    organizer = getattr(outgoing_mail, 'organizer', None)
+    settings_source = event or organizer
+
+    count, window = None, None
+    if settings_source and settings_source.settings.get('smtp_use_custom', as_type=bool):
+        # Custom SMTP: use event/organizer settings, never pretix.cfg
+        count = settings_source.settings.get('smtp_rate_limit_count', as_type=int)
+        window = settings_source.settings.get('smtp_rate_limit_window', as_type=int)
     else:
-        count, window = 0, 600
+        # System SMTP: always use pretix.cfg limits
+        if settings.EMAIL_RATE_LIMIT_COUNT is not None:
+            count = settings.EMAIL_RATE_LIMIT_COUNT
+            window = settings.EMAIL_RATE_LIMIT_WINDOW
 
-    # Fallback to pretix.cfg
-    if not count and settings.EMAIL_RATE_LIMIT_COUNT:
-        count = settings.EMAIL_RATE_LIMIT_COUNT
-        window = settings.EMAIL_RATE_LIMIT_WINDOW
-
-    if not count:
+    if count is None or window is None:
         return False, 0
 
-    # Key by SMTP identity
     host = getattr(backend, 'host', settings.EMAIL_HOST) or '_'
     username = getattr(backend, 'username', settings.EMAIL_HOST_USER) or '_'
     identity = hashlib.sha1(f"{username}@{host}".encode()).hexdigest()
-
-    window_id = int(time.time()) // window
-    redis_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
+    redis_key = f"pretix_mail_ratelimit_{identity}"
 
     from django_redis import get_redis_connection
     rc = get_redis_connection("redis")
 
-    cnt = rc.incr(redis_key)
-    if cnt == 1:
-        rc.expire(redis_key, window + 10)
+    now_ts = time.time()
+    member = f"{now_ts}:{uuid.uuid4().hex[:8]}"
+
+    # Sliding-window rate limit: prune expired entries, record this attempt,
+    # count hits in the window, and fetch the oldest entry for retry-after.
+    pipe = rc.pipeline()
+    pipe.zremrangebyscore(redis_key, '-inf', now_ts - settings.EMAIL_RATE_LIMIT_MAX_WINDOW)
+    pipe.zadd(redis_key, {member: now_ts})
+    pipe.zcount(redis_key, now_ts - window, '+inf')
+    pipe.expire(redis_key, settings.EMAIL_RATE_LIMIT_MAX_WINDOW + 10)
+    pipe.zrange(redis_key, 0, 0, withscores=True)
+    _, _, cnt, _, oldest = pipe.execute()
 
     if cnt > count:
-        ttl = rc.ttl(redis_key)
-        retry_after = max(ttl if ttl and ttl > 0 else 10, 5)
+        # Remove the just-added entry so blocked attempts don't inflate the counter
+        rc.zrem(redis_key, member)
+        # Oldest entry's timestamp + window = when the first slot frees up
+        if oldest:
+            retry_after = int(oldest[0][1]) + window - now_ts
+            retry_after = max(int(retry_after) + 1, MIN_RATE_LIMIT_RETRY_AFTER)
+        else:
+            retry_after = MIN_RATE_LIMIT_RETRY_AFTER
         return True, retry_after
 
     return False, 0

--- a/src/pretix/base/services/mail.py
+++ b/src/pretix/base/services/mail.py
@@ -39,6 +39,7 @@ import mimetypes
 import os
 import re
 import smtplib
+import time
 import uuid
 import warnings
 from datetime import timedelta
@@ -435,6 +436,22 @@ def mail_send_task(self, **kwargs) -> bool:
         assert outgoing_mail.orderposition.order_id == outgoing_mail.order_id
         outgoing_mail.orderposition.order = outgoing_mail.order
 
+    # Rate limit check
+    backend = outgoing_mail.get_mail_backend()
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    if is_limited:
+        logger.info(f"Rate limited email {outgoing_mail.guid}, retrying in {retry_after}s")
+        outgoing_mail.status = OutgoingMail.STATUS_AWAITING_RETRY
+        outgoing_mail.retry_after = now() + timedelta(seconds=retry_after)
+        outgoing_mail.save(update_fields=["status", "retry_after"])
+        try:
+            self.retry(max_retries=100, countdown=retry_after)
+        except MaxRetriesExceededError:
+            outgoing_mail.status = OutgoingMail.STATUS_FAILED
+            outgoing_mail.retry_after = None
+            outgoing_mail.save(update_fields=["status", "retry_after"])
+            return False
+
     headers = dict(outgoing_mail.headers)
     headers.setdefault('X-PX-Correlation', str(outgoing_mail.guid))
     email = CustomEmail(
@@ -647,7 +664,6 @@ def mail_send_task(self, **kwargs) -> bool:
                 "type": a[2],
             } for a in email.attachments
         ]
-        backend = outgoing_mail.get_mail_backend()
         try:
             backend.send_messages([email])
         except Exception as e:
@@ -1024,6 +1040,56 @@ def _wrap_plain_body(content_plain, signature, event, order, position, no_order_
     body_plain += "\r\n"
 
     return body_plain
+
+
+def _check_rate_limit(backend, outgoing_mail):
+    """
+    Fixed-window Redis counter keyed by SMTP identity + time bucket.
+    Returns (is_limited: bool, retry_after_seconds: int).
+    """
+    if not settings.HAS_REDIS:
+        return False, 0
+
+    # Resolve rate limit settings via hierarkey (event → organizer → global)
+    event = getattr(outgoing_mail, 'event', None)
+    if event:
+        count = event.settings.get('smtp_rate_limit_count', as_type=int)
+        window = event.settings.get('smtp_rate_limit_window', as_type=int)
+    elif outgoing_mail.organizer:
+        count = outgoing_mail.organizer.settings.get('smtp_rate_limit_count', as_type=int)
+        window = outgoing_mail.organizer.settings.get('smtp_rate_limit_window', as_type=int)
+    else:
+        count, window = 0, 600
+
+    # Fallback to pretix.cfg
+    if not count and settings.EMAIL_RATE_LIMIT_COUNT:
+        count = settings.EMAIL_RATE_LIMIT_COUNT
+        window = settings.EMAIL_RATE_LIMIT_WINDOW
+
+    if not count:
+        return False, 0
+
+    # Key by SMTP identity
+    host = getattr(backend, 'host', settings.EMAIL_HOST) or '_'
+    username = getattr(backend, 'username', settings.EMAIL_HOST_USER) or '_'
+    identity = hashlib.sha1(f"{username}@{host}".encode()).hexdigest()
+
+    window_id = int(time.time()) // window
+    redis_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
+
+    from django_redis import get_redis_connection
+    rc = get_redis_connection("redis")
+
+    cnt = rc.incr(redis_key)
+    if cnt == 1:
+        rc.expire(redis_key, window + 10)
+
+    if cnt > count:
+        ttl = rc.ttl(redis_key)
+        retry_after = max(ttl if ttl and ttl > 0 else 10, 5)
+        return True, retry_after
+
+    return False, 0
 
 
 def _retry_strategy(e: Exception):

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3061,11 +3061,11 @@ Your {organizer} team"""))  # noqa: W291
         'type': bool
     },
     'smtp_rate_limit_count': {
-        'default': '0',
+        'default': None,
         'type': int,
     },
     'smtp_rate_limit_window': {
-        'default': '600',
+        'default': None,
         'type': int,
     },
     'primary_color': {

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -3060,6 +3060,14 @@ Your {organizer} team"""))  # noqa: W291
         'default': 'False',
         'type': bool
     },
+    'smtp_rate_limit_count': {
+        'default': '0',
+        'type': int,
+    },
+    'smtp_rate_limit_window': {
+        'default': '600',
+        'type': int,
+    },
     'primary_color': {
         'default': settings.PRETIX_PRIMARY_COLOR,
         'type': str,

--- a/src/pretix/control/forms/global_settings.py
+++ b/src/pretix/control/forms/global_settings.py
@@ -104,7 +104,20 @@ class GlobalSettingsForm(SettingsForm):
                 help_text=_("Will be served at {domain}/.well-known/apple-developer-merchantid-domain-association").format(
                     domain=settings.SITE_URL
                 )
-            ))
+            )),
+            ('smtp_rate_limit_count', forms.IntegerField(
+                required=False,
+                label=_("Email rate limit (number of emails)"),
+                help_text=_("Maximum number of emails per time window through the default SMTP server. "
+                            "Set to 0 or leave empty to disable. Shared across all workers."),
+                min_value=0,
+            )),
+            ('smtp_rate_limit_window', forms.IntegerField(
+                required=False,
+                label=_("Email rate limit window (seconds)"),
+                help_text=_("Time window in seconds for the email rate limit. Default: 600 (10 minutes)."),
+                min_value=1,
+            )),
         ])
         responses = register_global_settings.send(self)
         for r, response in sorted(responses, key=lambda r: str(r[0])):

--- a/src/pretix/control/forms/global_settings.py
+++ b/src/pretix/control/forms/global_settings.py
@@ -35,6 +35,7 @@
 from collections import OrderedDict
 
 from django import forms
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from i18nfield.forms import I18nFormField, I18nTextInput
 
@@ -109,14 +110,18 @@ class GlobalSettingsForm(SettingsForm):
                 required=False,
                 label=_("Email rate limit (number of emails)"),
                 help_text=_("Maximum number of emails per time window through the default SMTP server. "
-                            "Set to 0 or leave empty to disable. Shared across all workers."),
+                            "Leave empty to disable. Set to 0 to block all emails. Shared across all workers."),
                 min_value=0,
             )),
             ('smtp_rate_limit_window', forms.IntegerField(
                 required=False,
                 label=_("Email rate limit window (seconds)"),
-                help_text=_("Time window in seconds for the email rate limit. Default: 600 (10 minutes)."),
+                help_text=format_lazy(
+                    _("Time window in seconds for the email rate limit. Maximum: {max_window} seconds."),
+                    max_window=settings.EMAIL_RATE_LIMIT_MAX_WINDOW,
+                ),
                 min_value=1,
+                max_value=settings.EMAIL_RATE_LIMIT_MAX_WINDOW,
             )),
         ])
         responses = register_global_settings.send(self)

--- a/src/pretix/control/forms/mailsetup.py
+++ b/src/pretix/control/forms/mailsetup.py
@@ -76,6 +76,19 @@ class SMTPMailForm(SettingsForm):
         help_text=_("Commonly enabled on port 465."),
         required=False
     )
+    smtp_rate_limit_count = forms.IntegerField(
+        label=_("Email rate limit (number of emails)"),
+        help_text=_("Maximum number of emails per time window. Set to 0 or leave empty to disable. "
+                    "Shared across all workers."),
+        required=False,
+        min_value=0,
+    )
+    smtp_rate_limit_window = forms.IntegerField(
+        label=_("Email rate limit window (seconds)"),
+        help_text=_("Time window in seconds for the email rate limit. Default: 600 (10 minutes)."),
+        required=False,
+        min_value=1,
+    )
 
     def clean(self):
         data = super().clean()

--- a/src/pretix/control/forms/mailsetup.py
+++ b/src/pretix/control/forms/mailsetup.py
@@ -78,16 +78,20 @@ class SMTPMailForm(SettingsForm):
     )
     smtp_rate_limit_count = forms.IntegerField(
         label=_("Email rate limit (number of emails)"),
-        help_text=_("Maximum number of emails per time window. Set to 0 or leave empty to disable. "
-                    "Shared across all workers."),
+        help_text=_("Maximum number of emails per time window. Leave empty to disable. "
+                    "Set to 0 to block all emails. Shared across all workers."),
         required=False,
         min_value=0,
     )
     smtp_rate_limit_window = forms.IntegerField(
         label=_("Email rate limit window (seconds)"),
-        help_text=_("Time window in seconds for the email rate limit. Default: 600 (10 minutes)."),
+        help_text=format_lazy(
+            _("Time window in seconds for the email rate limit. Maximum: {max_window} seconds."),
+            max_window=settings.EMAIL_RATE_LIMIT_MAX_WINDOW,
+        ),
         required=False,
         min_value=1,
+        max_value=settings.EMAIL_RATE_LIMIT_MAX_WINDOW,
     )
 
     def clean(self):

--- a/src/pretix/control/templates/pretixcontrol/email_setup.html
+++ b/src/pretix/control/templates/pretixcontrol/email_setup.html
@@ -94,7 +94,23 @@
                                 email sending.
                             {% endblocktrans %}
                         </p>
-                        {% bootstrap_form smtp_form layout="control" %}
+                        {% bootstrap_field smtp_form.mail_from layout="control" %}
+                        {% bootstrap_field smtp_form.smtp_host layout="control" %}
+                        {% bootstrap_field smtp_form.smtp_port layout="control" %}
+                        {% bootstrap_field smtp_form.smtp_username layout="control" %}
+                        {% bootstrap_field smtp_form.smtp_password layout="control" %}
+                        {% bootstrap_field smtp_form.smtp_use_tls layout="control" %}
+                        {% bootstrap_field smtp_form.smtp_use_ssl layout="control" %}
+                        <p>
+                            <a data-toggle="collapse" href="#smtp_advanced">
+                                {% trans "Advanced settings" %}
+                                <span class="fa fa-caret-down"></span>
+                            </a>
+                        </p>
+                        <div class="collapse{% if smtp_form.smtp_rate_limit_count.value %} in{% endif %}" id="smtp_advanced">
+                            {% bootstrap_field smtp_form.smtp_rate_limit_count layout="control" %}
+                            {% bootstrap_field smtp_form.smtp_rate_limit_window layout="control" %}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/pretix/control/views/mailsetup.py
+++ b/src/pretix/control/views/mailsetup.py
@@ -39,6 +39,10 @@ from pretix.control.forms.filter import OrganizerFilterForm
 from pretix.control.forms.mailsetup import SimpleMailForm, SMTPMailForm
 
 logger = logging.getLogger(__name__)
+SMTP_SETTINGS_TO_CLEAR = (
+    'smtp_host', 'smtp_port', 'smtp_username', 'smtp_password',
+    'smtp_use_tls', 'smtp_use_ssl', 'smtp_rate_limit_count', 'smtp_rate_limit_window',
+)
 
 
 def get_spf_record(hostname):
@@ -142,24 +146,16 @@ class MailSettingsSetupView(TemplateView):
             else:
                 del self.object.settings.mail_from
             self.object.settings.smtp_use_custom = False
-            del self.object.settings.smtp_host
-            del self.object.settings.smtp_port
-            del self.object.settings.smtp_username
-            del self.object.settings.smtp_password
-            del self.object.settings.smtp_use_tls
-            del self.object.settings.smtp_use_ssl
+            for key in SMTP_SETTINGS_TO_CLEAR:
+                self.object.settings.delete(key)
             messages.success(request, _('Your changes have been saved.'))
             return redirect(self.get_success_url())
 
         elif request.POST.get('mode') == 'reset':
             del self.object.settings.mail_from
             del self.object.settings.smtp_use_custom
-            del self.object.settings.smtp_host
-            del self.object.settings.smtp_port
-            del self.object.settings.smtp_username
-            del self.object.settings.smtp_password
-            del self.object.settings.smtp_use_tls
-            del self.object.settings.smtp_use_ssl
+            for key in SMTP_SETTINGS_TO_CLEAR:
+                self.object.settings.delete(key)
             messages.success(request, _('Your changes have been saved.'))
             return redirect(self.get_success_url())
 
@@ -176,12 +172,8 @@ class MailSettingsSetupView(TemplateView):
 
             if allow_save:
                 self.object.settings.smtp_use_custom = False
-                del self.object.settings.smtp_host
-                del self.object.settings.smtp_port
-                del self.object.settings.smtp_username
-                del self.object.settings.smtp_password
-                del self.object.settings.smtp_use_tls
-                del self.object.settings.smtp_use_ssl
+                for key in SMTP_SETTINGS_TO_CLEAR:
+                    self.object.settings.delete(key)
                 for k, v in self.simple_form.cleaned_data.items():
                     self.object.settings.set(k, v)
                 self.log_action(self.simple_form.cleaned_data)

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -250,6 +250,8 @@ EMAIL_USE_SSL = config.getboolean('mail', 'ssl', fallback=False)
 EMAIL_SUBJECT_PREFIX = '[pretix] '
 EMAIL_BACKEND = EMAIL_CUSTOM_SMTP_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_TIMEOUT = 60
+EMAIL_RATE_LIMIT_COUNT = config.getint('mail', 'rate_limit_count', fallback=0)
+EMAIL_RATE_LIMIT_WINDOW = config.getint('mail', 'rate_limit_window', fallback=600)
 
 ADMINS = [('Admin', n) for n in config.get('mail', 'admins', fallback='').split(",") if n]
 

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -250,8 +250,9 @@ EMAIL_USE_SSL = config.getboolean('mail', 'ssl', fallback=False)
 EMAIL_SUBJECT_PREFIX = '[pretix] '
 EMAIL_BACKEND = EMAIL_CUSTOM_SMTP_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_TIMEOUT = 60
-EMAIL_RATE_LIMIT_COUNT = config.getint('mail', 'rate_limit_count', fallback=0)
-EMAIL_RATE_LIMIT_WINDOW = config.getint('mail', 'rate_limit_window', fallback=600)
+EMAIL_RATE_LIMIT_COUNT = config.getint('mail', 'rate_limit_count', fallback=None)
+EMAIL_RATE_LIMIT_WINDOW = config.getint('mail', 'rate_limit_window', fallback=None)
+EMAIL_RATE_LIMIT_MAX_WINDOW = config.getint('mail', 'rate_limit_max_window', fallback=24 * 60 * 60)
 
 ADMINS = [('Admin', n) for n in config.get('mail', 'admins', fallback='').split(",") if n]
 

--- a/src/tests/base/test_mail.py
+++ b/src/tests/base/test_mail.py
@@ -55,7 +55,7 @@ from pretix.base.email import get_email_context
 from pretix.base.models import (
     Event, InvoiceAddress, Order, Organizer, OutgoingMail, User,
 )
-from pretix.base.services.mail import _check_rate_limit, mail, mail_send_task
+from pretix.base.services.mail import MIN_RATE_LIMIT_RETRY_AFTER, _check_rate_limit, mail, mail_send_task
 
 
 @pytest.fixture
@@ -606,13 +606,25 @@ def test_rate_limit_disabled_without_redis():
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_RATE_LIMIT_COUNT=0, EMAIL_RATE_LIMIT_WINDOW=1800)
-def test_rate_limit_disabled_when_count_zero(env, fakeredis_client):
+@override_settings(EMAIL_RATE_LIMIT_COUNT=None, EMAIL_RATE_LIMIT_WINDOW=None)
+def test_rate_limit_disabled_when_not_configured(env, fakeredis_client):
+    """When no rate limit is configured (None), all emails are allowed."""
     backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
     outgoing_mail = SimpleNamespace(organizer=None)
     is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
     assert is_limited is False
     assert retry_after == 0
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=0, EMAIL_RATE_LIMIT_WINDOW=60)
+def test_rate_limit_blocks_all_when_count_zero(env, fakeredis_client):
+    """count=0 means zero emails allowed, not 'disabled'."""
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=None)
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True
+    assert retry_after >= MIN_RATE_LIMIT_RETRY_AFTER
 
 
 @pytest.mark.django_db
@@ -628,71 +640,210 @@ def test_rate_limit_allows_under_limit(env, fakeredis_client):
 @pytest.mark.django_db
 @override_settings(EMAIL_RATE_LIMIT_COUNT=5, EMAIL_RATE_LIMIT_WINDOW=1800)
 def test_rate_limit_blocks_when_exceeded(env, fakeredis_client):
-    window_id = int(time.time()) // 1800
-    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
-    redis_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
-    fakeredis_client.set(redis_key, 5)
-    fakeredis_client.expire(redis_key, 1800)
-
     backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
     outgoing_mail = SimpleNamespace(organizer=None)
+
+    # First 5 should pass
+    for _ in range(5):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+        assert is_limited is False
+
+    # 6th should be blocked
     is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
     assert is_limited is True
-    assert retry_after >= 5
+    assert retry_after >= MIN_RATE_LIMIT_RETRY_AFTER
 
 
 @pytest.mark.django_db
-@override_settings(EMAIL_RATE_LIMIT_COUNT=5, EMAIL_RATE_LIMIT_WINDOW=1800)
+@override_settings(EMAIL_RATE_LIMIT_COUNT=3, EMAIL_RATE_LIMIT_WINDOW=1800)
 def test_rate_limit_separate_keys_per_backend(env, fakeredis_client):
     backend_a = SimpleNamespace(host='smtp-a.example.com', username='a@example.com')
     backend_b = SimpleNamespace(host='smtp-b.example.com', username='b@example.com')
     outgoing_mail = SimpleNamespace(organizer=None)
 
-    _check_rate_limit(backend_a, outgoing_mail)
-    _check_rate_limit(backend_b, outgoing_mail)
+    # Use up all 3 slots on backend_a
+    for _ in range(3):
+        _check_rate_limit(backend_a, outgoing_mail)
 
-    # Should have incremented two different keys (check via redis scan)
-    keys = [k for k in fakeredis_client.keys('pretix_mail_ratelimit_*')]
-    assert len(keys) == 2
+    # backend_b should still be allowed (separate counter)
+    is_limited, _ = _check_rate_limit(backend_b, outgoing_mail)
+    assert is_limited is False
 
-
-@pytest.mark.django_db
-@override_settings(EMAIL_RATE_LIMIT_COUNT=100, EMAIL_RATE_LIMIT_WINDOW=1800)
-def test_rate_limit_organizer_overrides_global(env, fakeredis_client):
-    event, user, organizer = env
-    organizer.settings.set('smtp_rate_limit_count', 3)
-    organizer.settings.set('smtp_rate_limit_window', 600)
-
-    # Pre-populate current window key at the organizer limit
-    window_id = int(time.time()) // 600
-    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
-    current_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
-    fakeredis_client.set(current_key, 3)
-
-    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
-    outgoing_mail = SimpleNamespace(organizer=organizer, event=None)
-
-    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    # backend_a should be blocked
+    is_limited, _ = _check_rate_limit(backend_a, outgoing_mail)
     assert is_limited is True
 
 
 @pytest.mark.django_db
 @override_settings(EMAIL_RATE_LIMIT_COUNT=100, EMAIL_RATE_LIMIT_WINDOW=1800)
-def test_rate_limit_event_overrides_organizer(env, fakeredis_client):
+def test_rate_limit_custom_smtp_uses_organizer_settings(env, fakeredis_client):
+    """Custom SMTP: organizer rate limit settings are used, not pretix.cfg."""
     event, user, organizer = env
+    organizer.settings.set('smtp_use_custom', True)
+    organizer.settings.set('smtp_rate_limit_count', 3)
+    organizer.settings.set('smtp_rate_limit_window', 600)
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=organizer, event=None)
+
+    # First 3 should pass (organizer limit=3, not pretix.cfg 100)
+    for _ in range(3):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+        assert is_limited is False
+
+    # 4th should be blocked by organizer limit
+    is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=100, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_custom_smtp_event_overrides_organizer(env, fakeredis_client):
+    """Custom SMTP: event-level limit overrides organizer limit."""
+    event, user, organizer = env
+    organizer.settings.set('smtp_use_custom', True)
     organizer.settings.set('smtp_rate_limit_count', 50)
     organizer.settings.set('smtp_rate_limit_window', 1800)
     event.settings.set('smtp_rate_limit_count', 2)
     event.settings.set('smtp_rate_limit_window', 300)
 
-    # Pre-populate current window key at the event limit (window=300)
-    window_id = int(time.time()) // 300
-    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
-    current_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
-    fakeredis_client.set(current_key, 2)
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=organizer, event=event)
+
+    # First 2 should pass (event limit=2, not organizer 50)
+    for _ in range(2):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+        assert is_limited is False
+
+    # 3rd should be blocked by event limit
+    is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=3, EMAIL_RATE_LIMIT_WINDOW=600)
+def test_rate_limit_system_smtp_uses_global_ignores_event_overrides(env, fakeredis_client):
+    """System SMTP: pretix.cfg limits always apply, event/organizer overrides are ignored."""
+    event, user, organizer = env
+    # Not using custom SMTP (system server)
+    organizer.settings.set('smtp_use_custom', False)
+    # Event tries to set a more generous limit — should be ignored
+    event.settings.set('smtp_rate_limit_count', 100)
+    event.settings.set('smtp_rate_limit_window', 1800)
 
     backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
     outgoing_mail = SimpleNamespace(organizer=organizer, event=event)
 
-    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    # First 3 should pass (pretix.cfg limit=3, not event's 100)
+    for _ in range(3):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+        assert is_limited is False
+
+    # 4th should be blocked by pretix.cfg limit
+    is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=None, EMAIL_RATE_LIMIT_WINDOW=None)
+def test_rate_limit_custom_smtp_no_limit_when_unconfigured(env, fakeredis_client):
+    """Custom SMTP with no rate limit configured: no limits applied."""
+    event, user, organizer = env
+    organizer.settings.set('smtp_use_custom', True)
+    # No rate limit settings configured on event or organizer
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=organizer, event=event)
+
+    # Should never be limited — no pretix.cfg fallback for custom SMTP
+    for _ in range(20):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail)
+        assert is_limited is False
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=None, EMAIL_RATE_LIMIT_WINDOW=None)
+def test_rate_limit_different_windows_share_counter(env, fakeredis_client):
+    """Events with different window sizes on the same SMTP identity must share
+    the same underlying counter, not create additive independent counters."""
+    event, user, organizer = env
+    organizer.settings.set('smtp_use_custom', True)
+    event.settings.set('smtp_rate_limit_count', 5)
+    event.settings.set('smtp_rate_limit_window', 30)
+
+    # Create a second event on the same organizer
+    event_b = Event.objects.create(
+        organizer=organizer, name='Event B', slug='eventb',
+        date_from=datetime.datetime(2017, 12, 27, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        live=True,
+    )
+    event_b.settings.set('smtp_rate_limit_count', 10)
+    event_b.settings.set('smtp_rate_limit_window', 60)
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail_a = SimpleNamespace(organizer=organizer, event=event)
+    outgoing_mail_b = SimpleNamespace(organizer=organizer, event=event_b)
+
+    # Send 5 emails via Event A — should exhaust Event A's limit
+    for _ in range(5):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail_a)
+        assert is_limited is False
+
+    # Event A should now be blocked
+    is_limited, _ = _check_rate_limit(backend, outgoing_mail_a)
+    assert is_limited is True
+
+    # Event B has limit=10 but the same SMTP identity already has 5 sends recorded.
+    # Blocked attempts are not counted, so Event B has 5 slots left.
+    for _ in range(5):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail_b)
+        assert is_limited is False
+
+    # Event B should now be blocked too (total sends via this SMTP = 10)
+    is_limited, _ = _check_rate_limit(backend, outgoing_mail_b)
+    assert is_limited is True
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=None, EMAIL_RATE_LIMIT_WINDOW=None)
+def test_rate_limit_short_window_does_not_prune_long_window_entries(env, fakeredis_client):
+    """A caller with a short window must not prune entries that a caller with a
+    longer window still needs to count."""
+    event, user, organizer = env
+    organizer.settings.set('smtp_use_custom', True)
+    event.settings.set('smtp_rate_limit_count', 100)
+    event.settings.set('smtp_rate_limit_window', 10)
+
+    event_b = Event.objects.create(
+        organizer=organizer, name='Event B', slug='eventb',
+        date_from=datetime.datetime(2017, 12, 27, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        live=True,
+    )
+    event_b.settings.set('smtp_rate_limit_count', 3)
+    event_b.settings.set('smtp_rate_limit_window', 60)
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail_a = SimpleNamespace(organizer=organizer, event=event)
+    outgoing_mail_b = SimpleNamespace(organizer=organizer, event=event_b)
+
+    # Send 3 emails via Event B (window=60, count=3) — uses up Event B's limit
+    for _ in range(3):
+        is_limited, _ = _check_rate_limit(backend, outgoing_mail_b)
+        assert is_limited is False
+
+    # Simulate time passing: entries are now 15s old (outside Event A's 10s window,
+    # but inside Event B's 60s window)
+    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
+    redis_key = f"pretix_mail_ratelimit_{identity}"
+    # Shift all existing entries 15 seconds into the past
+    members = fakeredis_client.zrange(redis_key, 0, -1, withscores=True)
+    for member, score in members:
+        fakeredis_client.zadd(redis_key, {member: score - 15})
+
+    # Now send via Event A (window=10) — this must NOT prune the 15s-old entries
+    _check_rate_limit(backend, outgoing_mail_a)
+
+    # Event B should still be blocked — those 3 entries from 15s ago are within
+    # its 60s window and must still be counted
+    is_limited, _ = _check_rate_limit(backend, outgoing_mail_b)
     assert is_limited is True

--- a/src/tests/base/test_mail.py
+++ b/src/tests/base/test_mail.py
@@ -33,10 +33,13 @@
 # License for the specific language governing permissions and limitations under the License.
 
 import datetime
+import hashlib
 import os
 import re
+import time
 from decimal import Decimal
 from email.mime.text import MIMEText
+from types import SimpleNamespace
 
 import pytest
 from django.conf import settings
@@ -52,7 +55,7 @@ from pretix.base.email import get_email_context
 from pretix.base.models import (
     Event, InvoiceAddress, Order, Organizer, OutgoingMail, User,
 )
-from pretix.base.services.mail import mail, mail_send_task
+from pretix.base.services.mail import _check_rate_limit, mail, mail_send_task
 
 
 @pytest.fixture
@@ -591,3 +594,105 @@ def test_attached_ical_localization(env, order):
         assert len(djmail.outbox) == 1
         assert len(djmail.outbox[0].attachments) == 1
         assert description in djmail.outbox[0].attachments[0][1]
+
+
+@override_settings(HAS_REDIS=False, EMAIL_RATE_LIMIT_COUNT=10, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_disabled_without_redis():
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=None)
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is False
+    assert retry_after == 0
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=0, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_disabled_when_count_zero(env, fakeredis_client):
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=None)
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is False
+    assert retry_after == 0
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=5, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_allows_under_limit(env, fakeredis_client):
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=None)
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is False
+    assert retry_after == 0
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=5, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_blocks_when_exceeded(env, fakeredis_client):
+    window_id = int(time.time()) // 1800
+    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
+    redis_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
+    fakeredis_client.set(redis_key, 5)
+    fakeredis_client.expire(redis_key, 1800)
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=None)
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True
+    assert retry_after >= 5
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=5, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_separate_keys_per_backend(env, fakeredis_client):
+    backend_a = SimpleNamespace(host='smtp-a.example.com', username='a@example.com')
+    backend_b = SimpleNamespace(host='smtp-b.example.com', username='b@example.com')
+    outgoing_mail = SimpleNamespace(organizer=None)
+
+    _check_rate_limit(backend_a, outgoing_mail)
+    _check_rate_limit(backend_b, outgoing_mail)
+
+    # Should have incremented two different keys (check via redis scan)
+    keys = [k for k in fakeredis_client.keys('pretix_mail_ratelimit_*')]
+    assert len(keys) == 2
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=100, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_organizer_overrides_global(env, fakeredis_client):
+    event, user, organizer = env
+    organizer.settings.set('smtp_rate_limit_count', 3)
+    organizer.settings.set('smtp_rate_limit_window', 600)
+
+    # Pre-populate current window key at the organizer limit
+    window_id = int(time.time()) // 600
+    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
+    current_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
+    fakeredis_client.set(current_key, 3)
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=organizer, event=None)
+
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_RATE_LIMIT_COUNT=100, EMAIL_RATE_LIMIT_WINDOW=1800)
+def test_rate_limit_event_overrides_organizer(env, fakeredis_client):
+    event, user, organizer = env
+    organizer.settings.set('smtp_rate_limit_count', 50)
+    organizer.settings.set('smtp_rate_limit_window', 1800)
+    event.settings.set('smtp_rate_limit_count', 2)
+    event.settings.set('smtp_rate_limit_window', 300)
+
+    # Pre-populate current window key at the event limit (window=300)
+    window_id = int(time.time()) // 300
+    identity = hashlib.sha1(b"user@example.com@smtp.example.com").hexdigest()
+    current_key = f"pretix_mail_ratelimit_{identity}_{window_id}"
+    fakeredis_client.set(current_key, 2)
+
+    backend = SimpleNamespace(host='smtp.example.com', username='user@example.com')
+    outgoing_mail = SimpleNamespace(organizer=organizer, event=event)
+
+    is_limited, retry_after = _check_rate_limit(backend, outgoing_mail)
+    assert is_limited is True


### PR DESCRIPTION
After we figured out that my initial approach (https://github.com/pretix/pretix/pull/5866) was a little naive and only worked reliably using one worker, this time I worked on a more sophisticated solution making rate limiting emails work via fixed windows and making it configurable per smtp client

**Why:** Our email provider limits sending to a fixed number of emails per time window.                                                                                                           
                                                                                                                                                                                         
**How it works:** A shared Redis counter tracks how many emails have been sent through each SMTP server within a configurable time window. When the limit is reached, emails are deferred and  automatically retried after the window resets.
                                                                                                                                                                                         
Configuration (in order of priority):
- Per-event or per-organizer: in the SMTP setup under "Advanced settings"
- System-wide via pretix.cfg: [mail] → rate_limit_count / rate_limit_window                                                                                                                
- Global admin UI: Settings → Email rate limit                             
                                                                                                                                                                                         
Set count to 0 (default) to disable. If no Redis is available, rate limiting is silently skipped. 

<img width="2314" height="1568" alt="Bildschirmfoto 2026-03-17 um 10 50 08" src="https://github.com/user-attachments/assets/9c9c833b-3bf1-423d-92b4-b1b10aa59bcb" />

Btw: I wasn't sure how translations are handled - like should I provide them in the MR or are they automatically generated using e.g. crowdin or so ?
