### PR TITLE
Drop line numbers from gettext .po files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,8 +6,8 @@ localecompile:
 	./manage.py compilemessages
 
 localegen:
-	./manage.py makemessages --keep-pot --ignore "pretix/static/npm_dir/*" $(LNGS)
-	./manage.py makemessages --keep-pot -e js,ts,vue -d djangojs --ignore "pretix/static/npm_dir/*" --ignore "pretix/helpers/*" --ignore "pretix/static/jsi18n/*" --ignore "pretix/static/jsi18n/*" --ignore "pretix/static.dist/*" --ignore "data/*" --ignore "pretix/static/rrule/*" --ignore "build/*" $(LNGS)
+	./manage.py makemessages --keep-pot --add-location file --ignore "pretix/static/npm_dir/*" $(LNGS)
+	./manage.py makemessages --keep-pot --add-location file -e js,ts,vue -d djangojs --ignore "pretix/static/npm_dir/*" --ignore "pretix/helpers/*" --ignore "pretix/static/jsi18n/*" --ignore "pretix/static/jsi18n/*" --ignore "pretix/static.dist/*" --ignore "data/*" --ignore "pretix/static/rrule/*" --ignore "build/*" $(LNGS)
 
 staticfiles: npminstall npmbuild jsi18n
 	./manage.py collectstatic --noinput


### PR DESCRIPTION
Knowing what file a string comes from is useful, but the line number is less useful and changes a lot, causing very unreadable diffs of translation files. I propose we drop them and only include the file names