### PR TITLE
Use HTTP-REFERER as fallback for vite_origins

### DIFF
--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -128,6 +128,9 @@ def _use_vite(request):
     origin = request.META.get('HTTP_ORIGIN', '')
     gs = GlobalSettingsObject()
     vite_origins = gs.settings.get('widget_vite_origins', as_type=str, default='')
+    if vite_origins and not origin:
+        referer = request.META.get('HTTP_REFERER', '')
+        origin = '/'.join(referer.split('/', 3)[:3])
     if origin and vite_origins:
         origins_list = [o.strip() for o in vite_origins.strip().splitlines() if o.strip()]
         return origin in origins_list


### PR DESCRIPTION
This PR adds HTTP Referrer as a fallback for HTTP origin as usually the Origin-header is not sent for script GET requests. This did not occur in testing as I had `crossorigin`-attribute on the widget’s script-element in my testing environment, which caused the origin header to be sent. 