### PR TITLE
Allow event being optional in LoggingMixin

### DIFF
--- a/src/pretix/base/models/base.py
+++ b/src/pretix/base/models/base.py
@@ -125,7 +125,7 @@ class LoggingMixin:
         elif isinstance(self, Event):
             event = self
             organizer_id = self.organizer_id
-        elif hasattr(self, 'event'):
+        elif hasattr(self, 'event') and self.event:
             event = self.event
             organizer_id = self.event.organizer_id
         elif hasattr(self, 'organizer_id'):


### PR DESCRIPTION
When using `LoggingMixin` with a model that has a property `event` that is optional, having `event=None` lead to errors. This PR allows a model with `LoggingMixin` to have an optional property `event`.