### PR TITLE
fixes bug in checkin rules editor where jquery select2 does not get removed correctly

### DIFF
--- a/src/pretix/static/pretixcontrol/js/ui/checkinrules/lookup-select2.vue
+++ b/src/pretix/static/pretixcontrol/js/ui/checkinrules/lookup-select2.vue
@@ -100,14 +100,19 @@ watch(() => props.value, (newval, oldval) => {
 	}
 })
 
+let rawSelectEl: HTMLSelectElement | null = null
+
 onMounted(() => {
+	rawSelectEl = select.value
 	build()
 })
 
 onUnmounted(() => {
-	$(select.value)
+	if (!rawSelectEl) return
+	$(rawSelectEl)
 		.off()
 		.select2('destroy')
+	rawSelectEl = null
 })
 </script>
 <template lang="pug">


### PR DESCRIPTION
As reported by @pc-coholic, this happens:

<img width="2107" height="349" alt="Screenshot from 2026-05-19 23-06-52" src="https://github.com/user-attachments/assets/56675d2b-f3a8-48a3-807d-b333d8391d04" />

if you click "or" (or "and").

Source was slightly different lifecycle behaviour and/or how component root elements are handled between vue2 and vue3.