### PR TITLE
Enable dragging answer options

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/items/question_edit.html
+++ b/src/pretix/control/templates/pretixcontrol/items/question_edit.html
@@ -76,13 +76,11 @@
                                             {% bootstrap_form_errors form %}
                                             {% bootstrap_field form.answer layout='inline' form_group_class="" %}
                                         </div>
-                                        <div class="col-xs-2 text-right flip">
+                                        <div class="col-xs-2 text-right flip question-option-actions">
                                             <span>&nbsp;</span><br>
-                                            <button type="button" class="btn btn-default" data-formset-move-up-button>
-                                                <i class="fa fa-arrow-up"></i></button>
-                                            <button type="button" class="btn btn-default" data-formset-move-down-button>
-                                                <i class="fa fa-arrow-down"></i></button>
-                                            <button type="button" class="btn btn-danger" data-formset-delete-button>
+                                            <button type="button" class="btn btn-default btn-sm question-option-drag-handle">
+                                                <i class="fa fa-arrows"></i></button>
+                                            <button type="button" class="btn btn-danger btn-sm" data-formset-delete-button>
                                                 <i class="fa fa-trash"></i></button>
                                         </div>
                                     </div>
@@ -104,13 +102,11 @@
                                     </span>
                                             {% bootstrap_field formset.empty_form.answer layout='inline' form_group_class="" %}
                                         </div>
-                                        <div class="col-xs-2 text-right flip">
+                                        <div class="col-xs-2 text-right flip question-option-actions">
                                             <span>&nbsp;</span><br>
-                                            <button type="button" class="btn btn-default" data-formset-move-up-button>
-                                                <i class="fa fa-arrow-up"></i></button>
-                                            <button type="button" class="btn btn-default" data-formset-move-down-button>
-                                                <i class="fa fa-arrow-down"></i></button>
-                                            <button type="button" class="btn btn-danger" data-formset-delete-button>
+                                            <button type="button" class="btn btn-default btn-sm question-option-drag-handle">
+                                                <i class="fa fa-arrows"></i></button>
+                                            <button type="button" class="btn btn-danger btn-sm" data-formset-delete-button>
                                                 <i class="fa fa-trash"></i></button>
                                         </div>
                                     </div>

--- a/src/pretix/static/pretixcontrol/js/ui/question.js
+++ b/src/pretix/static/pretixcontrol/js/ui/question.js
@@ -1,4 +1,4 @@
-/*global $, Morris, gettext*/
+/*global $, Morris, Sortable, gettext*/
 $(function () {
     // Question view
     if (!$("#question_chart").length) {
@@ -96,6 +96,50 @@ $(function () {
     $("#id_type").change(question_page_toggle_view);
     $("#id_required").change(question_page_toggle_view);
     question_page_toggle_view();
+
+    const $questionForm = $("#answer-options").closest("form");
+    const $optionFormset = $("#answer-options").find("[data-formset]");
+    const $optionFormsetBody = $optionFormset.find("[data-formset-body]");
+    let shouldTrackDirtyState = false;
+
+    function getActiveOptionForms() {
+        return $optionFormsetBody.children("[data-formset-form]").not("[data-formset-form-deleted]");
+    }
+
+    function syncAnswerOptionOrder(markDirty) {
+        const $activeForms = getActiveOptionForms();
+
+        $activeForms.each(function (index) {
+            $(this).find('[name*="-ORDER"]').val(index + 1);
+        });
+
+        $optionFormsetBody.find(".question-option-drag-handle").prop("disabled", $activeForms.length < 2);
+
+        if (markDirty && shouldTrackDirtyState) {
+            $questionForm.trigger("checkform.areYouSure");
+        }
+    }
+
+    syncAnswerOptionOrder(false);
+
+    Sortable.create($optionFormsetBody.get(0), {
+        animation: 150,
+        draggable: '[data-formset-form]:not([data-formset-form-deleted])',
+        handle: '.question-option-drag-handle',
+        onEnd: function () {
+            syncAnswerOptionOrder(true);
+        }
+    });
+
+    $optionFormset.on("formAdded formDeleted", "[data-formset-form]", function () {
+        window.setTimeout(function () {
+            syncAnswerOptionOrder(true);
+        }, 0);
+    });
+
+    window.setTimeout(function () {
+        shouldTrackDirtyState = true;
+    }, 0);
 
     function question_page_toggle_view() {
         var show = $("#id_type").val() == "C" || $("#id_type").val() == "M";

--- a/src/pretix/static/pretixcontrol/scss/_forms.scss
+++ b/src/pretix/static/pretixcontrol/scss/_forms.scss
@@ -149,6 +149,18 @@ td > .form-group > .checkbox {
   padding: 5px 0;
 }
 
+.question-option-actions {
+  white-space: nowrap;
+}
+
+.question-option-drag-handle {
+  cursor: move;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
 .i18n-form-group .i18n-field-markdown-note {
   border: 1px solid $input-border;
   color: $text-muted;


### PR DESCRIPTION
The arrows become very painful to use as the number of answers grow. I made an example with a dozen answers, but I have a real case with more than 30 answers.
It felt like it would take less time to make that PR than to actually bring that bottom answer to the top.

A before and after comparison video: 
[answer_options.webm](https://github.com/user-attachments/assets/b0130694-cb24-40a3-a0b1-168eaf581328)

Generated with AI (Claude)
