### PR TITLE
banktransfer import: Fix prefix confusion if shorter event name contains dash (Z#23234167)

### DIFF
--- a/src/pretix/plugins/banktransfer/tasks.py
+++ b/src/pretix/plugins/banktransfer/tasks.py
@@ -405,7 +405,7 @@ def process_banktransfers(self, job: int, data: list) -> None:
                         # We need to sort prefixes by length with long ones first. In case we have an event with slug
                         # "CONF" and one with slug "CONF2022", we want CONF2022 to match first, to avoid the parser
                         # thinking "2022" is already the order code.
-                        "|".join(sorted([re.escape(p).replace("\\-", r"[\- ]*") for p in prefixes], key=lambda p: len(p), reverse=True)),
+                        "|".join([re.escape(p).replace("\\-", r"[\- ]*") for p in sorted(prefixes, key=lambda p: len(p), reverse=True)]),
                         min(code_len_agg['min'] or 1, inr_len_agg['min'] or 1),
                         max(code_len_agg['max'] or 5, inr_len_agg['max'] or 5)
                     )

--- a/src/tests/plugins/banktransfer/test_import.py
+++ b/src/tests/plugins/banktransfer/test_import.py
@@ -863,6 +863,9 @@ def test_event_name_prefix_contains_dash(env, orga_job):
 @pytest.mark.xfail
 @pytest.mark.django_db
 def test_event_name_prefix_multiple_dashes(env, orga_job):
+    # We decided to ignore the case of multiple events where the event slugs only differ in dashes
+    # for now. If we change that, switch this test case from xfail to regular test.
+
     event, user, o1, o2 = env
     slugs = ['dummy-2', 'dummy--2', 'dummy2345']
     for slug in slugs:

--- a/src/tests/plugins/banktransfer/test_import.py
+++ b/src/tests/plugins/banktransfer/test_import.py
@@ -834,3 +834,53 @@ def test_ambigious_date_with_region(env, job):
 
     with scopes_disabled():
         assert env[2].payments.last().info_data["date"] == "2016-05-03"
+
+
+@pytest.mark.django_db
+def test_event_name_prefix_contains_dash(env, orga_job):
+    event, user, o1, o2 = env
+    slugs = ['dummy-2', 'dummy2345']
+    for slug in slugs:
+        event = Event.objects.create(
+            organizer=event.organizer, name=slug.upper(), slug=slug,
+            date_from=now(), plugins='pretix.plugins.banktransfer,pretix.plugins.paypal'
+        )
+    with scopes_disabled():
+        o1.event = Event.objects.get(slug="dummy2345")
+        o1.save()
+    process_banktransfers(orga_job, [{
+        'payer': 'Karla Kundin',
+        'reference': f'DUMMY2345-{o1.code}',
+        'date': '2016-01-26',
+        'amount': '23.00'
+    }])
+    with scopes_disabled():
+        job = BankImportJob.objects.last()
+        t = job.transactions.last()
+        assert t.state == BankTransaction.STATE_VALID
+
+
+@pytest.mark.xfail
+@pytest.mark.django_db
+def test_event_name_prefix_multiple_dashes(env, orga_job):
+    event, user, o1, o2 = env
+    slugs = ['dummy-2', 'dummy--2', 'dummy2345']
+    for slug in slugs:
+        event = Event.objects.create(
+            organizer=event.organizer, name=slug.upper(), slug=slug,
+            date_from=now(), plugins='pretix.plugins.banktransfer,pretix.plugins.paypal'
+        )
+
+    with scopes_disabled():
+        o1.event = Event.objects.get(slug="dummy-2")
+        o1.save()
+    process_banktransfers(orga_job, [{
+        'payer': 'Karla Kundin',
+        'reference': f'DUMMY2-{o1.code}',
+        'date': '2016-01-26',
+        'amount': '23.00'
+    }])
+    with scopes_disabled():
+        job = BankImportJob.objects.last()
+        t = job.transactions.last()
+        assert t.state == BankTransaction.STATE_VALID


### PR DESCRIPTION
There are still possible collisions here as event slugs are not guaranteed to be prefix-free (or even just collision-free after we apply the fuzzyness regarding dashes to the names). I added an `xfail` testcase that shows at least one possible collision that still exists (`test_event_name_prefix_multiple_dashes`)