### PR TITLE
Add `voucher_list_top_buttons` signal for voucher list page

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -76,7 +76,7 @@ Vouchers
 
 .. automodule:: pretix.control.signals
    :no-index:
-   :members: item_forms, voucher_form_class, voucher_form_html, voucher_form_validation
+   :members: item_forms, voucher_form_class, voucher_form_html, voucher_form_validation, voucher_list_top_buttons
 
 Dashboards
 """"""""""

--- a/src/pretix/control/signals.py
+++ b/src/pretix/control/signals.py
@@ -166,6 +166,25 @@ should return a list of dictionaries, where each dictionary can have the keys:
 This is a regular django signal (no pretix event signal).
 """
 
+voucher_list_top_buttons = EventPluginSignal()
+"""
+Arguments: ``request``, ``empty``
+
+This signal allows you to add additional buttons to the top of the voucher list page,
+next to the "Create a new voucher" and "Download list" buttons. You are expected to
+return HTML for one or more button elements.
+
+The ``empty`` argument is ``True`` when the voucher list has no results (either because
+no vouchers exist or because a search/filter matched nothing), and ``False`` otherwise.
+Pretix uses larger buttons in the empty state, so receivers may want to adjust their
+button styling accordingly.
+
+This signal is sent regardless of the user's permission level. Receivers should check
+permissions themselves via ``request`` before returning any HTML.
+
+As with all event plugin signals, the ``sender`` keyword argument will contain the event.
+"""
+
 voucher_form_html = EventPluginSignal()
 """
 Arguments: 'form'

--- a/src/pretix/control/templates/pretixcontrol/vouchers/index.html
+++ b/src/pretix/control/templates/pretixcontrol/vouchers/index.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load urlreplace %}
 {% load money %}
+{% load eventsignal %}
 {% block title %}{% trans "Vouchers" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Vouchers" %}</h1>
@@ -80,6 +81,7 @@
                 <a href="{% url "control:event.vouchers.import" organizer=request.event.organizer.slug event=request.event.slug %}"
                    class="btn btn-default btn-lg"><i class="fa fa-upload"></i> {% trans "Import vouchers" %}</a>
             {% endif %}
+            {% eventsignal request.event "pretix.control.signals.voucher_list_top_buttons" request=request empty=True %}
         </div>
     {% else %}
         <p>
@@ -96,6 +98,7 @@
             <a href="?{% url_replace request "download" "yes" %}"
                     class="btn btn-default"><i class="fa fa-download"></i>
                 {% trans "Download list" %}</a>
+            {% eventsignal request.event "pretix.control.signals.voucher_list_top_buttons" request=request empty=False %}
         </p>
         <form action="{% url "control:event.vouchers.bulkaction"  organizer=request.event.organizer.slug event=request.event.slug %}" method="post">
             {% csrf_token %}


### PR DESCRIPTION
Add a new `EventPluginSignal` that allows plugins to inject additional buttons at the top of the voucher list page, next to the existing "Create a new voucher" and "Download list" buttons.

The signal is rendered outside the write-permission check so that plugins can use it for read-only actions too. Receivers are responsible for checking permissions via the `request` object.

An `empty` boolean is passed to indicate whether the voucher list has results, so plugins can match the larger button styling pretix uses in the empty state.