### PR TITLE
Devex: Fix vite devserver capturing stdin

### DIFF
--- a/src/pretix/base/management/commands/runserver.py
+++ b/src/pretix/base/management/commands/runserver.py
@@ -44,7 +44,8 @@ class Command(Parent):
             # Start the vite server in the background
             vite_server = subprocess.Popen(
                 ["npm", "run", "dev:control"],
-                cwd=Path(__file__).parent.parent.parent.parent.parent
+                cwd=Path(__file__).parent.parent.parent.parent.parent,
+                stdin=subprocess.DEVNULL
             )
 
             def cleanup():


### PR DESCRIPTION
Pass DEVNULL as stdin to vite, otherwise the vite devserver captures parts of stdin, making things like pasting during debugging impossible