### PR TITLE
Organizer calendar: Respect event_calendar_future_only (Z#23238776)

### DIFF
--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1924,8 +1924,6 @@ DEFAULTS = {
         'serializer_class': serializers.BooleanField,
         'form_kwargs': dict(
             label=_("Hide all past dates from calendar"),
-            help_text=_("This option currently only affects the calendar of this event series, not the organizer-wide "
-                        "calendar.")
         )
     },
     'allow_modifications': {

--- a/src/pretix/presale/views/organizer.py
+++ b/src/pretix/presale/views/organizer.py
@@ -650,6 +650,10 @@ def add_subevents_for_days(qs, before, after, ebd, timezones, sales_channel, eve
             if hide:
                 continue
 
+        if s.event_calendar_future_only:
+            if (se.date_to or se.date_from) < time_machine_now():
+                continue
+
         timezones.add(s.timezone)
         tz = ZoneInfo(s.timezone)
         datetime_from = se.date_from.astimezone(tz)


### PR DESCRIPTION
We initially didn't do this for two reasons:

- Performance implications of calling the settings store for every event that shows up in the calendar. As of d43e85da, we need that anyways.
- Performance implications of filtering in Python except SQL but... it can't really be worse than not filtering at all.
- We don't easily know if it's valid for all events so we can't stop rendering the unused calendar rows. That's an acceptable issue for now, still better than nothing. We can always optimize later.

So we might as well implement it.