### PR TITLE
Fix mutable default argument in notify_user_changed_order

### DIFF
--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -1566,7 +1566,7 @@ def send_download_reminders(sender, **kwargs):
                             )
 
 
-def notify_user_changed_order(order, user=None, auth=None, invoices=[]):
+def notify_user_changed_order(order, user=None, auth=None, invoices=None):
     with language(order.locale, order.event.settings.region):
         email_template = order.event.settings.mail_text_order_changed
         email_context = get_email_context(event=order.event, order=order)


### PR DESCRIPTION
Fixes #6327

invoices=[] was a shared mutable default. Cahnged to None, consistent with Order.send_mail() and mail(). No behavior change for existing callers.