### PR TITLE
BasePaymentProvider: Fix type hinting on execute_payment()

### DIFF
--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -834,7 +834,7 @@ class BasePaymentProvider:
         """
         raise NotImplementedError()  # NOQA
 
-    def execute_payment(self, request: HttpRequest, payment: OrderPayment) -> str:
+    def execute_payment(self, request: HttpRequest, payment: OrderPayment) -> str | None:
         """
         After the user has confirmed their purchase, this method will be called to complete
         the payment process. This is the place to actually move the money if applicable.


### PR DESCRIPTION
Let me know if you'd rather I use `Optional` since it's used elsewhere. But the union operator is the usual way to express optionals since 3.10.