### PR TITLE
Fix sendmail/scheduled-mails preview event-based placeholders (Z#23241932)

### DIFF
--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -384,8 +384,8 @@ class RuleForm(FormPlaceholderMixin, I18nModelForm):
             ]
         )
 
-        self._set_field_placeholders('subject', ['event', 'order', 'event_or_subevent'])
-        self._set_field_placeholders('template', ['event', 'order', 'event_or_subevent'], rich=True)
+        self._set_field_placeholders('subject', ['event', 'order', 'position_or_address'])
+        self._set_field_placeholders('template', ['event', 'order', 'position_or_address'], rich=True)
 
         choices = [
             (Order.STATUS_PAID, _('Paid (or canceled with paid fee)')),

--- a/src/pretix/plugins/sendmail/forms.py
+++ b/src/pretix/plugins/sendmail/forms.py
@@ -384,8 +384,8 @@ class RuleForm(FormPlaceholderMixin, I18nModelForm):
             ]
         )
 
-        self._set_field_placeholders('subject', ['event', 'order', 'position_or_address'])
-        self._set_field_placeholders('template', ['event', 'order', 'position_or_address'], rich=True)
+        self._set_field_placeholders('subject', ['event', 'order', 'event_or_subevent', 'position_or_address'])
+        self._set_field_placeholders('template', ['event', 'order', 'event_or_subevent', 'position_or_address'], rich=True)
 
         choices = [
             (Order.STATUS_PAID, _('Paid (or canceled with paid fee)')),

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -243,7 +243,7 @@ class BaseSenderView(EventPermissionRequiredMixin, FormView):
 class OrderSendView(BaseSenderView):
     form_class = forms.OrderMailForm
     form_fragment_name = "pretixplugins/sendmail/send_form_fragment_orders.html"
-    context_parameters = ['event', 'order', 'position_or_address']
+    context_parameters = ['event', 'order', 'position_or_address', 'event_or_subevent']
     task = send_mails_to_orders
 
     ACTION_TYPE = 'pretix.plugins.sendmail.sent'

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -657,7 +657,7 @@ class UpdateRule(EventPermissionRequiredMixin, UpdateView):
 
         for lang in self.request.event.settings.locales:
             with language(lang, self.request.event.settings.region):
-                placeholders = get_sample_context(self.request.event, ['event', 'order', 'position_or_address'])
+                placeholders = get_sample_context(self.request.event, ['event', 'order', 'event_or_subevent', 'position_or_address'])
                 subject = bleach.clean(self.object.subject.localize(lang), tags=set())
                 preview_subject = prefix_subject(self.request.event, format_map(subject, placeholders), highlight=True)
                 template = self.object.template.localize(lang)

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -243,7 +243,7 @@ class BaseSenderView(EventPermissionRequiredMixin, FormView):
 class OrderSendView(BaseSenderView):
     form_class = forms.OrderMailForm
     form_fragment_name = "pretixplugins/sendmail/send_form_fragment_orders.html"
-    context_parameters = ['event', 'order', 'position_or_address', 'event_or_subevent']
+    context_parameters = ['event', 'order', 'position_or_address']
     task = send_mails_to_orders
 
     ACTION_TYPE = 'pretix.plugins.sendmail.sent'

--- a/src/tests/plugins/sendmail/conftest.py
+++ b/src/tests/plugins/sendmail/conftest.py
@@ -36,7 +36,7 @@ def event():
         date_from=now(), live=True,
         plugins='pretix.plugins.sendmail,tests.testdummy',
         location='Foo City',
-        date_admission=now().replace(hour=12, minute=30),
+        date_admission=now().replace(hour=11, minute=30),
     )
     return event
 
@@ -83,7 +83,12 @@ def event_series(event):
 
 @pytest.fixture
 def subevent1(event_series):
-    se1 = event_series.subevents.create(name='Meow', date_from=now() + datetime.timedelta(days=1))
+    se1 = event_series.subevents.create(
+        name='Meow',
+        date_from=now() + datetime.timedelta(days=1),
+        location='Meow Town',
+        date_admission=now().replace(hour=10, minute=0),
+    )
     return se1
 
 

--- a/src/tests/plugins/sendmail/conftest.py
+++ b/src/tests/plugins/sendmail/conftest.py
@@ -35,6 +35,8 @@ def event():
         organizer=o, name='Dummy', slug='dummy',
         date_from=now(), live=True,
         plugins='pretix.plugins.sendmail,tests.testdummy',
+        location='Foo City',
+        date_admission=now().replace(hour=12, minute=30),
     )
     return event
 

--- a/src/tests/plugins/sendmail/test_rules.py
+++ b/src/tests/plugins/sendmail/test_rules.py
@@ -186,7 +186,7 @@ def test_sendmail_rule_send_order_vs_pos(send_to, amount_mails, recipients, orde
 
     order.event.sendmail_rules.create(date_is_absolute=True, send_date=dt_now - datetime.timedelta(hours=1),
                                       send_to=send_to,
-                                      subject='meow', template='meow meow meow')
+                                      subject='{event}: {event_location} @ {event_admission_time}', template='meow meow meow')
     order.all_positions.create(item=item, price=0, attendee_email='meow@dummy.test')
 
     sendmail_run_rules(None)
@@ -195,6 +195,8 @@ def test_sendmail_rule_send_order_vs_pos(send_to, amount_mails, recipients, orde
 
     _recipients = [mail.to[0] for mail in djmail.outbox]
     assert set(recipients) == set(_recipients)
+
+    assert djmail.outbox[0].subject == 'Dummy: Foo City @ 11:30'
 
 
 @pytest.mark.django_db
@@ -243,7 +245,7 @@ def test_sendmail_rule_send_correct_subevent(order, event_series, subevent1, sub
 
     event_series.sendmail_rules.create(date_is_absolute=False, offset_is_after=False, send_offset_days=2,
                                        send_offset_time=datetime.time(9, 30), send_to=Rule.ATTENDEES,
-                                       subject='meow', template='meow meow meow')
+                                       subject='{event}: {event_location} @ {event_admission_time}', template='meow meow meow')
     p1 = order.all_positions.create(item=item, price=13, attendee_email='se1@dummy.test', subevent=subevent1)
     order.all_positions.create(item=item, price=23, attendee_email='se2@dummy.test', subevent=subevent2)
 
@@ -252,6 +254,8 @@ def test_sendmail_rule_send_correct_subevent(order, event_series, subevent1, sub
     assert len(djmail.outbox) == 1
 
     assert djmail.outbox[0].to[0] == p1.attendee_email
+
+    assert djmail.outbox[0].subject == 'Meow: Meow Town @ 10:00'
 
 
 @pytest.mark.django_db

--- a/src/tests/plugins/sendmail/test_sendmail.py
+++ b/src/tests/plugins/sendmail/test_sendmail.py
@@ -395,7 +395,7 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
                                           'recipients': 'attendees',
                                           'items': i2.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
+                                          'message_0': 'This is a test file for sending mails.',
                                           },
                                          follow=True)
     assert response.status_code == 200
@@ -404,7 +404,6 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
     assert djmail.outbox[0].to == ['attendee2@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
-    assert 'This is a test file for sending mails. Dummy, Foo City, Admission 12:30' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -413,8 +412,8 @@ def test_sendmail_attendee_subevent_filter(logged_in_client, sendmail_url, event
     event.has_subevents = True
     event.save()
     with scopes_disabled():
-        se1 = event.subevents.create(name='Subevent FOO', date_from=now(), location='FOO Town', date_admission=now().replace(hour=15))
-        se2 = event.subevents.create(name='Bar', date_from=now(), location='Bar City')
+        se1 = event.subevents.create(name='Subevent FOO', date_from=now())
+        se2 = event.subevents.create(name='Bar', date_from=now())
         pos.attendee_email = 'attendee1@dummy.test'
         pos.subevent = se1
         pos.save()
@@ -430,7 +429,7 @@ def test_sendmail_attendee_subevent_filter(logged_in_client, sendmail_url, event
                                           'recipients': 'attendees',
                                           'items': item.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
+                                          'message_0': 'This is a test file for sending mails.',
                                           'subevent': se2.pk,
                                           },
                                          follow=True)
@@ -440,7 +439,6 @@ def test_sendmail_attendee_subevent_filter(logged_in_client, sendmail_url, event
     assert djmail.outbox[0].to == ['attendee2@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
-    assert 'This is a test file for sending mails. Subevent FOO, FOO Town, 15:00' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -466,7 +464,7 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
                                           'recipients': 'attendees',
                                           'items': item.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails.',
+                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
                                           'subevents_from_0': '2023-07-01',
                                           'subevents_from_1': '00:00:00',
                                           'subevents_to_0': '2023-08-01',
@@ -479,6 +477,7 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
     assert djmail.outbox[0].to == ['attendee1@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
+    assert 'This is a test file for sending mails. ' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db

--- a/src/tests/plugins/sendmail/test_sendmail.py
+++ b/src/tests/plugins/sendmail/test_sendmail.py
@@ -464,7 +464,7 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
                                           'recipients': 'attendees',
                                           'items': item.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails.',
+                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
                                           'subevents_from_0': '2023-07-01',
                                           'subevents_from_1': '00:00:00',
                                           'subevents_to_0': '2023-08-01',
@@ -477,6 +477,7 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
     assert djmail.outbox[0].to == ['attendee1@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
+    assert 'This is a test file for sending mails. ' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -599,7 +600,7 @@ def test_waitinglist_sendmail_simple_case(logged_in_client, sendmail_url, event,
                                      {'action': 'send',
                                       'items': waitinglistentry.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails.',
+                                      'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -608,7 +609,7 @@ def test_waitinglist_sendmail_simple_case(logged_in_client, sendmail_url, event,
     assert len(djmail.outbox) == 1
     assert djmail.outbox[0].to == [waitinglistentry.email]
     assert djmail.outbox[0].subject == 'Test subject'
-    assert 'This is a test file for sending mails.' in djmail.outbox[0].body
+    assert 'This is a test file for sending mails. Dummy, Foo City, Admission 12:30' in djmail.outbox[0].body
 
     url = sendmail_url + 'history/'
     response = logged_in_client.get(url)

--- a/src/tests/plugins/sendmail/test_sendmail.py
+++ b/src/tests/plugins/sendmail/test_sendmail.py
@@ -464,7 +464,7 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
                                           'recipients': 'attendees',
                                           'items': item.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
+                                          'message_0': 'This is a test file for sending mails.',
                                           'subevents_from_0': '2023-07-01',
                                           'subevents_from_1': '00:00:00',
                                           'subevents_to_0': '2023-08-01',
@@ -477,7 +477,6 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
     assert djmail.outbox[0].to == ['attendee1@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
-    assert 'This is a test file for sending mails. ' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -600,7 +599,7 @@ def test_waitinglist_sendmail_simple_case(logged_in_client, sendmail_url, event,
                                      {'action': 'send',
                                       'items': waitinglistentry.item_id,
                                       'subject_0': 'Test subject',
-                                      'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
+                                      'message_0': 'This is a test file for sending mails.',
                                       },
                                      follow=True)
     assert response.status_code == 200
@@ -609,7 +608,7 @@ def test_waitinglist_sendmail_simple_case(logged_in_client, sendmail_url, event,
     assert len(djmail.outbox) == 1
     assert djmail.outbox[0].to == [waitinglistentry.email]
     assert djmail.outbox[0].subject == 'Test subject'
-    assert 'This is a test file for sending mails. Dummy, Foo City, Admission 12:30' in djmail.outbox[0].body
+    assert 'This is a test file for sending mails.' in djmail.outbox[0].body
 
     url = sendmail_url + 'history/'
     response = logged_in_client.get(url)

--- a/src/tests/plugins/sendmail/test_sendmail.py
+++ b/src/tests/plugins/sendmail/test_sendmail.py
@@ -395,7 +395,7 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
                                           'recipients': 'attendees',
                                           'items': i2.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails.',
+                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
                                           },
                                          follow=True)
     assert response.status_code == 200
@@ -404,6 +404,7 @@ def test_sendmail_attendee_product_filter(logged_in_client, sendmail_url, event,
     assert djmail.outbox[0].to == ['attendee2@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
+    assert 'This is a test file for sending mails. Dummy, Foo City, Admission 12:30' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -412,8 +413,8 @@ def test_sendmail_attendee_subevent_filter(logged_in_client, sendmail_url, event
     event.has_subevents = True
     event.save()
     with scopes_disabled():
-        se1 = event.subevents.create(name='Subevent FOO', date_from=now())
-        se2 = event.subevents.create(name='Bar', date_from=now())
+        se1 = event.subevents.create(name='Subevent FOO', date_from=now(), location='FOO Town', date_admission=now().replace(hour=15))
+        se2 = event.subevents.create(name='Bar', date_from=now(), location='Bar City')
         pos.attendee_email = 'attendee1@dummy.test'
         pos.subevent = se1
         pos.save()
@@ -429,7 +430,7 @@ def test_sendmail_attendee_subevent_filter(logged_in_client, sendmail_url, event
                                           'recipients': 'attendees',
                                           'items': item.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails.',
+                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
                                           'subevent': se2.pk,
                                           },
                                          follow=True)
@@ -439,6 +440,7 @@ def test_sendmail_attendee_subevent_filter(logged_in_client, sendmail_url, event
     assert djmail.outbox[0].to == ['attendee2@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
+    assert 'This is a test file for sending mails. Subevent FOO, FOO Town, 15:00' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db
@@ -464,7 +466,7 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
                                           'recipients': 'attendees',
                                           'items': item.pk,
                                           'subject_0': 'Test subject',
-                                          'message_0': 'This is a test file for sending mails. {event}, {event_location}, Admission {event_admission_time}',
+                                          'message_0': 'This is a test file for sending mails.',
                                           'subevents_from_0': '2023-07-01',
                                           'subevents_from_1': '00:00:00',
                                           'subevents_to_0': '2023-08-01',
@@ -477,7 +479,6 @@ def test_sendmail_attendee_subevent_range_filter(logged_in_client, sendmail_url,
     assert djmail.outbox[0].to == ['attendee1@dummy.test']
     assert '/ticket/' in djmail.outbox[0].body
     assert '/order/' not in djmail.outbox[0].body
-    assert 'This is a test file for sending mails. ' in djmail.outbox[0].body
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Event-based placeholders were available and worked when sending the actual email, but not when rendered in preview. This PR also adds test for sent emails to really contain the placeholders.