### PR TITLE
Add trace IDs from request to celery task

### DIFF
--- a/src/pretix/celery_app.py
+++ b/src/pretix/celery_app.py
@@ -19,14 +19,55 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <https://www.gnu.org/licenses/>.
 #
+import logging
 import os
 
-from celery import Celery
+from celery import Celery, signals
+from django.dispatch import receiver
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pretix.settings")
+logger = logging.getLogger(__name__)
 
 from django.conf import settings
 
 app = Celery('pretix')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@receiver(signals.before_task_publish)
+def on_before_task_publish(sender, body, exchange, routing_key, headers, properties, declare, retry_policy, **kwargs):
+    from pretix.helpers.logs import local
+
+    trace = getattr(local, 'trace', [])
+    request_id = getattr(local, 'request_id', None)
+    if request_id:
+        trace.append(request_id)
+
+    headers["X-Pretix-Trace"] = " ".join(trace)
+
+
+@receiver(signals.task_received)
+def on_task_received(sender, request, **kwargs):
+    trace = request._request_dict.get("X-Pretix-Trace")
+    if trace:
+        logger.info(f"Task {request.id} has trace {trace}")
+
+
+@receiver(signals.task_prerun)
+def on_task_prerun(sender, task_id, task, **kwargs):
+    from pretix.helpers.logs import local
+
+    if "X-Pretix-Trace" in task.request.headers:
+        local.trace = task.request.headers["X-Pretix-Trace"].split(" ")
+    else:
+        local.trace = []
+    local.trace.append(task_id)
+
+
+@receiver(signals.task_postrun)
+def on_task_postrun(sender, task_id, task, **kwargs):
+    from pretix.helpers.logs import local
+
+    local.request_id = None
+    local.trace = []

--- a/src/pretix/celery_app.py
+++ b/src/pretix/celery_app.py
@@ -58,6 +58,7 @@ def on_task_received(sender, request, **kwargs):
 def on_task_prerun(sender, task_id, task, **kwargs):
     from pretix.helpers.logs import local
 
+    local.request_id = task_id
     if "X-Pretix-Trace" in task.request.headers:
         local.trace = task.request.headers["X-Pretix-Trace"].split(" ")
     else:

--- a/src/pretix/helpers/logs.py
+++ b/src/pretix/helpers/logs.py
@@ -20,6 +20,7 @@
 # <https://www.gnu.org/licenses/>.
 #
 import logging
+import uuid
 
 from django.core.signals import request_finished
 from django.dispatch import receiver
@@ -65,7 +66,9 @@ class RequestIdMiddleware:
                 import sentry_sdk
                 sentry_sdk.set_tag("request_id", request.request_id)
         else:
-            local.request_id = request.request_id = None
+            # Web server did not pass a request ID, we still generate one to correlate between django logs and
+            # celery logs
+            local.request_id = request.request_id = str(uuid.uuid4())
 
         return self.get_response(request)
 


### PR DESCRIPTION
Celery tasks will log the request ID they were triggered from:

    [2026-07-02 10:33:17,614: INFO/MainProcess] Task pretix.base.services.orders.cancel_order[5f3104b3-0a54-4e49-921e-c866c4dc4c6d] received
    [2026-07-02 10:33:17,614: INFO/MainProcess] Task 5f3104b3-0a54-4e49-921e-c866c4dc4c6d has trace 4d389638-00ab-4c4d-bdec-d73ac322bf44

Nested celery tasks will then contain both the request ID as well as the previous tasks:

    [2026-07-02 10:33:18,354: INFO/MainProcess] Task pretix.base.services.notifications.notify[d52a3a49-9c89-4f67-bdde-9f773586fc07] received
    [2026-07-02 10:33:18,354: INFO/MainProcess] Task d52a3a49-9c89-4f67-bdde-9f773586fc07 has trace 4d389638-00ab-4c4d-bdec-d73ac322bf44 5f3104b3-0a54-4e49-921e-c866c4dc4c6d