### PR TITLE
Event settings: Improve wording of help message for is_remote

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -649,7 +649,7 @@ class Event(EventMixin, LoggedModel):
     is_remote = models.BooleanField(
         default=False,
         verbose_name=_("This event is remote or partially remote."),
-        help_text=_("This will be used to let users know if the event is in a different timezone and let’s us calculate users’ local times."),
+        help_text=_("This will be used to let users know if the event is in a different timezone, and to let us calculate the local time of a user."),
     )
     geo_lat = models.FloatField(
         verbose_name=_("Latitude"),


### PR DESCRIPTION
I have barely started trying out pretix, but hey: I noticed a small typo (`let's us` vs `lets us`). I adjusted the message to make it a bit easier to read.

Not sure if I need to sign the CLA for such a trivial change, or how to submit it. - edit: the bot tells me that I do not need to.