### PR TITLE
filter out the 404 log records from django.request

### DIFF
--- a/src/pretix/helpers/logs.py
+++ b/src/pretix/helpers/logs.py
@@ -46,6 +46,13 @@ class RequestIdFilter(logging.Filter):
         return True
 
 
+class SkipNotFoundFilter(logging.Filter):
+    # Drop the WARNING "Not Found: ..." records django.request emits for 404s
+    # We have different access logs for that
+    def filter(self, record):
+        return getattr(record, 'status_code', None) != 404
+
+
 class RequestIdMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response

--- a/src/pretix/settings.py
+++ b/src/pretix/settings.py
@@ -624,6 +624,9 @@ LOGGING = {
         'request_id': {
             '()': 'pretix.helpers.logs.RequestIdFilter'
         },
+        'skip_not_found': {
+            '()': 'pretix.helpers.logs.SkipNotFoundFilter',
+        }
     },
     'handlers': {
         'console': {
@@ -665,6 +668,7 @@ LOGGING = {
             'handlers': ['file', 'console', 'mail_admins'],
             'level': loglevel,
             'propagate': True,
+            'filters': ['skip_not_found'],
         },
         'pretix.security.csp': {
             'handlers': ['csp_file'],


### PR DESCRIPTION
This information is usually well placed in the access log of the webserver. Duplicating that info into the application server logs doesn't provide us any advantages.

see https://pretix.slack.com/archives/C016Y0BE2UF/p1781773269358599