### PR TITLE
Improve iOS VoiceOver year dropdown selection (Z#23234442)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_subevent_calendar.html
@@ -20,28 +20,23 @@
                         <input type="hidden" name="{{ f }}" value="{{ v }}">
                     {% endif %}
                 {% endfor %}
-                <fieldset>
-                    <legend class="sr-only">{% trans "Select a month to display" %}</legend>
-                    <div>
-                        <label for="calendar-input-date">{% trans "Month" %}</label>
-                    </div>
-                    <div class="input-group">
-                        <select name="date" class="form-control" id="calendar-input-date">
-                        {% for y in subevent_list.years %}
-                            <optgroup label="{{ y }}">
-                            {% for m in subevent_list.months %}
-                                <option value="{{ y }}-{{ m|date:"m" }}" {% if m.month == subevent_list.date.month and y == subevent_list.date.year %}selected{% endif %}>{{ m|date:"F" }} {{ y }}</option>
-                            {% endfor %}
-                            </optgroup>
+                <div>
+                    <label for="calendar-input-date">{% trans "Month" %}</label>
+                </div>
+                <div class="input-group">
+                    <select name="date" class="form-control" id="calendar-input-date">
+                    {% for y in subevent_list.years %}
+                        {% for m in subevent_list.months %}
+                            <option value="{{ y }}-{{ m|date:"m" }}" {% if m.month == subevent_list.date.month and y == subevent_list.date.year %}selected{% endif %}>{{ m|date:"F" }} {{ y }}</option>
                         {% endfor %}
-                        </select>
-                        <span class="input-group-btn">
-                            <button type="submit" class="btn btn-default" aria-label="{% trans "Show month" %}">
-                                {% icon "chevron-right" %}
-                            </button>
-                        </span>
-                    </div>
-                </fieldset>
+                    {% endfor %}
+                    </select>
+                    <span class="input-group-btn">
+                        <button type="submit" class="btn btn-default" aria-label="{% trans "Show month" %}">
+                            {% icon "chevron-right" %}
+                        </button>
+                    </span>
+                </div>
             </form>
         </li>
         <li class="text-right flip">

--- a/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/calendar.html
@@ -52,28 +52,23 @@
                                     <input type="hidden" name="{{ f }}" value="{{ v }}">
                                 {% endif %}
                             {% endfor %}
-                            <fieldset>
-                                <legend class="sr-only">{% trans "Select a month to display" %}</legend>
-                                <div>
-                                    <label for="calendar-input-date">{% trans "Month" %}</label>
-                                </div>
-                                <div class="input-group">
-                                    <select name="date" class="form-control" id="calendar-input-date">
-                                    {% for y in years %}
-                                        <optgroup label="{{ y }}">
-                                        {% for m in months %}
-                                            <option value="{{ y }}-{{ m|date:"m" }}" {% if m.month == date.month and y == date.year %}selected{% endif %}>{{ m|date:"F" }} {{ y }}</option>
-                                        {% endfor %}
-                                        </optgroup>
+                            <div>
+                                <label for="calendar-input-date">{% trans "Month" %}</label>
+                            </div>
+                            <div class="input-group">
+                                <select name="date" class="form-control" id="calendar-input-date">
+                                {% for y in years %}
+                                    {% for m in months %}
+                                        <option value="{{ y }}-{{ m|date:"m" }}" {% if m.month == date.month and y == date.year %}selected{% endif %}>{{ m|date:"F" }} {{ y }}</option>
                                     {% endfor %}
-                                    </select>
-                                    <span class="input-group-btn">
-                                        <button type="submit" class="btn btn-default" aria-label="{% trans "Show month" %}">
-                                            {% icon "chevron-right" %}
-                                        </button>
-                                    </span>
-                                </div>
-                            </fieldset>
+                                {% endfor %}
+                                </select>
+                                <span class="input-group-btn">
+                                    <button type="submit" class="btn btn-default" aria-label="{% trans "Show month" %}">
+                                        {% icon "chevron-right" %}
+                                    </button>
+                                </span>
+                            </div>
                         </form>
                     </li>
                     <li class="text-right flip">


### PR DESCRIPTION
Using the calendar month-dropdown on iOS VoiceOver is harder than it needs to be.

1. The fieldset around the dropdown just adds noise and one unneccessary indirection for the form-start. This PR therefore removes the fieldset.
2. The optgroups are read like normal select-options, but cannot be selected and duplicate the year anyways as we added the year to every month as well.

One iOS VoiceOver-bug that cannot be fixed with the dropdown is, that on activating the dropdown, the focus moves to the first item of the select.

IMHO the best improvement would be to use `input type="month"`, which would need a JavaScript-based solution to 1. check if type=month is supported and the replace the select-element with this input. With a quick test I did not manage to replace the select with a type=month input on iOS only, but also on Safari macOS, which does not offer a good UI for it. :(

