### PR TITLE
Validate async_id as celery uses and returns any provided ID-value for unknown AsyncResults

### DIFF
--- a/src/pretix/base/views/tasks.py
+++ b/src/pretix/base/views/tasks.py
@@ -53,6 +53,7 @@ from pretix.celery_app import app
 from pretix.helpers.http import redirect_to_url
 
 logger = logging.getLogger('pretix.base.tasks')
+RE_ASYNC_ID = re.compile(r"^[a-zA-Z0-9\-]+$")
 
 
 class AsyncMixin:
@@ -134,7 +135,7 @@ class AsyncMixin:
     def get_result(self, request):
         if not request.GET.get('async_id'):
             raise BadRequest("No async_id given")
-        if not re.match(r"^[a-zA-Z0-9\-]+$", request.GET.get('async_id')):
+        if not RE_ASYNC_ID.match(request.GET.get('async_id')):
             raise BadRequest("Invalid async_id given")
         res = AsyncResult(request.GET.get('async_id'))
         if 'ajax' in self.request.GET:

--- a/src/pretix/base/views/tasks.py
+++ b/src/pretix/base/views/tasks.py
@@ -20,6 +20,7 @@
 # <https://www.gnu.org/licenses/>.
 #
 import logging
+import re
 from collections import defaultdict
 from datetime import timedelta
 from importlib import import_module
@@ -133,6 +134,8 @@ class AsyncMixin:
     def get_result(self, request):
         if not request.GET.get('async_id'):
             raise BadRequest("No async_id given")
+        if not re.match(r"^[a-zA-Z0-9\-]+$", request.GET.get('async_id')):
+            raise BadRequest("Invalid async_id given")
         res = AsyncResult(request.GET.get('async_id'))
         if 'ajax' in self.request.GET:
             return JsonResponse(self._return_ajax_result(res, timeout=0.25))


### PR DESCRIPTION
This came up in a PCI-DSS review as a „reflected cross-site scripting vulnerability“. Any async_id provided to celery is returned as-is, even if no task is currently found for that id. This is intended behaviour for unkown IDs, but as the ID is returned to the client without any validation, HTML-script was able to be inserted in the response – the response itself is JSON, so that should not really be a problem. But to make sure, this PR adds a validation to the async_id.

Although we use default async_ids, if we at some point decide to customize async_ids, it might be helpful to pre-define/parse that regex somewhere more central, such as settings.py?