### PR TITLE
Remove leftovers from contact url in quick setup

### DIFF
--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -1905,12 +1905,6 @@ class QuickSetupForm(I18nForm):
         required=False,
         help_text=_("We'll show this publicly to allow attendees to contact you.")
     )
-    contact_url = forms.URLField(
-        label=_("Contact URL"),
-        required=False,
-        help_text=_("If you set this, the footer contact link will point here instead of using the email address above. "
-                    "Please note that you still need to add a contact email address that will be shared with all emails you send.")
-    )
     total_quota = forms.IntegerField(
         label=_("Total capacity"),
         min_value=0,

--- a/src/pretix/control/templates/pretixcontrol/event/quick_setup.html
+++ b/src/pretix/control/templates/pretixcontrol/event/quick_setup.html
@@ -193,7 +193,6 @@
                     {% endblocktrans %}
                 </p>
                 {% bootstrap_field form.contact_mail layout="control" %}
-                {% bootstrap_field form.contact_url layout="control" %}
                 {% bootstrap_field form.imprint_url layout="control" %}
             </div>
         </fieldset>


### PR DESCRIPTION
Those should be deleted if we don't include this option in the quick setup.