### PR TITLE
Make disable_url optional for notifications

### DIFF
--- a/src/pretix/base/templates/pretixbase/email/notification.html
+++ b/src/pretix/base/templates/pretixbase/email/notification.html
@@ -55,10 +55,12 @@
                 {% trans "You receive these emails based on your notification settings." %}<br>
                 <a href="{{ settings_url }}">
                     {% trans "Click here to view and change your notification settings" %}
-                </a><br>
-                <a href="{{ disable_url }}">
-                    {% trans "Click here disable all notifications immediately." %}
                 </a>
+                {% if disable_url %}<br>
+                    <a href="{{ disable_url }}">
+                        {% trans "Click here disable all notifications immediately." %}
+                    </a>
+                {% endif %}
             </div>
             <!--[if gte mso 9]>
                     </td></tr></table>

--- a/src/pretix/base/templates/pretixbase/email/notification.txt
+++ b/src/pretix/base/templates/pretixbase/email/notification.txt
@@ -14,5 +14,6 @@
 {% trans "You receive these emails based on your notification settings." %}
 {% trans "Click here to view and change your notification settings:" %}
 {{ settings_url }}
-{% trans "Click here disable all notifications immediately:" %}
+{% if disable_url %}{% trans "Click here disable all notifications immediately:" %}
 {{ disable_url }}
+{% endif %}


### PR DESCRIPTION
pretix currently only supports system-notifications on event-level. Because of this pretix-withdrawal re-implements the notification-mail by re-using pretix.base-templates. One thing, that is not possible, is to disable its notifications immediately – it is in fact not possible at all to disable notifications in pretix-withdrawal. This PR makes the `disable_url` optional for notification-mails.