### PR TITLE
include errors.js by default and make it coop with async_task_replace_page (Z#23236752)

### DIFF
--- a/src/pretix/base/templates/error.html
+++ b/src/pretix/base/templates/error.html
@@ -11,6 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="utf-8">
     <link rel="icon" href="{% static "pretixbase/img/favicon.ico" %}">
+    <script type="text/javascript" src="{% static "pretixbase/js/errors.js" %}"></script>
     {% block custom_header %}{% endblock %}
     {% if css_theme %}
         <link rel="stylesheet" type="text/css" href="{{ css_theme }}" />

--- a/src/pretix/base/templates/error.html
+++ b/src/pretix/base/templates/error.html
@@ -20,6 +20,5 @@
 <div class="container">
     {% block content %}{% endblock %}
 </div>
-<script src="{% static "pretixbase/js/errors.js" %}"></script>
 </body>
 </html>

--- a/src/pretix/control/templates/pretixcontrol/base.html
+++ b/src/pretix/control/templates/pretixcontrol/base.html
@@ -66,6 +66,7 @@
             <script type="text/javascript" src="{% static "lightbox/js/lightbox.js" %}"></script>
             <script type="text/javascript" src="{% static "are-you-sure/jquery.are-you-sure.js" %}"></script>
             <script type="text/javascript" src="{% static "pretixbase/js/addressform.js" %}"></script>
+            <script type="text/javascript" src="{% static "pretixbase/js/errors.js" %}"></script>
 		{% endcompress %}
         {{ html_head|safe }}
 

--- a/src/pretix/presale/templates/pretixpresale/fragment_js.html
+++ b/src/pretix/presale/templates/pretixpresale/fragment_js.html
@@ -22,4 +22,5 @@
     <script type="text/javascript" src="{% static "pretixpresale/js/ui/iframe.js" %}"></script>
     <script type="text/javascript" src="{% static "pretixbase/js/addressform.js" %}"></script>
     <script type="text/javascript" src="{% static "pretixbase/js/deanonymize_email.js" %}"></script>
+    <script type="text/javascript" src="{% static "pretixbase/js/errors.js" %}"></script>
 {% endcompress %}

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -182,7 +182,7 @@ function async_task_error(jqXHR, textStatus, errorThrown) {
                     jqXHR.responseText.indexOf("<body"),
                     jqXHR.responseText.indexOf("</body")
                 ));
-                document.dispatchEvent(new Event("pretix:async_task_replace_page:on_error"))
+                document.dispatchEvent(new Event("pretix:async-task-error"))
 
             }
 

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -107,6 +107,7 @@ function async_task_replace_page(target, new_html) {
     setup_collapsible_details($(target));
     window.setTimeout(function () { $(window).scrollTop(0) }, 200)
     $(document).trigger("pretix:bind-forms");
+		$(document).trigger("pretix:async_task_replace_page");
 }
 
 function async_task_check_error(jqXHR, textStatus, errorThrown) {

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -107,7 +107,6 @@ function async_task_replace_page(target, new_html) {
     setup_collapsible_details($(target));
     window.setTimeout(function () { $(window).scrollTop(0) }, 200)
     $(document).trigger("pretix:bind-forms");
-		$(document).trigger("pretix:async_task_replace_page");
 }
 
 function async_task_check_error(jqXHR, textStatus, errorThrown) {
@@ -175,15 +174,15 @@ function async_task_error(jqXHR, textStatus, errorThrown) {
         var respdom = $(jqXHR.responseText);
         var c = respdom.filter('.container');
         if (respdom.filter('form') && (respdom.filter('.has-error') || respdom.filter('.alert-danger'))) {
-            // This is a failed form validation, let's just use it
-
             if (respdom.filter('#page-wrapper') && $('#page-wrapper').length) {
+								// This is a failed form validation, let's just use it
                 async_task_replace_page("#page-wrapper", respdom.find("#page-wrapper").html());
             } else {
                 async_task_replace_page("body", jqXHR.responseText.substring(
                     jqXHR.responseText.indexOf("<body"),
                     jqXHR.responseText.indexOf("</body")
                 ));
+								$(document).trigger("pretix:async_task_replace_page:on_error");
             }
 
         } else if (c.length > 0) {

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -182,7 +182,7 @@ function async_task_error(jqXHR, textStatus, errorThrown) {
                     jqXHR.responseText.indexOf("<body"),
                     jqXHR.responseText.indexOf("</body")
                 ));
-								$(document).trigger("pretix:async_task_replace_page:on_error");
+                $(document).trigger("pretix:async_task_replace_page:on_error");
             }
 
         } else if (c.length > 0) {

--- a/src/pretix/static/pretixbase/js/asynctask.js
+++ b/src/pretix/static/pretixbase/js/asynctask.js
@@ -175,14 +175,15 @@ function async_task_error(jqXHR, textStatus, errorThrown) {
         var c = respdom.filter('.container');
         if (respdom.filter('form') && (respdom.filter('.has-error') || respdom.filter('.alert-danger'))) {
             if (respdom.filter('#page-wrapper') && $('#page-wrapper').length) {
-								// This is a failed form validation, let's just use it
+                // This is a failed form validation, let's just use it
                 async_task_replace_page("#page-wrapper", respdom.find("#page-wrapper").html());
             } else {
                 async_task_replace_page("body", jqXHR.responseText.substring(
                     jqXHR.responseText.indexOf("<body"),
                     jqXHR.responseText.indexOf("</body")
                 ));
-                $(document).trigger("pretix:async_task_replace_page:on_error");
+                document.dispatchEvent(new Event("pretix:async_task_replace_page:on_error"))
+
             }
 
         } else if (c.length > 0) {

--- a/src/pretix/static/pretixbase/js/errors.js
+++ b/src/pretix/static/pretixbase/js/errors.js
@@ -1,17 +1,11 @@
-const registerErrorLinkHandlers = (reloadAll = false) => {
-  const backwards = document.getElementById('goback');
-  if (backwards) {
-    backwards.onclick = reloadAll
-      ? () => window.location.reload(true)
-      : () => window.history.back();
-  }
-
-  const reload = document.getElementById('reload');
-  if (reload) {
-    reload.onclick = () => window.location.reload(true);
-  }
-};
-
-document.addEventListener("DOMContentLoaded", () => registerErrorLinkHandlers());
-
-document.addEventListener("pretix:async_task_replace_page:on_error", () => registerErrorLinkHandlers(true));
+['DOMContentLoaded', 'pretix:async-task-error'].forEach(function (ev) {
+  document.addEventListener(ev, function () {
+    document.querySelectorAll('#goback, #reload').forEach(function (element) {
+      const regularLoad = ev === 'DOMContentLoaded' && element.id === 'goback';
+      element.addEventListener('click', regularLoad
+        ? () => window.history.back()
+        : () => window.location.reload()
+      );
+    });
+  });
+});

--- a/src/pretix/static/pretixbase/js/errors.js
+++ b/src/pretix/static/pretixbase/js/errors.js
@@ -14,4 +14,4 @@ const registerErrorLinkHandlers = (reloadAll = false) => {
 
 registerErrorLinkHandlers();
 
-$(document).on("pretix:async_task_replace_page", () => registerErrorLinkHandlers(true));
+$(document).on("pretix:async_task_replace_page:on_error", () => registerErrorLinkHandlers(true));

--- a/src/pretix/static/pretixbase/js/errors.js
+++ b/src/pretix/static/pretixbase/js/errors.js
@@ -12,6 +12,6 @@ const registerErrorLinkHandlers = (reloadAll = false) => {
   }
 };
 
-registerErrorLinkHandlers();
+document.addEventListener("DOMContentLoaded", () => registerErrorLinkHandlers());
 
-$(document).on("pretix:async_task_replace_page:on_error", () => registerErrorLinkHandlers(true));
+document.addEventListener("pretix:async_task_replace_page:on_error", () => registerErrorLinkHandlers(true));

--- a/src/pretix/static/pretixbase/js/errors.js
+++ b/src/pretix/static/pretixbase/js/errors.js
@@ -1,5 +1,17 @@
-document.getElementById('goback').onclick =
-   function() {window.history.back()};
+const registerErrorLinkHandlers = (reloadAll = false) => {
+  const backwards = document.getElementById('goback');
+  if (backwards) {
+    backwards.onclick = reloadAll
+      ? () => window.location.reload(true)
+      : () => window.history.back();
+  }
 
-document.getElementById('reload').onclick =
- function() {window.location.reload(true)};
+  const reload = document.getElementById('reload');
+  if (reload) {
+    reload.onclick = () => window.location.reload(true);
+  }
+};
+
+registerErrorLinkHandlers();
+
+$(document).on("pretix:async_task_replace_page", () => registerErrorLinkHandlers(true));


### PR DESCRIPTION
Errors.js is small enough to include by default and as a result sidestep the security implications of [replacing innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations).

Listening to the new `pretix:async_task_replace_page` event also allows us to change the backwards-link behaviour to a reload of the page whenever the page contend is replaced

