### PR TITLE
Rephrase refund info paragraph

### DIFF
--- a/src/pretix/control/templates/pretixcontrol/order/refund_choose.html
+++ b/src/pretix/control/templates/pretixcontrol/order/refund_choose.html
@@ -23,9 +23,9 @@
             <legend>{% trans "How should the refund be sent?" %}</legend>
             <p>
                 {% blocktrans trimmed %}
-                    Any payments that you selected for automatical refunds will be immediately communicate the refund
-                    request to the respective payment provider. Manual refunds will be created as pending refunds, you
-                    can then later mark them as done once you actually transferred the money back to the customer.
+                    Any payments you selected for automatic refunds will have the refund request sent immediately to the
+                    respective payment provider. Manual refunds will be created as pending refunds, which you can later
+                    mark as done once you have actually transferred the money back to the customer.
                 {% endblocktrans %}
             </p>
 


### PR DESCRIPTION
`refunds will be immediately communicate the refund request to the respective payment provider` does not make sense.