### PR TITLE
Add Docker secrets support in config

### DIFF
--- a/src/pretix/helpers/config.py
+++ b/src/pretix/helpers/config.py
@@ -29,19 +29,19 @@ class EnvOrParserConfig:
         self.cp = configparser
 
     def _envkey(self, section, option):
-        section = re.sub('[^a-zA-Z0-9]', '_', section.upper())
-        option = re.sub('[^a-zA-Z0-9]', '_', option.upper())
-        return f'PRETIX_{section}_{option}'
-    
+        section = re.sub("[^a-zA-Z0-9]", "_", section.upper())
+        option = re.sub("[^a-zA-Z0-9]", "_", option.upper())
+        return f"PRETIX_{section}_{option}"
+
     def _file_envkey(self, section, option):
-        section = re.sub('[^a-zA-Z0-9]', '_', section.upper())
-        option = re.sub('[^a-zA-Z0-9]', '_', option.upper())
-        return f'FILE__PRETIX_{section}_{option}'
+        section = re.sub("[^a-zA-Z0-9]", "_", section.upper())
+        option = re.sub("[^a-zA-Z0-9]", "_", option.upper())
+        return f"FILE__PRETIX_{section}_{option}"
 
     def get(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
             try:
-                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                with open(os.environ[self._file_envkey(section, option)], "r") as f:
                     return f.read().strip()
             except Exception:
                 pass  # If the file cannot be read, we fall back to the normal config value
@@ -52,7 +52,7 @@ class EnvOrParserConfig:
     def getint(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
             try:
-                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                with open(os.environ[self._file_envkey(section, option)], "r") as f:
                     return int(f.read().strip())
             except Exception:
                 pass  # If the file cannot be read, we fall back to the normal config value
@@ -63,7 +63,7 @@ class EnvOrParserConfig:
     def getfloat(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
             try:
-                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                with open(os.environ[self._file_envkey(section, option)], "r") as f:
                     return float(f.read().strip())
             except Exception:
                 pass  # If the file cannot be read, we fall back to the normal config value
@@ -74,18 +74,22 @@ class EnvOrParserConfig:
     def getboolean(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
             try:
-                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                with open(os.environ[self._file_envkey(section, option)], "r") as f:
                     return self.cp._convert_to_boolean(f.read().strip())
             except Exception:
                 pass  # If the file cannot be read, we fall back to the normal config value
         if self._envkey(section, option) in os.environ:
-            return self.cp._convert_to_boolean(os.environ[self._envkey(section, option)])
-        return self.cp.getboolean(section, option, raw=raw, vars=vars, fallback=fallback)
+            return self.cp._convert_to_boolean(
+                os.environ[self._envkey(section, option)]
+            )
+        return self.cp.getboolean(
+            section, option, raw=raw, vars=vars, fallback=fallback
+        )
 
     def has_section(self, section):
-        if any(k.startswith(self._file_envkey(section, '')) for k in os.environ):
+        if any(k.startswith(self._file_envkey(section, "")) for k in os.environ):
             return True
-        if any(k.startswith(self._envkey(section, '')) for k in os.environ):
+        if any(k.startswith(self._envkey(section, "")) for k in os.environ):
             return True
         return self.cp.has_section(section)
 

--- a/src/pretix/helpers/config.py
+++ b/src/pretix/helpers/config.py
@@ -40,44 +40,32 @@ class EnvOrParserConfig:
 
     def get(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
-            try:
-                with open(os.environ[self._file_envkey(section, option)], "r") as f:
-                    return f.read().strip()
-            except Exception:
-                pass  # If the file cannot be read, we fall back to the normal config value
+            with open(os.environ[self._file_envkey(section, option)], "r") as f:
+                return f.read().strip()
         if self._envkey(section, option) in os.environ:
             return os.environ[self._envkey(section, option)]
         return self.cp.get(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def getint(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
-            try:
-                with open(os.environ[self._file_envkey(section, option)], "r") as f:
-                    return int(f.read().strip())
-            except Exception:
-                pass  # If the file cannot be read, we fall back to the normal config value
+            with open(os.environ[self._file_envkey(section, option)], "r") as f:
+                return int(f.read().strip())
         if self._envkey(section, option) in os.environ:
             return int(os.environ[self._envkey(section, option)])
         return self.cp.getint(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def getfloat(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
-            try:
-                with open(os.environ[self._file_envkey(section, option)], "r") as f:
-                    return float(f.read().strip())
-            except Exception:
-                pass  # If the file cannot be read, we fall back to the normal config value
+            with open(os.environ[self._file_envkey(section, option)], "r") as f:
+                return float(f.read().strip())
         if self._envkey(section, option) in os.environ:
             return float(os.environ[self._envkey(section, option)])
         return self.cp.getfloat(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def getboolean(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
         if self._file_envkey(section, option) in os.environ:
-            try:
-                with open(os.environ[self._file_envkey(section, option)], "r") as f:
-                    return self.cp._convert_to_boolean(f.read().strip())
-            except Exception:
-                pass  # If the file cannot be read, we fall back to the normal config value
+            with open(os.environ[self._file_envkey(section, option)], "r") as f:
+                return self.cp._convert_to_boolean(f.read().strip())
         if self._envkey(section, option) in os.environ:
             return self.cp._convert_to_boolean(
                 os.environ[self._envkey(section, option)]

--- a/src/pretix/helpers/config.py
+++ b/src/pretix/helpers/config.py
@@ -32,33 +32,66 @@ class EnvOrParserConfig:
         section = re.sub('[^a-zA-Z0-9]', '_', section.upper())
         option = re.sub('[^a-zA-Z0-9]', '_', option.upper())
         return f'PRETIX_{section}_{option}'
+    
+    def _file_envkey(self, section, option):
+        section = re.sub('[^a-zA-Z0-9]', '_', section.upper())
+        option = re.sub('[^a-zA-Z0-9]', '_', option.upper())
+        return f'FILE__PRETIX_{section}_{option}'
 
     def get(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
+        if self._file_envkey(section, option) in os.environ:
+            try:
+                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                    return f.read().strip()
+            except Exception:
+                pass  # If the file cannot be read, we fall back to the normal config value
         if self._envkey(section, option) in os.environ:
             return os.environ[self._envkey(section, option)]
         return self.cp.get(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def getint(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
+        if self._file_envkey(section, option) in os.environ:
+            try:
+                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                    return int(f.read().strip())
+            except Exception:
+                pass  # If the file cannot be read, we fall back to the normal config value
         if self._envkey(section, option) in os.environ:
             return int(os.environ[self._envkey(section, option)])
         return self.cp.getint(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def getfloat(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
+        if self._file_envkey(section, option) in os.environ:
+            try:
+                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                    return float(f.read().strip())
+            except Exception:
+                pass  # If the file cannot be read, we fall back to the normal config value
         if self._envkey(section, option) in os.environ:
             return float(os.environ[self._envkey(section, option)])
         return self.cp.getfloat(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def getboolean(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
+        if self._file_envkey(section, option) in os.environ:
+            try:
+                with open(os.environ[self._file_envkey(section, option)], 'r') as f:
+                    return self.cp._convert_to_boolean(f.read().strip())
+            except Exception:
+                pass  # If the file cannot be read, we fall back to the normal config value
         if self._envkey(section, option) in os.environ:
             return self.cp._convert_to_boolean(os.environ[self._envkey(section, option)])
         return self.cp.getboolean(section, option, raw=raw, vars=vars, fallback=fallback)
 
     def has_section(self, section):
+        if any(k.startswith(self._file_envkey(section, '')) for k in os.environ):
+            return True
         if any(k.startswith(self._envkey(section, '')) for k in os.environ):
             return True
         return self.cp.has_section(section)
 
     def has_option(self, section, option):
+        if self._file_envkey(section, option) in os.environ:
+            return True
         if self._envkey(section, option) in os.environ:
             return True
         return self.cp.has_option(section, option)

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -100,6 +100,11 @@ SECRET_KEY_FALLBACKS = []
 for i in range(10):
     if config.has_option('django', f'secret_fallback{i}'):
         SECRET_KEY_FALLBACKS.append(config.get('django', f'secret_fallback{i}'))
+fallback_secret_file_key = config._file_envkey('django', 'secret_fallbacks')  # FILE__PRETIX_DJANGO_SECRET_FALLBACKS
+if fallback_secret_file_key in os.environ and os.path.exists(os.environ[fallback_secret_file_key]):
+    with open(os.environ[fallback_secret_file_key], 'r') as f:
+        for line in f:
+            SECRET_KEY_FALLBACKS.append(line.strip())
 
 
 # Adjustable settings


### PR DESCRIPTION
This pull request enhances the configuration handling in `src/pretix/helpers/config.py` by adding support for loading configuration values from files referenced by environment variables. This provides a more secure and flexible way to manage sensitive configuration data, such as docker secrets, by allowing environment variables to point to files rather than storing sensitive values directly.

The reason for using an environment variable rather than simply checking whether a file exists in `/run/secrets` is that this increases flexibility and also allows, for example, standard volume mappings to be used.

As this is a fairly small and straightforward PR with an obviously positive impact, I created it without any prior discussion or issue. I hope that was OK 😅

**File-based environment variable support:**

* Added a `_file_envkey` method to generate environment variable names for file-based configuration values (e.g. `FILE__PRETIX_SECTION_OPTION`).
* Updated `get`, `getint`, `getfloat`, and `getboolean` methods to check for file-based environment variables first, read their contents, and use them as configuration values.

**Configuration presence checks:**

* Modified `has_section` and `has_option` to recognize the presence of file-based environment variables as valid configuration sources.

**docker-compose.yml example:**

```
services:
  pretix:
    image: pretix/standalone:stable
    ...
    environment:
      - FILE__PRETIX_PRETIX_INSTANCE_NAME=/run/secrets/instance_name
    secrets:
      - instance_name

secrets:
  instance_name:
    file: ./instance_name.txt
```
or
```
services:
  pretix:
    image: pretix/standalone:stable
    ...
    environment:
      - FILE__PRETIX_PRETIX_INSTANCE_NAME=/some_random_dir/instance_name
    volumes:
      - ./instance_name.txt:/some_random_dir/instance_name:ro
```
Of course, this feature is primarily intended for real secrets, such as the database password. I only used the `instance_name` for illustrative purposes and to test the new feature easily.