### PR TITLE
Add `voucher_filter_qs` signal for plugin-based voucher filtering

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -76,7 +76,7 @@ Vouchers
 
 .. automodule:: pretix.control.signals
    :no-index:
-   :members: item_forms, voucher_form_class, voucher_form_html, voucher_form_validation
+   :members: item_forms, voucher_form_class, voucher_form_html, voucher_form_validation, voucher_filter_qs
 
 Dashboards
 """"""""""

--- a/src/pretix/control/forms/vouchers.py
+++ b/src/pretix/control/forms/vouchers.py
@@ -106,6 +106,11 @@ class VoucherForm(I18nModelForm):
                 pass
         super().__init__(*args, **kwargs)
 
+        self.fields['tag'].widget.attrs['data-typeahead-url'] = reverse('control:event.vouchers.tags.typeahead', kwargs={
+            'event': instance.event.slug,
+            'organizer': instance.event.organizer.slug,
+        })
+
         if instance.event.has_subevents:
             self.fields['subevent'].queryset = instance.event.subevents.all()
             self.fields['subevent'].widget = Select2(

--- a/src/pretix/control/signals.py
+++ b/src/pretix/control/signals.py
@@ -166,6 +166,19 @@ should return a list of dictionaries, where each dictionary can have the keys:
 This is a regular django signal (no pretix event signal).
 """
 
+voucher_filter_qs = EventPluginSignal()
+"""
+Arguments: ``qs``, ``request``
+
+This signal is sent when building the voucher queryset for the voucher list page,
+the tag overview page, and the tag typeahead. Receivers are passed a voucher queryset
+in the ``qs`` argument and should return a filtered queryset excluding any vouchers
+that should be hidden.
+
+As with all event plugin signals, the ``sender`` keyword argument will contain the event.
+"""
+
+
 voucher_form_html = EventPluginSignal()
 """
 Arguments: 'form'

--- a/src/pretix/control/urls.py
+++ b/src/pretix/control/urls.py
@@ -367,6 +367,7 @@ urlpatterns = [
         re_path(r'^discounts/add$', discounts.DiscountCreate.as_view(), name='event.items.discounts.add'),
         re_path(r'^vouchers/$', vouchers.VoucherList.as_view(), name='event.vouchers'),
         re_path(r'^vouchers/tags/$', vouchers.VoucherTags.as_view(), name='event.vouchers.tags'),
+        re_path(r'^vouchers/tags/typeahead$', typeahead.voucher_tag_typeahead, name='event.vouchers.tags.typeahead'),
         re_path(r'^vouchers/rng$', vouchers.VoucherRNG.as_view(), name='event.vouchers.rng'),
         re_path(r'^vouchers/item_select$', typeahead.itemvarquota_select2, name='event.vouchers.itemselect2'),
         re_path(r'^vouchers/(?P<voucher>\d+)/$', vouchers.VoucherUpdate.as_view(), name='event.voucher'),

--- a/src/pretix/control/views/typeahead.py
+++ b/src/pretix/control/views/typeahead.py
@@ -956,6 +956,21 @@ def subevent_meta_values(request, organizer, event):
     })
 
 
+@event_permission_required('event.vouchers:read')
+def voucher_tag_typeahead(request, **kwargs):
+    q = request.GET.get('q', '')
+    tags = request.event.vouchers.filter(
+        tag__isnull=False,
+        waitinglistentries__isnull=True,
+    ).filter(
+        tag__icontains=q,
+    ).values_list('tag', flat=True).distinct().order_by('tag')[:10]
+
+    return JsonResponse({
+        'results': [{'name': t} for t in tags]
+    })
+
+
 def item_meta_values(request, organizer, event):
     q = request.GET.get('q')
     propname = request.GET.get('property')

--- a/src/pretix/control/views/typeahead.py
+++ b/src/pretix/control/views/typeahead.py
@@ -56,6 +56,7 @@ from pretix.control.forms.event import EventWizardCopyForm
 from pretix.control.permissions import (
     event_permission_required, organizer_permission_required,
 )
+from pretix.control.signals import voucher_filter_qs
 from pretix.helpers.daterange import daterange
 from pretix.helpers.i18n import i18ncomp, parse_date_localized
 
@@ -959,10 +960,16 @@ def subevent_meta_values(request, organizer, event):
 @event_permission_required('event.vouchers:read')
 def voucher_tag_typeahead(request, **kwargs):
     q = request.GET.get('q', '')
-    tags = request.event.vouchers.filter(
+    qs = request.event.vouchers.filter(
         tag__isnull=False,
         waitinglistentries__isnull=True,
-    ).filter(
+    )
+
+    qs = voucher_filter_qs.send_chained(
+        request.event, chain_kwarg_name='qs', qs=qs, request=request
+    )
+
+    tags = qs.filter(
         tag__icontains=q,
     ).values_list('tag', flat=True).distinct().order_by('tag')[:10]
 

--- a/src/pretix/control/views/vouchers.py
+++ b/src/pretix/control/views/vouchers.py
@@ -72,7 +72,7 @@ from pretix.base.views.tasks import AsyncFormView
 from pretix.control.forms.filter import VoucherFilterForm, VoucherTagFilterForm
 from pretix.control.forms.vouchers import VoucherBulkForm, VoucherForm
 from pretix.control.permissions import EventPermissionRequiredMixin
-from pretix.control.signals import voucher_form_class
+from pretix.control.signals import voucher_filter_qs, voucher_form_class
 from pretix.control.views import PaginationMixin
 from pretix.helpers.compat import CompatDeleteView
 from pretix.helpers.format import SafeFormatter, format_map
@@ -93,6 +93,11 @@ class VoucherList(PaginationMixin, EventPermissionRequiredMixin, ListView):
         ).select_related(
             'item', 'variation', 'seat'
         ))
+
+        qs = voucher_filter_qs.send_chained(
+            self.request.event, chain_kwarg_name='qs', qs=qs, request=self.request
+        )
+
         if self.filter_form.is_valid():
             qs = self.filter_form.filter_qs(qs)
 
@@ -162,6 +167,10 @@ class VoucherTags(EventPermissionRequiredMixin, TemplateView):
         qs = self.request.event.vouchers.order_by('tag').filter(
             tag__isnull=False,
             waitinglistentries__isnull=True
+        )
+
+        qs = voucher_filter_qs.send_chained(
+            self.request.event, chain_kwarg_name='qs', qs=qs, request=self.request
         )
 
         if self.filter_form.is_valid():

--- a/src/tests/control/test_vouchers.py
+++ b/src/tests/control/test_vouchers.py
@@ -44,7 +44,7 @@ from tests.base import SoupTestMixin, extract_form_fields
 
 from pretix.base.models import (
     Event, Item, ItemVariation, Order, OrderPosition, Organizer, Quota, Team,
-    User, Voucher,
+    User, Voucher, WaitingListEntry,
 )
 
 
@@ -771,3 +771,38 @@ class VoucherFormTest(SoupTestMixin, TransactionTestCase):
 
         assert len(doc.select('.alert-warning ul li')) == 1  # Check that there's exactly 1 item in the warning list
         assert doc.text.count('Order DEDUP') == 1  # Check that the order is listed exactly once
+
+    def test_tag_typeahead(self):
+        with scopes_disabled():
+            self.event.vouchers.create(item=self.ticket, code='AAAAAAA', tag='early-bird')
+            self.event.vouchers.create(item=self.ticket, code='BBBBBBB', tag='early-vip')
+            self.event.vouchers.create(item=self.ticket, code='CCCCCCC', tag='sponsor')
+
+        url = '/control/event/%s/%s/vouchers/tags/typeahead' % (self.orga.slug, self.event.slug)
+        resp = self.client.get(url + '?q=early')
+
+        assert resp.status_code == 200
+        data = json.loads(resp.content.decode())
+        names = [r['name'] for r in data['results']]
+
+        assert 'early-bird' in names
+        assert 'early-vip' in names
+        assert 'sponsor' not in names
+
+    def test_tag_typeahead_excludes_waiting_list(self):
+        with scopes_disabled():
+            v = self.event.vouchers.create(item=self.ticket, code='AAAAAAA', tag='waiting-list')
+            WaitingListEntry.objects.create(
+                event=self.event, item=self.ticket, email='foo@example.com', voucher=v
+            )
+            self.event.vouchers.create(item=self.ticket, code='BBBBBBB', tag='walk-ins')
+
+        url = '/control/event/%s/%s/vouchers/tags/typeahead' % (self.orga.slug, self.event.slug)
+        resp = self.client.get(url + '?q=wa')
+
+        assert resp.status_code == 200
+        data = json.loads(resp.content.decode())
+        names = [r['name'] for r in data['results']]
+
+        assert 'walk-ins' in names
+        assert 'waiting-list' not in names

--- a/src/tests/control/test_vouchers.py
+++ b/src/tests/control/test_vouchers.py
@@ -806,3 +806,48 @@ class VoucherFormTest(SoupTestMixin, TransactionTestCase):
 
         assert 'walk-ins' in names
         assert 'waiting-list' not in names
+
+    def test_voucher_filter_qs_signal_filters_list(self):
+        with scopes_disabled():
+            self.event.plugins = 'tests.testdummy'
+            self.event.save()
+            self.event.vouchers.create(item=self.ticket, code='AAAAAAA', tag='visible')
+            self.event.vouchers.create(item=self.ticket, code='BBBBBBB', tag='hidden')
+
+        doc = self.client.get('/control/event/%s/%s/vouchers/' % (self.orga.slug, self.event.slug))
+        content = doc.content.decode()
+
+        assert 'AAAAAAA' in content
+        assert 'BBBBBBB' not in content
+
+    def test_voucher_filter_qs_signal_filters_typeahead(self):
+        with scopes_disabled():
+            self.event.plugins = 'tests.testdummy'
+            self.event.save()
+            self.event.vouchers.create(item=self.ticket, code='AAAAAAA', tag='visible')
+            self.event.vouchers.create(item=self.ticket, code='BBBBBBB', tag='hidden')
+
+        url = '/control/event/%s/%s/vouchers/tags/typeahead' % (self.orga.slug, self.event.slug)
+        resp = self.client.get(url + '?q=')
+
+        assert resp.status_code == 200
+        data = json.loads(resp.content.decode())
+        names = [r['name'] for r in data['results']]
+
+        assert 'visible' in names
+        assert 'hidden' not in names
+
+    def test_voucher_filter_qs_signal_chains_multiple_receivers(self):
+        with scopes_disabled():
+            self.event.plugins = 'tests.testdummy'
+            self.event.save()
+            self.event.vouchers.create(item=self.ticket, code='AAAAAAA', tag='visible')
+            self.event.vouchers.create(item=self.ticket, code='BBBBBBB', tag='hidden')
+            self.event.vouchers.create(item=self.ticket, code='CCCCCCC', tag='hidden2')
+
+        doc = self.client.get('/control/event/%s/%s/vouchers/' % (self.orga.slug, self.event.slug))
+        content = doc.content.decode()
+
+        assert 'AAAAAAA' in content
+        assert 'BBBBBBB' not in content
+        assert 'CCCCCCC' not in content

--- a/src/tests/testdummy/signals.py
+++ b/src/tests/testdummy/signals.py
@@ -32,6 +32,7 @@ from pretix.base.signals import (
     register_payment_providers, register_sales_channel_types,
     register_ticket_outputs,
 )
+from pretix.control.signals import voucher_filter_qs
 from pretix.presale.signals import html_head
 
 
@@ -144,3 +145,13 @@ class TestPeppolTransmissionProvider(TransmissionProvider):
     def transmit(self, invoice):
         invoice.transmission_status = Invoice.TRANSMISSION_STATUS_COMPLETED
         invoice.save()
+
+
+@receiver(voucher_filter_qs, dispatch_uid="voucher_filter_qs_dummy")
+def filter_vouchers(sender, qs, **kwargs):
+    return qs.exclude(tag='hidden')
+
+
+@receiver(voucher_filter_qs, dispatch_uid="voucher_filter_qs_dummy2")
+def filter_vouchers_2(sender, qs, **kwargs):
+    return qs.exclude(tag='hidden2')


### PR DESCRIPTION
Allow plugins to filter the voucher queryset on the list page, tag overview page, and tag typeahead. Similar to how waiting list vouchers are excluded from these views, plugins can now hide vouchers they manage from the standard voucher UI.

We have plugins that automatically generate large numbers of vouchers and need the flexibility to hide these, just as waiting list vouchers are already hidden as a special case. This signal generalises that pattern.

Depends on #6058 being merged first. That commit is included here but will disappear from the diff once merged.