### PR TITLE
Fix #6117 -- fr_CA locale renders wrong event times on PDF tickets

### DIFF
--- a/src/pretix/helpers/formats/fr_CA/__init__.py
+++ b/src/pretix/helpers/formats/fr_CA/__init__.py
@@ -1,0 +1,21 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#

--- a/src/pretix/helpers/formats/fr_CA/formats.py
+++ b/src/pretix/helpers/formats/fr_CA/formats.py
@@ -1,0 +1,34 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+
+# Date according to https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+
+# Django's fr_CA locale leaves the "h" in its time formats unescaped, so it is interpreted as the
+# 12-hour-clock hour instead of a literal "h". At midnight this renders a time like "00 h 20" as
+# "00 12 20" (see GitHub issue #6117). This was fixed upstream in Django 6.0 (commit b67a36ec) but
+# was not backported to the 5.2 series we depend on, so we override the affected formats here.
+# This file can be removed once we require Django >= 6.0.
+#
+# \xa0 is the non-breaking space Django uses in the fr_CA time formats.
+TIME_FORMAT = "H\xa0\\h\xa0i"
+DATETIME_FORMAT = "j F Y, H\xa0\\h\xa0i"
+SHORT_DATETIME_FORMAT = "Y-m-d H\xa0\\h\xa0i"

--- a/src/tests/helpers/test_i18n.py
+++ b/src/tests/helpers/test_i18n.py
@@ -19,7 +19,10 @@
 # You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
 # <https://www.gnu.org/licenses/>.
 #
+import datetime
+
 import pytest
+from django.utils.formats import date_format
 from django.utils.translation import get_language
 
 from pretix.base.i18n import (
@@ -35,6 +38,17 @@ def test_js_formats():
         assert get_javascript_format('DATE_INPUT_FORMATS') == 'YYYY-MM-DD'
     with language('en-US'):
         assert get_javascript_format('DATE_INPUT_FORMATS') == 'MM/DD/YYYY'
+
+
+def test_fr_ca_time_format_escapes_literal_h():
+    # Regression test for GH #6117: Django 5.2's fr_CA locale leaves the "h" in its time formats
+    # unescaped, so it is treated as the 12-hour-clock hour. At midnight a time like "00 h 20" was
+    # therefore rendered as "00 12 20", which showed up e.g. in the event_begin/event_begin_time
+    # placeholders on ticket PDFs. The override in pretix.helpers.formats.fr_CA fixes this.
+    dt = datetime.datetime(2026, 8, 23, 0, 20)
+    with language('fr', 'CA'):
+        assert date_format(dt, 'TIME_FORMAT') == '00\xa0h\xa020'
+        assert date_format(dt, 'SHORT_DATETIME_FORMAT') == '2026-08-23 00\xa0h\xa020'
 
 
 def test_get_locale():


### PR DESCRIPTION
Fixes #6117.

**Problem.** With the `fr-ca` locale (French + region Canada), ticket-PDF placeholders like `event_begin` / `event_begin_time` render times wrongly — a begin time of `00 h 20` comes out as `00 12 20` on customer-facing PDFs.

**Cause.** pretix pins `Django==5.2.*`. Django's `fr_CA` locale defines its time formats with an unescaped `h` (`TIME_FORMAT = "H h i"`, etc.). In Django's date mini-language `h` is the 12-hour-clock hour, which is `12` at midnight — so `date_format(dt, "TIME_FORMAT")` yields `00 12 20`. pretix's PDF placeholders (`src/pretix/base/pdf.py`) go through exactly this path. Django 6.0 (commit `b67a36ec`) fixed it by escaping the `h`, but it was not backported to `stable/5.2.x`, so we're affected until we move to Django 6 — matching the "override the file in the meantime" direction discussed in the issue.

**Fix.** Add a `pretix.helpers.formats.fr_CA` override (same mechanism already used for `en_CA`, `en_NZ`, …) escaping the literal `h` in `TIME_FORMAT`, `DATETIME_FORMAT`, `SHORT_DATETIME_FORMAT`. Removable once we require Django >= 6.0.

**Test.** Regression test in `src/tests/helpers/test_i18n.py`, fail-before/pass-after (verified against Django 5.2: default fr_CA renders `00 12 20`, the override renders `00 h 20`).

**AI disclosure (per the project's AI policy).** Prepared with Claude Code (Anthropic). AI was used to locate the affected code path, cross-check Django's upstream fix, and draft the override + regression test; the change and its reasoning were reviewed and understood by a human before submission.
