### PR TITLE
Add cssclass for footer-nav and improve button-style in footer

### DIFF
--- a/src/pretix/presale/signals.py
+++ b/src/pretix/presale/signals.py
@@ -126,7 +126,7 @@ footer_link = EventPluginSignal()
 Arguments: ``request``
 
 The signal ``pretix.presale.signals.footer_link`` allows you to add links to the footer of an event page. You
-are expected to return a dictionary containing the keys ``label`` and ``url``.
+are expected to return a dictionary containing the keys ``label``, ``url`` and optionally ``cssclass``.
 
 As with all event plugin signals, the ``sender`` keyword argument will contain the event.
 """

--- a/src/pretix/presale/templates/pretixpresale/base.html
+++ b/src/pretix/presale/templates/pretixpresale/base.html
@@ -80,7 +80,7 @@
                 <li>{{ footer_text }}</li>
             {% endif %}
             {% for f in footer %}
-                <li><a href="{% safelink f.url %}" target="_blank" rel="noopener">{{ f.label }}</a></li>
+                <li><a class="{{ f.cssclass }}" href="{% safelink f.url %}" target="_blank" rel="noopener">{{ f.label }}</a></li>
             {% endfor %}
             {% include "pretixpresale/base_footer.html" %} {# removing or hiding this might be in violation of pretix' license #}
             </ul>

--- a/src/pretix/static/pretixpresale/scss/main.scss
+++ b/src/pretix/static/pretixpresale/scss/main.scss
@@ -201,12 +201,15 @@ footer nav li:not(:first-child):before {
     width: 1.5em;
     text-align: center;
 }
+footer nav .btn, 
 footer nav .btn-link {
     display: inline;
-    padding: 0;
     margin: 0;
     font-size: 11px;
     vertical-align: baseline;
+}
+footer nav .btn-link {
+    padding: 0;
 }
 
 .js-only {


### PR DESCRIPTION
pretix-withdrawal needs to style a foot-link. This PR adds support for passing a cssclass in the signals result. It furthermore improves the display of `.btn`-styled links in footer nav.