### PR TITLE
Remove unused download of all tickets of an order in pretix-control

### DIFF
--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -79,7 +79,7 @@ from pretix.base.email import get_email_context
 from pretix.base.exporter import MultiSheetListExporter
 from pretix.base.i18n import language
 from pretix.base.models import (
-    CachedCombinedTicket, CachedFile, CachedTicket, Checkin, Invoice,
+    CachedFile, CachedTicket, Checkin, Invoice,
     InvoiceAddress, Item, ItemVariation, LogEntry, Order, QuestionAnswer,
     Quota, ScheduledEventExport, generate_secret,
 )

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -718,30 +718,13 @@ class OrderDownload(AsyncAction, OrderView):
                     ),
                     content_type=value.type
                 )
-        elif isinstance(value, CachedCombinedTicket):
-            if value.type == 'text/uri-list':
-                resp = HttpResponseRedirect(value.file.file.read())
-                return resp
-            else:
-                return FileResponse(
-                    value.file.file,
-                    filename='{}-{}-{}{}'.format(
-                        self.request.event.slug.upper(), self.order.code, self.output.identifier, value.extension
-                    ),
-                    content_type=value.type
-                )
         else:
             return redirect(self.get_self_url())
 
     def get_last_ct(self):
-        if 'position' in self.kwargs:
-            ct = CachedTicket.objects.filter(
-                order_position=self.order_position, provider=self.output.identifier, file__isnull=False
-            ).last()
-        else:
-            ct = CachedCombinedTicket.objects.filter(
-                order=self.order, provider=self.output.identifier, file__isnull=False
-            ).last()
+        ct = CachedTicket.objects.filter(
+            order_position=self.order_position, provider=self.output.identifier, file__isnull=False
+        ).last()
         if not ct or not ct.file:
             return None
         return ct

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -79,9 +79,9 @@ from pretix.base.email import get_email_context
 from pretix.base.exporter import MultiSheetListExporter
 from pretix.base.i18n import language
 from pretix.base.models import (
-    CachedFile, CachedTicket, Checkin, Invoice,
-    InvoiceAddress, Item, ItemVariation, LogEntry, Order, QuestionAnswer,
-    Quota, ScheduledEventExport, generate_secret,
+    CachedFile, CachedTicket, Checkin, Invoice, InvoiceAddress, Item,
+    ItemVariation, LogEntry, Order, QuestionAnswer, Quota,
+    ScheduledEventExport, generate_secret,
 )
 from pretix.base.models.orders import (
     CancellationRequest, OrderFee, OrderPayment, OrderPosition, OrderRefund,


### PR DESCRIPTION
As @luelista  noted in #5994  there is unused code in pretix-control to download all tickets. There is no URL defined for this, so the code can/should be removed. This is likely copied from pretix-presale, which does offer that functionality.