### PR TITLE
Allow `frame-ancestors` in custom CSP header

### DIFF
--- a/src/pretix/base/middleware.py
+++ b/src/pretix/base/middleware.py
@@ -280,8 +280,8 @@ def _parse_csp(header):
 
 
 VALID_CSP_DIRECTIVES = [
-    "child-src", "connect-src", "default-src", "fenced-frame-src", "font-src", "form-action", "frame-src", "img-src",
-    "manifest-src", "media-src", "object-src", "prefetch-src", "report-uri", "script-src", "script-src-elem",
+    "child-src", "connect-src", "default-src", "fenced-frame-src", "font-src", "form-action", "frame-src", "frame-ancestors",
+    "img-src", "manifest-src", "media-src", "object-src", "prefetch-src", "report-uri", "script-src", "script-src-elem",
     "script-src-attr", "style-src", "style-src-elem", "style-src-attr", "worker-src",
 ]
 


### PR DESCRIPTION
This PR permits the specification of the [`frame-ancestors`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors) CSP directive in the respective configuration field (`pretix.csp_additional_header`).

Current behavior: raises ValueError and thus HTTP 500 after update. 