### PR TITLE
Add the order_approve_info signal

### DIFF
--- a/doc/development/api/general.rst
+++ b/doc/development/api/general.rst
@@ -64,8 +64,8 @@ Backend
 
 .. automodule:: pretix.control.signals
    :members: nav_event, html_head, html_page_start, quota_detail_html, nav_topbar, nav_global, nav_organizer, nav_event_settings,
-             order_info, event_settings_widget, oauth_application_registered, order_position_buttons, subevent_forms,
-             item_formsets, order_search_filter_q, order_search_forms
+             order_info, order_approve_info, event_settings_widget, oauth_application_registered,
+             order_position_buttons, subevent_forms, item_formsets, order_search_filter_q, order_search_forms
 
 .. automodule:: pretix.base.signals
    :no-index:

--- a/src/pretix/control/signals.py
+++ b/src/pretix/control/signals.py
@@ -261,6 +261,16 @@ As with all event plugin signals, the ``sender`` keyword argument will contain t
 Additionally, the argument ``order`` and ``request`` are available.
 """
 
+order_approve_info = EventPluginSignal()
+"""
+Arguments: ``order``, ``request``
+
+This signal is sent out to display additional information on the order approve page
+
+As with all event plugin signals, the ``sender`` keyword argument will contain the event.
+Additionally, the argument ``order`` and ``request`` are available.
+"""
+
 order_position_buttons = EventPluginSignal()
 """
 Arguments: ``order``, ``position``, ``request``

--- a/src/pretix/control/templates/pretixcontrol/order/approve.html
+++ b/src/pretix/control/templates/pretixcontrol/order/approve.html
@@ -1,4 +1,5 @@
 {% extends "pretixcontrol/event/base.html" %}
+{% load eventsignal %}
 {% load i18n %}
 {% block title %}
     {% trans "Approve order" %}
@@ -7,6 +8,9 @@
     <h1>
         {% trans "Approve order" %}
     </h1>
+
+    {% eventsignal request.event "pretix.control.signals.order_approve_info" order=order request=request %}
+
     <p>{% blocktrans trimmed %}
         Do you really want to approve this order?
     {% endblocktrans %}</p>


### PR DESCRIPTION
Added after the `order_info` signal since they're conceptually related.  Not sure that makes much difference, but it made sense to me!