### PR TITLE
Prune wheel and setuptools-rust from build-system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ COPY vite.config.ts /pretix/vite.config.ts
 
 RUN pip3 install -U \
         pip \
-        setuptools \
-        wheel && \
+        setuptools && \
     cd /pretix && \
     PRETIX_DOCKER_BUILD=TRUE pip3 install \
         -e ".[memcached]" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,6 @@ build-backend = "backend"
 backend-path = ["_build"]
 requires = [
   "setuptools",
-  "setuptools-rust",
-  "wheel",
   "importlib_metadata",
   "tomli",
 ]


### PR DESCRIPTION
For wheel the setuptools documentation notes:

> Historically this documentation has unnecessarily listed wheel in
> the requires list, and many projects still do that. This is not
> recommended, as the backend no longer requires the wheel package,
> and listing it explicitly causes it to be unnecessarily required for
> source distribution builds.

https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use

For setuptools-rust I could not find any Rust extension that need to be built. The introduction goes back to c132ccd14, where css-inline, a rust component, was added as a dependency.