### PR TITLE
Do not use redis cache at import time

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -53,6 +53,7 @@ from django.db.models import QuerySet
 from django.forms import Select, widgets
 from django.forms.widgets import FILE_INPUT_CONTRADICTION
 from django.utils.formats import date_format
+from django.utils.functional import lazy
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.text import format_lazy
@@ -324,16 +325,21 @@ class WrappedPhonePrefixSelect(Select):
     initial = None
 
     def __init__(self, initial=None):
-        choices = [("", "---------")]
+        def _get_choices():
+            choices = [("", "---------")]
 
-        if initial:
-            for prefix, values in COUNTRY_CODE_TO_REGION_CODE.items():
-                if all(v == REGION_CODE_FOR_NON_GEO_ENTITY for v in values):
-                    continue
-                if initial in values:
-                    self.initial = "+%d" % prefix
-                    break
-        choices += get_phone_prefixes_sorted_and_localized()
+            if initial:
+                for prefix, values in COUNTRY_CODE_TO_REGION_CODE.items():
+                    if all(v == REGION_CODE_FOR_NON_GEO_ENTITY for v in values):
+                        continue
+                    if initial in values:
+                        self.initial = "+%d" % prefix
+                        break
+            choices += get_phone_prefixes_sorted_and_localized()
+            return choices
+
+        choices = lazy(_get_choices, list)()
+
         super().__init__(choices=choices, attrs={
             'aria-label': pgettext_lazy('phonenumber', 'International area code'),
             'autocomplete': 'tel-country-code',

--- a/src/pretix/base/management/commands/noop.py
+++ b/src/pretix/base/management/commands/noop.py
@@ -1,0 +1,29 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Do nothing. Useful for startup performance testing."
+
+    def handle(self, *args, **options):
+        pass

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1673,7 +1673,7 @@ class CountriesAndEUAndStates(CountriesAndEU):
 
 class TaxRuleLineForm(I18nForm):
     country = LazyTypedChoiceField(
-        choices=CountriesAndEUAndStates(),
+        choices=lazy(lambda: CountriesAndEUAndStates(), CountriesAndEUAndStates),
         required=False
     )
     address_type = forms.ChoiceField(

--- a/src/tests/test_startup.py
+++ b/src/tests/test_startup.py
@@ -1,0 +1,46 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def test_start_with_redis_down():
+    """
+    This is a test that ensures that pretix is able to start without a running redis server,
+    even if one is configured.
+    """
+    with tempfile.NamedTemporaryFile(suffix="cfg") as f:
+        f.write(b"[redis]\nlocation=redis://127.0.0.99:65534/2\n")
+        f.flush()
+
+        assert subprocess.check_call(
+            [
+                sys.executable,
+                os.path.join(os.path.dirname(__file__), '../manage.py'),
+                "noop",
+            ],
+            env={
+                "PRETIX_CONFIG_FILE": f.name,
+            }
+        ) == 0


### PR DESCRIPTION
During our [2026-06-27 incident](https://pretix.eu/about/en/blog/20260630-pretix-hosted-outage/), we noticed that pretix is using redis at import time. This means that gunicorn and celery process were unable to start on servers who could currently not reach redis. This is kinda mitigated through auto-restart on systemd or docker level, but that's not really how it is supposed to work. Celery even has smart retry/reconnect logic that becomes pointless this way.