### PR TITLE
add widget's display-event-info property to pretix-button

### DIFF
--- a/src/pretix/static/pretixpresale/widget/src/button.ts
+++ b/src/pretix/static/pretixpresale/widget/src/button.ts
@@ -10,6 +10,11 @@ export function createButtonInstance (element: Element, htmlId?: string): App {
 		targetUrl += '/'
 	}
 
+	const displayEventInfoAttr = element.attributes['display-event-info']?.value
+	// null means "auto" (as before), everything other than "false" is true
+	const displayEventInfo: boolean | null
+		= 'display-event-info' in element.attributes && displayEventInfoAttr !== 'auto' ? displayEventInfoAttr !== 'false' : null
+
 	const widgetData: WidgetData = JSON.parse(JSON.stringify(window.PretixWidget.widget_data))
 
 	for (const attr of Array.from(element.attributes)) {
@@ -35,6 +40,7 @@ export function createButtonInstance (element: Element, htmlId?: string): App {
 		subevent: element.attributes.subevent?.value || null,
 		skipSsl: 'skip-ssl-check' in element.attributes,
 		disableIframe: 'disable-iframe' in element.attributes,
+		displayEventInfo,
 		widgetData,
 		htmlId: htmlId || element.id || makeid(16),
 		isButton: true,


### PR DESCRIPTION
When using the Widget, the `<pretix-button>` currently doesnt support adding the `display-event-info` flag.
The button uses the same underlying logic as the `<pretix-widget>`, yet still doesn't support that flag - so i added it:)

If accepted, adjusting the available props documented on https://docs.pretix.eu/guides/widget/#pretix-button would follow