### PR TITLE
Enable sending logs to Sentry

### DIFF
--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -709,6 +709,7 @@ if config.has_option('sentry', 'dsn') and not any(c in sys.argv for c in ('shell
     from .sentry import PretixSentryIntegration, setup_custom_filters
 
     SENTRY_TOKEN = config.get('sentry', 'traces_sample_token', fallback='')
+    SENTRY_ENABLE_LOGS = config.getboolean('sentry', 'enable_logs', fallback=False)
     pretix_denylist = DEFAULT_DENYLIST + [
         "access_token",
         "sentry_dsn",
@@ -733,7 +734,8 @@ if config.has_option('sentry', 'dsn') and not any(c in sys.argv for c in ('shell
             CeleryIntegration(),
             LoggingIntegration(
                 level=logging.INFO,
-                event_level=logging.CRITICAL
+                event_level=logging.CRITICAL,
+                sentry_logs_level=logging.NOTSET if SENTRY_ENABLE_LOGS else None,
             )
         ],
         traces_sampler=traces_sampler,
@@ -741,6 +743,7 @@ if config.has_option('sentry', 'dsn') and not any(c in sys.argv for c in ('shell
         release=__version__,
         event_scrubber=EventScrubber(denylist=pretix_denylist, recursive=True),
         send_default_pii=False,
+        enable_logs=SENTRY_ENABLE_LOGS,
         propagate_traces=False,  # see https://github.com/getsentry/sentry-python/issues/1717
     )
     ignore_logger('pretix.base.tasks')

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -735,7 +735,7 @@ if config.has_option('sentry', 'dsn') and not any(c in sys.argv for c in ('shell
             LoggingIntegration(
                 level=logging.INFO,
                 event_level=logging.CRITICAL,
-                sentry_logs_level=logging.NOTSET if SENTRY_ENABLE_LOGS else None,
+                sentry_logs_level=logging.INFO,
             )
         ],
         traces_sampler=traces_sampler,


### PR DESCRIPTION
Sentry has a feature to see logs in its UI. My changes allow configuring that.
I've tested the changes on my instance. It works well.

I put the log level to `NOTSET`, but I could make it configurable if you want.