### PR TITLE
Limit widget frame inner height to 100dvh (Z#23231969)

### DIFF
--- a/src/pretix/static/pretixpresale/scss/widget.scss
+++ b/src/pretix/static/pretixpresale/scss/widget.scss
@@ -966,6 +966,7 @@ $table-bg-accent: rgba(128, 128, 128, 0.05);
   width: 80vw;
   max-width: 1080px;
   height: 80vh;
+  max-height: 100dvh;
 }
 .pretix-widget-frame-inner iframe {
   width: 100% !important;


### PR DESCRIPTION
Fixes a bug where the submit buttons were obscured by the browsers elements on some ios devices