### PR TITLE
Event product list: Fix another performance issue for large series

### DIFF
--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -155,8 +155,8 @@ def get_grouped_items(event, *, channel: SalesChannel, subevent=None, voucher=No
         ).filter(
             variation_q,
             Q(all_sales_channels=True) | Q(limit_sales_channels=channel),
+            Exists(Quota.variations.through.objects.filter(quota__subevent_id=subevent, itemvariation_id=OuterRef("pk"))),
             active=True,
-            quotas__isnull=False,
             subevent_disabled=False
         ).prefetch_related(
             *prefetch_membership_types,


### PR DESCRIPTION
This is a follow-up for #6318, basically the same problem but in a neighboring query.

Performance comparison for real-world event with 13k subevents:

Before:
```
In [15]: %time get_grouped_items(e, subevent=se, channel=e.organizer.sales_channels.get(identifier="web"))
CPU times: user 49.1 ms, sys: 3.79 ms, total: 52.9 ms
Wall time: 1.12 s
Out[15]: ([<Item: xxx>], True)
```

After:
```
In [16]: %time get_grouped_items_patched(e, subevent=se, channel=e.organizer.sales_channels.get(identifier="web"))
CPU times: user 30.2 ms, sys: 445 μs, total: 30.6 ms
Wall time: 45.3 ms
Out[16]: ([<Item: xxx>], True)
```