### PR TITLE
use cookieretry only on presale event pages (Z#23236752)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -26,7 +26,6 @@
     {% if event.settings.google_site_verification %}
         <meta name="google-site-verification" content="{{ event.settings.google_site_verification }}" />
     {% endif %}
-    <script type="text/javascript" src="{% static "pretixpresale/js/csrfcookieretry.js" %}"></script>
     {{ block.super }}
 {% endblock %}
 {% block above %}

--- a/src/pretix/presale/templates/pretixpresale/event/base.html
+++ b/src/pretix/presale/templates/pretixpresale/event/base.html
@@ -9,7 +9,7 @@
 {% load anonymize_email %}
 {% block thetitle %}
     {% if messages %}
-        {{ messages|join:" " }} :: 
+        {{ messages|join:" " }} ::
     {% endif %}
     {% block title %}{% endblock %}{% if request.resolver_match.url_name != "event.index" %} :: {% endif %}{{ event.name }}
 {% endblock %}
@@ -26,6 +26,7 @@
     {% if event.settings.google_site_verification %}
         <meta name="google-site-verification" content="{{ event.settings.google_site_verification }}" />
     {% endif %}
+    <script type="text/javascript" src="{% static "pretixpresale/js/csrfcookieretry.js" %}"></script>
     {{ block.super }}
 {% endblock %}
 {% block above %}

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -39,6 +39,7 @@
     {% else %}
         <meta property="og:url" content="{% abseventurl request.event "presale:event.index" %}" />
     {% endif %}
+    <script type="text/javascript" src="{% static "pretixpresale/js/csrfcookieretry.js" %}"></script>
 {% endblock %}
 {% block content %}
 

--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -1,6 +1,7 @@
 {% extends "pretixpresale/event/base.html" %}
 {% load i18n %}
 {% load l10n %}
+{% load static %}
 {% load eventurl %}
 {% load cache_large %}
 {% load money %}

--- a/src/pretix/presale/templates/pretixpresale/event/order.html
+++ b/src/pretix/presale/templates/pretixpresale/event/order.html
@@ -6,6 +6,7 @@
 {% load money %}
 {% load expiresformat %}
 {% load eventurl %}
+{% load static %}
 {% load phone_format %}
 {% load rich_text %}
 {% load getitem %}
@@ -21,6 +22,10 @@
         {% endif %}
     {% endif %}
     {% trans "Order details" %}
+{% endblock %}
+{% block custom_header %}
+    {{ block.super }}
+     <script type="text/javascript" src="{% static "pretixpresale/js/csrfcookieretry.js" %}"></script>
 {% endblock %}
 {% block content %}
     {% if "thanks" in request.GET or "paid" in request.GET %}

--- a/src/pretix/static/pretixpresale/js/csrfcookieretry.js
+++ b/src/pretix/static/pretixpresale/js/csrfcookieretry.js
@@ -1,0 +1,13 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const COOKIE_NAME = "__Host-pretix_csrftoken";
+  const RELOAD_FLAG = "csrfReloadPerformed";
+
+  const hasCookie = document.cookie
+    .split("; ")
+    .some((c) => c.startsWith(COOKIE_NAME + "="));
+
+  if (!hasCookie && !sessionStorage.getItem(RELOAD_FLAG)) {
+    sessionStorage.setItem(RELOAD_FLAG, "1");
+    location.reload();
+  }
+});

--- a/src/pretix/static/pretixpresale/js/csrfcookieretry.js
+++ b/src/pretix/static/pretixpresale/js/csrfcookieretry.js
@@ -9,5 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!hasCookie && !sessionStorage.getItem(RELOAD_FLAG)) {
     sessionStorage.setItem(RELOAD_FLAG, "1");
     location.reload();
+  } else if (hasCookie && sessionStorage.getItem(RELOAD_FLAG)) {
+      sessionStorage.removeItem(RELOAD_FLAG);
   }
 });


### PR DESCRIPTION
We are seeing a few reports of missing csrf cookies on event pages, the customers stumble upon them when adding a product to their cart.

Yesterday I was able to reproduce the behaviour by:

- opening a private safari tab
- navigating to a third party website
- entering the url to a pretix shop manually and omitting the last slash

this would lead to a request to `/organizer/shop` which we respond to with a `301` redirect to `/organizer/shop/`.
The request to `/organizer/shop/` would result in a `200` with all the right cookies in the headers, including the csrf cookie.
BUT that cookie wasn't stored in the cookiejar. 

This behaviour matches cases like these here: 
`django.security.csrf log Forbidden (CSRF cookie not set.): /{{event}}/cart/add` of which we are seeing quite a few.

~~This reproduction worked well enough on 18.06. to demo it in the dev call but a day later it doesn't work anymore.~~
I can repro again

The proposed solution here is a bit crude (but did work in testing [^1]) but loading an event index page without having a csrf token will break as soon as the user is adding something to their cart. 
So the tradeoff here is that adding the white flash of the reload is the less of an disruption than seeing the csrf error page after trying to add a product.

[^1]: on the 18.06. now I cannot get the system in the state anymore.