### PR TITLE
Add NoUrlValidator to validators

### DIFF
--- a/src/pretix/base/validators.py
+++ b/src/pretix/base/validators.py
@@ -24,9 +24,11 @@ import calendar
 from dateutil.rrule import DAILY, MONTHLY, WEEKLY, YEARLY, rrule, rrulestr
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
+from django.core.validators import RegexValidator, validate_email
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
+
+from pretix.base.templatetags.rich_text import URL_RE
 
 # This file is based on an earlier version of pretix which was released under the Apache License 2.0. The full text of
 # the Apache License 2.0 can be obtained at <http://www.apache.org/licenses/LICENSE-2.0>.
@@ -111,6 +113,33 @@ def multimail_validate(val):
     for part in s:
         validate_email(part.strip())
     return s
+
+
+class RegexValidatorWithMatchParam(RegexValidator):
+    def __call__(self, value):
+        regex_matches = self.regex.search(str(value))
+        invalid_input = regex_matches if self.inverse_match else not regex_matches
+        if invalid_input:
+            raise ValidationError(
+                self.message,
+                code=self.code,
+                params={
+                    "value": value,
+                    "match": regex_matches.group(0),
+                }
+            )
+
+
+class NoUrlValidator(RegexValidatorWithMatchParam):
+    regex = URL_RE
+    inverse_match = True
+
+    def __init__(self, **kwargs):
+        if not kwargs.get("message"):
+            kwargs["message"] = _('You entered an URL, which is not allowed. Please remove %(match)s from your input.')
+        if not kwargs.get("code"):
+            kwargs["code"] = "contains_url"
+        super().__init__(**kwargs)
 
 
 class RRuleValidator:

--- a/src/pretix/base/validators.py
+++ b/src/pretix/base/validators.py
@@ -115,24 +115,24 @@ def multimail_validate(val):
     return s
 
 
-class RegexValidatorWithMatchParam(RegexValidator):
+class RegexValidatorInverseMatchAndParam(RegexValidator):
+    inverse_match = True
+
     def __call__(self, value):
         regex_matches = self.regex.search(str(value))
-        invalid_input = regex_matches if self.inverse_match else not regex_matches
-        if invalid_input:
+        if regex_matches:
             raise ValidationError(
                 self.message,
                 code=self.code,
                 params={
                     "value": value,
-                    "match": regex_matches.group(0),
+                    "match": regex_matches.group(0) if regex_matches else "",
                 }
             )
 
 
-class NoUrlValidator(RegexValidatorWithMatchParam):
+class NoUrlValidator(RegexValidatorInverseMatchAndParam):
     regex = URL_RE
-    inverse_match = True
 
     def __init__(self, **kwargs):
         if not kwargs.get("message"):


### PR DESCRIPTION
This PR adds two validators to improve error messages when doing regex-based validation.

1. it extends django’s RegexValidator to include the whole match in the params for the message (it must have inverse_match for this to work)
2. it adds a NoUrlValidator for better/easier SPAM-protection where error message lists the matched URL, that needs to be removed.