### PR TITLE
Align email footer attribution with site footer

### DIFF
--- a/src/pretix/base/context.py
+++ b/src/pretix/base/context.py
@@ -30,39 +30,81 @@ from pretix.base.settings import GlobalSettingsObject
 from pretix.base.templatetags.safelink import safelink as sl
 
 
-def get_powered_by(request, safelink=True):
+def _get_powered_by_data(request=None, safelink=True):
+    """
+    Look up the configured attribution settings used by `get_powered_by()`
+    and `get_email_powered_by()`. Centralising this avoids drift between the
+    website and email renderings.
+    """
     gs = GlobalSettingsObject()
     d = gs.settings.license_check_input
-    if d.get('poweredby_name'):
-        if d.get('poweredby_url'):
+
+    pretix_url = sl('https://pretix.eu') if safelink else 'https://pretix.eu'
+    name = d.get('poweredby_name')
+
+    name_url = None
+    if name and d.get('poweredby_url'):
+        name_url = sl(d['poweredby_url']) if safelink else d['poweredby_url']
+
+    source_url = None
+    if d.get('base_license') == 'agpl' and request is not None:
+        source_url = request.build_absolute_uri(reverse('source'))
+
+    return name, name_url, pretix_url, source_url
+
+
+def _anchor_attrs(url):
+    return 'href="{}" target="_blank" rel="noopener"'.format(url)
+
+
+def _anchor(url, text):
+    return '<a {}>{}</a>'.format(_anchor_attrs(url), text)
+
+
+def get_powered_by(request, safelink=True):
+    name, name_url, pretix_url, source_url = _get_powered_by_data(request, safelink)
+    if name:
+        if name_url:
             msg = gettext('<a {a_name_attr}>powered by {name}</a> <a {a_attr}>based on pretix</a>').format(
-                name=d['poweredby_name'],
-                a_name_attr='href="{}" target="_blank" rel="noopener"'.format(
-                    sl(d['poweredby_url']) if safelink else d['poweredby_url'],
-                ),
-                a_attr='href="{}" target="_blank" rel="noopener"'.format(
-                    sl('https://pretix.eu') if safelink else 'https://pretix.eu',
-                )
+                name=name,
+                a_name_attr=_anchor_attrs(name_url),
+                a_attr=_anchor_attrs(pretix_url),
             )
         else:
             msg = gettext('<a {a_attr}>powered by {name} based on pretix</a>').format(
-                name=d['poweredby_name'],
-                a_attr='href="{}" target="_blank" rel="noopener"'.format(
-                    sl('https://pretix.eu') if safelink else 'https://pretix.eu',
-                )
+                name=name,
+                a_attr=_anchor_attrs(pretix_url),
             )
+
     else:
         msg = gettext('<a %(a_attr)s>ticketing powered by pretix</a>') % {
-            'a_attr': 'href="{}" target="_blank" rel="noopener"'.format(
-                sl('https://pretix.eu') if safelink else 'https://pretix.eu',
-            )
+            'a_attr': _anchor_attrs(pretix_url),
         }
 
-    if d.get('base_license') == 'agpl':
-        msg += ' (<a href="{}" target="_blank" rel="noopener">{}</a>)'.format(
-            request.build_absolute_uri(reverse('source')),
-            gettext('source code')
+    if source_url:
+        msg += ' ({})'.format(_anchor(source_url, gettext('source code')))
+
+    return mark_safe(msg)
+
+
+def get_email_powered_by():
+    """
+    Like `get_powered_by()` but renders narrower links: only the configured
+    name and the word "pretix" are anchors, the surrounding text stays plain.
+    A full-width hyperlinked footer looks visually heavy in HTML emails, and
+    the license attribution requirement applies to generated web pages only,
+    so this variant is unconstrained.
+    """
+    name, name_url, pretix_url, _ = _get_powered_by_data(safelink=False)
+    pretix_link = _anchor(pretix_url, 'pretix')
+
+    if name:
+        name_part = _anchor(name_url, name) if name_url else name
+        msg = gettext('powered by {name} based on {pretix}').format(
+            name=name_part, pretix=pretix_link,
         )
+    else:
+        msg = gettext('ticketing powered by {pretix}').format(pretix=pretix_link)
 
     return mark_safe(msg)
 

--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -36,6 +36,7 @@ from django.dispatch import receiver
 from django.template.loader import get_template
 from django.utils.translation import get_language, gettext_lazy as _
 
+from pretix.base.context import get_email_powered_by
 from pretix.base.models import Event
 from pretix.base.signals import register_html_mail_renderers
 from pretix.base.templatetags.rich_text import (
@@ -167,6 +168,7 @@ class TemplateBasedMailRenderer(BaseHTMLMailRenderer):
             'subject': str(subject),
             'color': settings.PRETIX_PRIMARY_COLOR,
             'rtl': get_language() in settings.LANGUAGES_RTL or get_language().split('-')[0] in settings.LANGUAGES_RTL,
+            'poweredby': get_email_powered_by(),
         }
         if self.organizer:
             htmlctx['organizer'] = self.organizer

--- a/src/pretix/base/templates/pretixbase/email/email_footer.html
+++ b/src/pretix/base/templates/pretixbase/email/email_footer.html
@@ -1,6 +1,1 @@
-{% load i18n %}
-{% with 'target="blank" href="https://pretix.eu"'|safe as a_attr %}
-    {% blocktrans trimmed %}
-        powered by <a {{ a_attr }}>pretix</a>
-    {% endblocktrans %}
-{% endwith %}
+{{ poweredby }}


### PR DESCRIPTION
Replace the hardcoded "powered by pretix" with the configured attribution shown on the site.

Adds `get_email_powered_by()`, which links only the name and "pretix" (a full-width link looks heavy in email). The settings lookup is shared with `get_powered_by()` via a new `_get_powered_by_data()` helper.