### PR TITLE
Orders API: Fix race condition in voucher redemption (Z#23230391)

### DIFF
--- a/src/pretix/api/serializers/order.py
+++ b/src/pretix/api/serializers/order.py
@@ -1412,6 +1412,7 @@ class OrderCreateSerializer(I18nAwareModelSerializer):
         qa = QuotaAvailability()
         qa.queue(*[q for q, d in quota_diff_for_locking.items() if d > 0])
         qa.compute()
+        v_avail = {}
 
         # These are not technically correct as diff use due to the time offset applied above, so let's prevent accidental
         # use further down
@@ -1441,11 +1442,13 @@ class OrderCreateSerializer(I18nAwareModelSerializer):
 
                 voucher_usage[v] += 1
                 if voucher_usage[v] > 0:
-                    redeemed_in_carts = CartPosition.objects.filter(
-                        Q(voucher=pos_data['voucher']) & Q(event=self.context['event']) & Q(expires__gte=now_dt)
-                    ).exclude(pk__in=[cp.pk for cp in delete_cps])
-                    v_avail = v.max_usages - v.redeemed - redeemed_in_carts.count()
-                    if v_avail < voucher_usage[v]:
+                    if v not in v_avail:
+                        v.refresh_from_db(fields=['redeemed'])
+                        redeemed_in_carts = CartPosition.objects.filter(
+                            Q(voucher=v) & Q(event=self.context['event']) & Q(expires__gte=now_dt)
+                        ).exclude(pk__in=[cp.pk for cp in delete_cps])
+                        v_avail[v] = v.max_usages - v.redeemed - redeemed_in_carts.count()
+                    if v_avail[v] < voucher_usage[v]:
                         errs[i]['voucher'] = [
                             'The voucher has already been used the maximum number of times.'
                         ]

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -727,8 +727,6 @@ def _check_positions(event: Event, now_dt: datetime, time_machine_now_dt: dateti
     _check_date(event, time_machine_now_dt)
 
     products_seen = Counter()
-    q_avail = Counter()
-    v_avail = Counter()
     v_usages = Counter()
     v_budget = {}
     deleted_positions = set()
@@ -792,6 +790,9 @@ def _check_positions(event: Event, now_dt: datetime, time_machine_now_dt: dateti
                 [op.seat for op in sorted_positions if op.seat],
                 shared_lock_objects=[event]
             )
+
+    q_avail = Counter()
+    v_avail = Counter()
 
     # Check maximum order size
     limit = min(int(event.settings.max_items_per_order), settings.PRETIX_MAX_ORDER_SIZE)


### PR DESCRIPTION
The old code relied on the `Voucher.redeemed` value obtained *before* the lock was taken, not afterwards.

The change in services/orders.py is functionally pointless, but it makes the pattern of "fill availability only after lock" clearer and might avoid introducing similar bugs in the future.