### PR TITLE
Remove more usages of |safe

### DIFF
--- a/src/pretix/base/payment.py
+++ b/src/pretix/base/payment.py
@@ -936,7 +936,7 @@ class BasePaymentProvider:
         """
         Will be called if the *event administrator* views the details of a payment.
 
-        It should return HTML code containing information regarding the current payment
+        It should return a SafeString containing HTML code, with information regarding the current payment
         status and, if applicable, next steps.
 
         The default implementation returns an empty string.
@@ -961,7 +961,7 @@ class BasePaymentProvider:
         """
         Will be called if the *event administrator* views the details of a refund.
 
-        It should return HTML code containing information regarding the current refund
+        It should return a SafeString containing HTML code, with information regarding the current refund
         status and, if applicable, next steps.
 
         The default implementation returns an empty string.

--- a/src/pretix/control/templates/pretixcontrol/auth/login_2fa.html
+++ b/src/pretix/control/templates/pretixcontrol/auth/login_2fa.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% load compress %}
+{% load escapejson %}
 {% block content %}
     <form class="form-signin" action="" method="post" id="webauthn-form">
         {% csrf_token %}
@@ -30,8 +31,7 @@
     </form>
     {% if jsondata %}
         <script type="text/json" id="webauthn-login">
-            {{ jsondata|safe }}
-
+            {{ jsondata|escapejson }}
         </script>
     {% endif %}
     {% compress js %}

--- a/src/pretix/control/templates/pretixcontrol/order/cancel.html
+++ b/src/pretix/control/templates/pretixcontrol/order/cancel.html
@@ -26,7 +26,7 @@
         {% if form.cancellation_fee %}
             {% if fee %}
                 {% with fee|money:request.event.currency as f %}
-                    <p>{% blocktrans trimmed with fee="<strong>"|add:f|add:"</strong>"|safe %}
+                    <p>{% blocktrans trimmed with fee=f|wrap_in:"strong" %}
                         The configured cancellation fee for a self-service cancellation would be {{ fee }} for this
                         order, but for a cancellation performed by you, you need to set the cancellation fee here:
                     {% endblocktrans %}</p>

--- a/src/pretix/control/templates/pretixcontrol/order/cancel.html
+++ b/src/pretix/control/templates/pretixcontrol/order/cancel.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% load money %}
+{% load wrap_in %}
 {% block title %}
     {% trans "Cancel order" %}
 {% endblock %}

--- a/src/pretix/control/templates/pretixcontrol/order/index.html
+++ b/src/pretix/control/templates/pretixcontrol/order/index.html
@@ -903,7 +903,7 @@
                                             <tr>
                                                 <td colspan="1"></td>
                                                 <td colspan="5">
-                                                    {{ p.html_info|safe }}
+                                                    {{ p.html_info }}
                                                     {% if staff_session %}
                                                         <p>
                                                             <a href="" class="btn btn-default btn-xs admin-only" data-expandpayment data-id="{{ p.pk }}">
@@ -1018,7 +1018,7 @@
                                                             </dl>
                                                         {% endif %}
                                                         {% if r.html_info %}
-                                                            {{ r.html_info|safe }}
+                                                            {{ r.html_info }}
                                                         {% endif %}
                                                         {% if staff_session %}
                                                             <p>

--- a/src/pretix/control/templates/pretixcontrol/organizers/device_connect.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/device_connect.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% load bootstrap3 %}
+{% load escapejson_dumps %}
 {% block inner %}
     <h1>{% trans "Connect to device:" %} {{ device.name }}</h1>
 
@@ -18,7 +19,7 @@
                 {% trans "Open the app that you want to connect and optionally reset it to the original state." %}
             </li>
             <li>{% trans "Scan the following configuration code:" %}<br><br>
-                <script type="text/json" data-replace-with-qr>{{ qrdata|safe }}</script><br>
+                <script type="application/json" data-replace-with-qr>{{ qrdata|escapejson_dumps }}</script><br>
                 {% trans "If your app/device does not support scanning a QR code, you can also enter the following information:" %}
                 <br>
                 <strong>{% trans "System URL:" %}</strong> <code id="system_url">{{ settings.SITE_URL }}</code>

--- a/src/pretix/control/templates/pretixcontrol/organizers/device_connect.html
+++ b/src/pretix/control/templates/pretixcontrol/organizers/device_connect.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% load bootstrap3 %}
-{% load escapejson_dumps %}
+{% load escapejson %}
 {% block inner %}
     <h1>{% trans "Connect to device:" %} {{ device.name }}</h1>
 

--- a/src/pretix/control/templates/pretixcontrol/user/2fa_confirm_totp.html
+++ b/src/pretix/control/templates/pretixcontrol/user/2fa_confirm_totp.html
@@ -1,6 +1,7 @@
 {% extends "pretixcontrol/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load escapejson %}
 {% block title %}{% trans "Add a two-factor authentication device" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Add a two-factor authentication device" %}</h1>
@@ -32,7 +33,7 @@
         </li>
         <li>
             {% trans "Add a new account to the app by scanning the following barcode:" %}
-            <div class="qrcode-canvas" data-qrdata="#qrdata"></div>
+            <script type="application/json" data-replace-with-qr>{{ qrdata|escapejson_dumps }}</script>
             <p>
                 <a data-toggle="collapse" href="#no_scan">
                     {% trans "Can't scan the barcode?" %}
@@ -81,9 +82,4 @@
         </li>
     </ol>
 
-    <script type="text/json" id="qrdata">
-        {{ qrdata|safe }}
-
-
-    </script>
 {% endblock %}

--- a/src/pretix/control/templates/pretixcontrol/user/2fa_confirm_webauthn.html
+++ b/src/pretix/control/templates/pretixcontrol/user/2fa_confirm_webauthn.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load static %}
 {% load compress %}
+{% load escapejson %}
 {% block title %}{% trans "Add a two-factor authentication device" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Add a two-factor authentication device" %}</h1>
@@ -26,9 +27,7 @@
         {% trans "Device registration failed." %}
     </div>
     <script type="text/json" id="webauthn-enroll">
-        {{ jsondata|safe }}
-
-
+        {{ jsondata|escapejson }}
     </script>
     {% compress js %}
         <script type="text/javascript" src="{% static "pretixcontrol/js/base64js.js" %}"></script>

--- a/src/pretix/control/templates/pretixcontrol/user/reauth.html
+++ b/src/pretix/control/templates/pretixcontrol/user/reauth.html
@@ -3,6 +3,7 @@
 {% load bootstrap3 %}
 {% load compress %}
 {% load static %}
+{% load escapejson %}
 {% block content %}
     <form class="form-signin" id="webauthn-form" action="" method="post">
         {% csrf_token %}
@@ -43,7 +44,7 @@
 
         {% if jsondata %}
             <script type="text/json" id="webauthn-login">
-            {{ jsondata|safe }}
+                {{ jsondata|escapejson }}
             </script>
         {% endif %}
         {% compress js %}

--- a/src/pretix/control/views/orders.py
+++ b/src/pretix/control/views/orders.py
@@ -551,10 +551,10 @@ class OrderDetail(OrderView):
         ctx['refunds'] = self.order.refunds.select_related('payment').order_by('-created')
         for p in ctx['payments']:
             if p.payment_provider:
-                p.html_info = (p.payment_provider.payment_control_render(self.request, p) or "").strip()
+                p.html_info = p.payment_provider.payment_control_render(self.request, p) or ""
         for r in ctx['refunds']:
             if r.payment_provider:
-                r.html_info = (r.payment_provider.refund_control_render(self.request, r) or "").strip()
+                r.html_info = r.payment_provider.refund_control_render(self.request, r) or ""
         ctx['invoices'] = list(self.order.invoices.all().select_related('event'))
         ctx['comment_form'] = CommentForm(initial={
             'comment': self.order.comment,

--- a/src/pretix/helpers/escapejson.py
+++ b/src/pretix/helpers/escapejson.py
@@ -47,5 +47,5 @@ def escapejson(value):
 
 @keep_lazy(str, SafeText)
 def escapejson_attr(value):
-    """Hex encodes characters for use in a html attributw script."""
+    """Hex encodes characters for use in a html attribute."""
     return mark_safe(force_str(value).translate(_json_escapes_attr))

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -323,7 +323,7 @@ $(function () {
             }
         }
     } else if ($("#stripe_payment_intent_next_action_redirect_url").length) {
-        let payment_intent_next_action_redirect_url = $.trim($("#stripe_payment_intent_next_action_redirect_url").html());
+        let payment_intent_next_action_redirect_url = JSON.parse($("#stripe_payment_intent_next_action_redirect_url").html());
         pretixstripe.handlePaymentRedirectAction(payment_intent_next_action_redirect_url);
     } else if ($.trim($("#stripe_payment_intent_action_type").html()) === "promptpay_display_qr_code") {
         waitingDialog.hide();

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/sca.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/sca.html
@@ -9,7 +9,7 @@
     <script type="text/plain" id="stripe_payment_intent_action_type">{{ payment_intent_action_type }}</script>
     <script type="text/plain" id="stripe_payment_intent_client_secret">{{ payment_intent_client_secret }}</script>
     {% if payment_intent_next_action_redirect_url %}
-        <script type="text/plain" id="stripe_payment_intent_next_action_redirect_url">{{ payment_intent_next_action_redirect_url|safe }}</script>
+        {{ payment_intent_next_action_redirect_url|json_script:"stripe_payment_intent_next_action_redirect_url" }}
     {% endif %}
     {% if payment_intent_redirect_action_handling %}
         <script type="text/plain" id="stripe_payment_intent_redirect_action_handling">{{ payment_intent_redirect_action_handling }}</script>

--- a/src/pretix/static/pretixcontrol/js/ui/main.js
+++ b/src/pretix/static/pretixcontrol/js/ui/main.js
@@ -874,14 +874,6 @@ function setup_basics(el) {
         });
     });
 
-    el.find(".qrcode-canvas").each(function () {
-        $(this).qrcode(
-            {
-                text: $.trim($($(this).attr("data-qrdata")).html())
-            }
-        );
-    });
-
     el.find(".propagated-settings-box").find("input, textarea, select").not("[readonly]")
         .attr("data-propagated-locked", "true").prop("readonly", true);
 


### PR DESCRIPTION
- html_info from payment providers
   The change of `payment_control_render` and `refund_control_render` seems safe to me, as all our payment provider plugins either return a `template.render(...)` result, which is a SafeString, or a plain string which shouldn't contain any HTML.
- `data-replace-with-qr` QR codes
  I think we should switch from `<script type='text/plain'>` to `<script type='application/json'>`, because for text/plain there is no well-defined escaping mechanism
- some other `<script>{{ some_json_string|safe }}</script>` occurences

