### PR TITLE
Invoice: fix issuer details rendering when address missing

### DIFF
--- a/src/pretix/base/invoicing/pdf.py
+++ b/src/pretix/base/invoicing/pdf.py
@@ -1160,7 +1160,7 @@ class Modern1Renderer(ClassicInvoiceRenderer):
         return stylesheet
 
     def _draw_invoice_from(self, canvas):
-        if not self.invoice.invoice_from:
+        if not self.invoice.address_invoice_from:
             return
         c = [
             self._clean_text(l)


### PR DESCRIPTION
When inputting all issuer details but not the "Address line", it skipped rendering the issuer details altogether.