### PR TITLE
Presale: Frontend enforcement of max item per order

### DIFF
--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -864,7 +864,7 @@ class Event(EventMixin, LoggedModel):
             self.settings.get('payment_term_last', as_type=RelativeDateWrapper).datetime(self).date(),
             time(hour=23, minute=59, second=59)
         ), tz)
-        
+
     @property
     def max_items_per_order(self):
         """

--- a/src/pretix/base/models/event.py
+++ b/src/pretix/base/models/event.py
@@ -864,6 +864,14 @@ class Event(EventMixin, LoggedModel):
             self.settings.get('payment_term_last', as_type=RelativeDateWrapper).datetime(self).date(),
             time(hour=23, minute=59, second=59)
         ), tz)
+        
+    @property
+    def max_items_per_order(self):
+        """
+        Returns the maximum number of items that can be ordered in a single order. This is the minimum of
+        the global limit and the event-specific limit.
+        """
+        return min(int(self.settings.max_items_per_order), settings.PRETIX_MAX_ORDER_SIZE)
 
     def allow_copy_data(self, new_organizer, auth) -> bool:
         """

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -41,7 +41,6 @@ from typing import List, Optional
 
 from celery.exceptions import MaxRetriesExceededError
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import DatabaseError, transaction
 from django.db.models import Count, Exists, IntegerField, OuterRef, Q, Value

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -558,7 +558,7 @@ class CartManager:
             cartsize += sum([op.count for op in self._operations if isinstance(op, self.AddOperation) and not op.addon_to])
             cartsize -= len([1 for op in self._operations if isinstance(op, self.RemoveOperation) if
                              not op.position.addon_to_id])
-            limit = min(int(self.event.settings.max_items_per_order), settings.PRETIX_MAX_ORDER_SIZE)
+            limit = self.event.max_items_per_order
             if cartsize > limit:
                 raise CartError(error_messages['max_items'] % limit)
 

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -802,7 +802,7 @@ def _check_positions(event: Event, now_dt: datetime, time_machine_now_dt: dateti
     v_avail = Counter()
 
     # Check maximum order size
-    limit = min(int(event.settings.max_items_per_order), settings.PRETIX_MAX_ORDER_SIZE)
+    limit = event.max_items_per_order
     if sum(1 for cp in sorted_positions if not cp.addon_to) > limit:
         err = err or (error_messages['max_items'] % limit)
 

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_addon_choice.html
@@ -7,13 +7,13 @@
 {% load rich_text %}
 {% for c in form.categories %}
     {% with category_idx=forloop.counter %}
-    <fieldset data-addon-max-count="{{ c.max_count }}"{% if c.multi_allowed %} data-addon-multi-allowed{% endif %}>
+    <fieldset data-max-count="{{ c.max_count }}"{% if c.multi_allowed %} data-multi-allowed{% endif %}>
         <legend>{{ c.category.name }}</legend>
         {% if c.category.description %}
             {{ c.category.description|rich_text }}
         {% endif %}
         {% if c.min_count == c.max_count %}
-            <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
+            <p class="count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc">
                 {% blocktrans trimmed count min_count=c.min_count %}
                     You need to choose exactly one option from this category.
                 {% plural %}
@@ -22,7 +22,7 @@
             </p>
         {% elif c.min_count == 0 and c.max_count >= c.items|length and not c.multi_allowed %}
         {% elif c.min_count == 0 %}
-            <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
+            <p class="count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc">
                 {% blocktrans trimmed count max_count=c.max_count %}
                     You can choose one option from this category.
                 {% plural %}
@@ -30,7 +30,7 @@
                 {% endblocktrans %}
             </p>
         {% else %}
-            <p class="addon-count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
+            <p class="count-desc" id="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc">
                 {% blocktrans trimmed with min_count=c.min_count max_count=c.max_count %}
                     You can choose between {{ min_count }} and {{ max_count }} options from
                     this category.
@@ -198,12 +198,12 @@
                                                         id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                         aria-labelledby="cp-{{ form.pos.pk }}-item-{{ item.pk }}-{{ var.pk }}-legend cp-{{ form.pos.pk }}-item-{{ item.pk }}-legend"
-                                                        aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
+                                                        aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc">
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" context "checkbox" %}
                                             </label>
                                         {% else %}
-                                            <fieldset class="input-item-count-group" aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
+                                            <fieldset class="input-item-count-group" aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
                                                 <legend class="sr-only">{% trans "Quantity" %}</legend>
                                                 <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="- {{ item }}, {{ var }}: {% trans "Decrease quantity" %}">-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
@@ -211,7 +211,7 @@
                                                     {% if item.free_price %}
                                                        data-checked-onchange="price-variation-{{form.pos.pk}}-{{ item.pk }}-{{ var.pk }}"
                                                     {% endif %}
-                                                    max="{{ c.max_count }}"
+                                                    max-selection="{{ c.max_count }}"
                                                     id="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                     name="cp_{{ form.pos.pk }}_variation_{{ item.id }}_{{ var.id }}"
                                                     aria-labelledby="cp-{{ form.pos.pk }}-item-{{ item.pk }}-{{ var.pk }}-legend cp-{{ form.pos.pk }}-item-{{ item.pk }}-legend">
@@ -344,19 +344,19 @@
                                             name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             id="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                             aria-labelledby="cp-{{ form.pos.pk }}-item-{{ item.pk }}-legend"
-                                            aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc">
+                                            aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc">
                                             <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                             {% trans "Select" context "checkbox" %}
                                 </label>
                             {% else %}
-                                <fieldset class="input-item-count-group" aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-addon-count-desc cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
+                                <fieldset class="input-item-count-group" aria-describedby="c-{{ form.pos.pk }}-{{ category_idx }}-count-desc cp-{{ form.pos.pk }}-item-{{ item.pk }}-min-order">
                                     <legend class="sr-only">{% trans "Quantity" %}</legend>
                                     <button type="button" data-step="-1" data-controls="cp_{{ form.pos.pk }}_item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="- {{ item }}: {% trans "Decrease quantity" %}">-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
                                         {% if item.free_price %}
                                            data-checked-onchange="price-item-{{ form.pos.pk }}-{{ item.pk }}"
                                         {% endif %}
-                                        max="{{ c.max_count }}"
+                                        max-selection="{{ c.max_count }}"
                                         {% if item.initial %}value="{{ item.initial }}"{% endif %}
                                         name="cp_{{ form.pos.pk }}_item_{{ item.id }}"
                                         id="cp_{{ form.pos.pk }}_item_{{ item.id }}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_cart.html
@@ -298,7 +298,7 @@
                     </form>
                     {% endif %}
                     {{ line.count }}
-                    {% if editable %}
+                    {% if editable and cart.itemcount < max_items %}
                     <form action="{% eventurl event "presale:event.cart.add" cart_namespace=cart_namespace|default_if_none:"" %}"
                             data-asynctask-headline="{% trans "We're trying to reserve another one for you!" %}"
                             data-asynctask-text="{% blocktrans with time=event.settings.reservation_time %}Once the items are in your cart, you will have {{ time }} minutes to complete your purchase.{% endblocktrans %}"

--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -7,6 +7,25 @@
 {% load getitem %}
 {% load eventsignal %}
 {% load rich_text %}
+<fieldset data-max-count="{{ max_items }}" data-multi-allowed data-count-in-cart>
+<p class="count-desc" id="count-desc">
+    {% if max_items == 1 %}
+        {% blocktrans trimmed %}
+            You can choose only one product.
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans trimmed with max_count=max_items %}
+            You can choose up to {{ max_count }} products.
+        {% endblocktrans %}
+    {% endif %}
+    {% if cart.itemcount > 0 %}
+        {% blocktrans trimmed count count=cart.itemcount %}
+            You have already made one selection.
+        {% plural %}
+            You have already selected {{ count }} products.
+        {% endblocktrans %}
+    {% endif %}
+</p>
 {% for tup in items_by_category %}{% with category=tup.0 items=tup.1 form_prefix=tup.2 %}
     {% if category %}
         <section class="item-category" aria-labelledby="{{ form_prefix }}category-{{ category.id }}"{% if category.description %} aria-describedby="{{ form_prefix }}category-info-{{ category.id }}"{% endif %}>
@@ -36,12 +55,12 @@
                         <div class="col-md-8 col-sm-6 col-xs-12">
                             {% if item.picture %}
                                 <a href="{{ item.picture.url }}" class="productpicture"
-                                   data-title="{{ item.name|force_escape|force_escape }}"
+                                data-title="{{ item.name|force_escape|force_escape }}"
                                         {# Yes, double-escape to prevent XSS in lightbox #}
-                                   data-lightbox="{{ item.id }}"
-                                   aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
+                                data-lightbox="{{ item.id }}"
+                                aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
                                     <img src="{{ item.picture|thumb:'60x60^' }}"
-                                         alt="{{ item.name }}"/>
+                                        alt="{{ item.name }}"/>
                                 </a>
                             {% endif %}
                             <div class="product-description {% if item.picture %}with-picture{% endif %}">
@@ -168,22 +187,23 @@
                                         <div class="input-group input-group-price">
                                             <span class="input-group-addon">{{ event.currency }}</span>
                                             <input type="number" class="form-control input-item-price"
-                                                   id="{{ form_prefix }}price-variation-{{ item.pk }}-{{ var.pk }}"
-                                                   {% if not ev.presale_is_running %}disabled{% endif %}
-                                                   placeholder="0"
-                                                   min="{% if event.settings.display_net_prices %}{{ var.display_price.net|money_numberfield:event.currency }}{% else %}{{ var.display_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                                   name="{{ form_prefix }}price_{{ item.id }}_{{ var.id }}"
-                                                   {% if var.suggested_price.gross != var.display_price.gross %}
-                                                       {% if event.settings.display_net_prices %}
-                                                           title="{% blocktrans trimmed with item=var.value price=var.display_price.net|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
-                                                       {% else %}
-                                                           title="{% blocktrans trimmed with item=var.value price=var.display_price.gross|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
-                                                       {% endif %}
-                                                   {% else %}
-                                                       title="{% blocktrans trimmed with item=var.value %}Modify price for {{ item }}{% endblocktrans %}"
-                                                   {% endif %}
-                                                   step="any"
-                                                   value="{% if event.settings.display_net_prices %}{{ var.suggested_price.net|money_numberfield:event.currency }}{% else %}{{ var.suggested_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                                id="{{ form_prefix }}price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                already-in-cart="{{ cart.itemvarsums|getitem:var|default:0 }}"
+                                                {% if not ev.presale_is_running %}disabled{% endif %}
+                                                placeholder="0"
+                                                min="{% if event.settings.display_net_prices %}{{ var.display_price.net|money_numberfield:event.currency }}{% else %}{{ var.display_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                                name="{{ form_prefix }}price_{{ item.id }}_{{ var.id }}"
+                                                {% if var.suggested_price.gross != var.display_price.gross %}
+                                                    {% if event.settings.display_net_prices %}
+                                                        title="{% blocktrans trimmed with item=var.value price=var.display_price.net|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
+                                                    {% else %}
+                                                        title="{% blocktrans trimmed with item=var.value price=var.display_price.gross|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
+                                                    {% endif %}
+                                                {% else %}
+                                                    title="{% blocktrans trimmed with item=var.value %}Modify price for {{ item }}{% endblocktrans %}"
+                                                {% endif %}
+                                                step="any"
+                                                value="{% if event.settings.display_net_prices %}{{ var.suggested_price.net|money_numberfield:event.currency }}{% else %}{{ var.suggested_price.gross|money_numberfield:event.currency }}{% endif %}"
                                             >
                                         </div>
                                         <p>
@@ -222,17 +242,18 @@
                                 </div>
                                 {% if var.cached_availability.0 == 100 and not item.current_unavailability_reason and not var.current_unavailability_reason %}
                                     <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
-										{% if var.order_max == 1 %}
+                                        {% if var.order_max == 1 %}
                                             <label class="btn btn-default btn-checkbox{% if not ev.presale_is_running %} disabled{% endif %}">
                                                 <input type="checkbox" value="1"
                                                     {% if item.free_price %}
-                                                       data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
                                                     {% endif %}
-                                                       {% if not ev.presale_is_running %}disabled{% endif %}
-                                                       id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-legend {{ form_prefix }}item-{{ item.pk }}-legend"
-                                                       {% if var.description %} aria-describedby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
+                                                    {% if not ev.presale_is_running %}disabled{% endif %}
+                                                    already-in-cart="{{ cart.itemvarsums|getitem:var|default:0 }}"
+                                                    id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                    name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                    aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-legend {{ form_prefix }}item-{{ item.pk }}-legend"
+                                                    {% if var.description %} aria-describedby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-description"{% endif %}>
                                                 <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                                 {% trans "Select" context "checkbox" %}
                                             </label>
@@ -242,14 +263,15 @@
                                                 <button type="button" data-step="-1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-dec" aria-label="- {{ item }}, {{ var }}: {% trans "Decrease quantity" %}"
                                                     {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                                 <input type="number" class="form-control input-item-count" placeholder="0" min="0"
-                                                       {% if not ev.presale_is_running %}disabled{% endif %}
-                                                        {% if item.free_price %}
-                                                           data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
-                                                        {% endif %}
-                                                       max="{{ var.order_max }}"
-                                                       id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
-                                                       aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-legend {{ form_prefix }}item-{{ item.pk }}-legend">
+                                                    {% if not ev.presale_is_running %}disabled{% endif %}
+                                                    {% if item.free_price %}
+                                                        data-checked-onchange="price-variation-{{ item.pk }}-{{ var.pk }}"
+                                                    {% endif %}
+                                                    max-selection="{{ var.order_max }}"
+                                                    already-in-cart="{{ cart.itemvarsums|getitem:var|default:0 }}"
+                                                    id="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                    name="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}"
+                                                    aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-{{ var.pk }}-legend {{ form_prefix }}item-{{ item.pk }}-legend">
                                                 <button type="button" data-step="1" data-controls="{{ form_prefix }}variation_{{ item.id }}_{{ var.id }}" class="btn btn-default input-item-count-inc" aria-label="+ {{ item }}, {{ var }}: {% trans "Increase quantity" %}"
                                                     {% if not ev.presale_is_running %}disabled{% endif %}>+</button>
                                             </fieldset>
@@ -271,12 +293,12 @@
                     <div class="col-md-8 col-sm-6 col-xs-12">
                         {% if item.picture %}
                             <a href="{{ item.picture.url }}" class="productpicture"
-                               data-title="{{ item.name|force_escape|force_escape }}"
+                            data-title="{{ item.name|force_escape|force_escape }}"
                                     {# Yes, double-escape to prevent XSS in lightbox #}
-                               data-lightbox="{{ item.id }}"
-                               aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
+                            data-lightbox="{{ item.id }}"
+                            aria-label="{% blocktrans trimmed with item=item.name %}Show full-size image of {{ item }}{% endblocktrans %}">
                                 <img src="{{ item.picture|thumb:'60x60^' }}"
-                                     alt="{{ item.name }}"/>
+                                    alt="{{ item.name }}"/>
                             </a>
                         {% endif %}
                         <div class="product-description {% if item.picture %}with-picture{% endif %}">
@@ -335,21 +357,22 @@
                             <div class="input-group input-group-price">
                                 <span class="input-group-addon" aria-hidden="true">{{ event.currency }}</span>
                                 <input type="number" class="form-control input-item-price" placeholder="0"
-                                       id="{{ form_prefix }}price-item-{{ item.pk }}"
-                                       {% if not ev.presale_is_running %}disabled{% endif %}
-                                       min="{% if event.settings.display_net_prices %}{{ item.display_price.net|money_numberfield:event.currency }}{% else %}{{ item.display_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                       name="{{ form_prefix }}price_{{ item.id }}"
-                                       {% if item.suggested_price.gross != item.display_price.gross %}
-                                           {% if event.settings.display_net_prices %}
+                                    id="{{ form_prefix }}price-item-{{ item.pk }}"
+                                    {% if not ev.presale_is_running %}disabled{% endif %}
+                                    already-in-cart="{{ cart.itemvarsums|getitem:item|default:0 }}"
+                                    min="{% if event.settings.display_net_prices %}{{ item.display_price.net|money_numberfield:event.currency }}{% else %}{{ item.display_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                    name="{{ form_prefix }}price_{{ item.id }}"
+                                    {% if item.suggested_price.gross != item.display_price.gross %}
+                                        {% if event.settings.display_net_prices %}
                                                 title="{% blocktrans trimmed with item=item.name price=item.display_price.net|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
-                                           {% else %}
-                                               title="{% blocktrans trimmed with item=item.name price=item.display_price.gross|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
-                                           {% endif %}
-                                       {% else %}
-                                           title="{% blocktrans trimmed with item=item.name %}Modify price for {{ item }}{% endblocktrans %}"
-                                       {% endif %}
-                                       value="{% if event.settings.display_net_prices %}{{ item.suggested_price.net|money_numberfield:event.currency }}{% else %}{{ item.suggested_price.gross|money_numberfield:event.currency }}{% endif %}"
-                                       step="any">
+                                        {% else %}
+                                            title="{% blocktrans trimmed with item=item.name price=item.display_price.gross|money:event.currency %}Modify price for {{ item }}, at least {{ price }}{% endblocktrans %}"
+                                        {% endif %}
+                                    {% else %}
+                                        title="{% blocktrans trimmed with item=item.name %}Modify price for {{ item }}{% endblocktrans %}"
+                                    {% endif %}
+                                    value="{% if event.settings.display_net_prices %}{{ item.suggested_price.net|money_numberfield:event.currency }}{% else %}{{ item.suggested_price.gross|money_numberfield:event.currency }}{% endif %}"
+                                    step="any">
                             </div>
                             <p>
                         {% elif not item.display_price.gross %}
@@ -387,16 +410,17 @@
                     </div>
                     {% if item.cached_availability.0 == 100 and not item.current_unavailability_reason %}
                         <div class="col-md-2 col-sm-3 col-xs-6 availability-box available">
-							{% if item.order_max == 1 %}
+                            {% if item.order_max == 1 %}
                                 <label class="btn btn-default btn-checkbox{% if not ev.presale_is_running %} disabled{% endif %}">
                                     <input type="checkbox" value="1" {% if itemnum == 1 %}checked{% endif %}
                                         {% if item.free_price %}
-                                           data-checked-onchange="price-item-{{ item.pk }}"
+                                            data-checked-onchange="price-item-{{ item.pk }}"
                                         {% endif %}
-                                           {% if not ev.presale_is_running %}disabled{% endif %}
-                                           name="{{ form_prefix }}item_{{ item.id }}" id="{{ form_prefix }}item_{{ item.id }}"
-                                           aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-legend"
-                                           {% if item.description %} aria-describedby="{{ form_prefix }}item-{{ item.id }}-description"{% endif %}>
+                                        {% if not ev.presale_is_running %}disabled{% endif %}
+                                        already-in-cart="{{ cart.itemvarsums|getitem:item|default:0 }}"
+                                        name="{{ form_prefix }}item_{{ item.id }}" id="{{ form_prefix }}item_{{ item.id }}"
+                                        aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-legend"
+                                        {% if item.description %} aria-describedby="{{ form_prefix }}item-{{ item.id }}-description"{% endif %}>
                                         <i class="fa fa-shopping-cart" aria-hidden="true"></i>
                                         {% trans "Select" context "checkbox" %}
                                 </label>
@@ -406,15 +430,16 @@
                                     <button type="button" data-step="-1" data-controls="{{ form_prefix }}item_{{ item.id }}" class="btn btn-default input-item-count-dec" aria-label="- {{ item }}: {% trans "Decrease quantity" %}"
                                         {% if not ev.presale_is_running %}disabled{% endif %}>-</button>
                                     <input type="number" class="form-control input-item-count" placeholder="0" min="0"
-                                           {% if not ev.presale_is_running %}disabled{% endif %}
-                                           {% if itemnum == 1 %}value="1"{% endif %}
-                                            {% if item.free_price %}
-                                               data-checked-onchange="price-item-{{ item.pk }}"
-                                            {% endif %}
-                                           max="{{ item.order_max }}"
-                                           name="{{ form_prefix }}item_{{ item.id }}"
-                                           id="{{ form_prefix }}item_{{ item.id }}"
-                                           aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-legend">
+                                        {% if not ev.presale_is_running %}disabled{% endif %}
+                                        {% if itemnum == 1 %}value="1"{% endif %}
+                                        {% if item.free_price %}
+                                            data-checked-onchange="price-item-{{ item.pk }}"
+                                        {% endif %}
+                                        already-in-cart="{{ cart.itemvarsums|getitem:item|default:0 }}"
+                                        max-selection="{{ item.order_max }}"
+                                        name="{{ form_prefix }}item_{{ item.id }}"
+                                        id="{{ form_prefix }}item_{{ item.id }}"
+                                        aria-labelledby="{{ form_prefix }}item-{{ item.pk }}-legend">
                                     <button type="button" data-step="1" data-controls="{{ form_prefix }}item_{{ item.id }}" class="btn btn-default input-item-count-inc" aria-label="+ {{ item }}: {% trans "Increase quantity" %}"
                                         {% if not ev.presale_is_running %}disabled{% endif %}>+</button>
                                 </fieldset>
@@ -429,3 +454,4 @@
         {% endfor %}
     </section>
 {% endwith %}{% endfor %}
+</fieldset>

--- a/src/pretix/presale/views/event.py
+++ b/src/pretix/presale/views/event.py
@@ -244,6 +244,7 @@ class EventIndex(EventViewMixin, EventListMixin, CartMixin, TemplateView):
             context['items_by_category'] = item_group_by_category(items)
             context['display_add_to_cart'] = display_add_to_cart
 
+        context['max_items'] = self.request.event.max_items_per_order
         context['cart'] = self.get_cart()
         context['has_addon_choices'] = any(cp.has_addon_choices for cp in get_cart(self.request))
 

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -144,20 +144,6 @@ var form_handlers = function (el) {
         ).find("canvas").attr("role", "img").attr("aria-label", this.getAttribute("data-desc"));
     });
 
-    /*
-    - fieldset-max-count (MAX NUMBER PER SECTION)
-    - availability-box input (I vari input)
-    - count-desc (TEXT TO SHOW WHEN MAX IS REACHED)
-    - count-in-cart (If present (hasAttribute), count how many of the items are already in the cart and add them to the count)
-    - max-count
-
-    Per contare:
-    - Per ogni input, predere l'item id e cercarlo nel cart quanti di quell'item id sono già nel carrello
-    - sommare quanti item sono nella selezione
-
-    Se count > max, mantenere logica
-    */
-
     el.find("fieldset[data-max-count]").each(function() {
         // usually addons are only allowed once one per item
         var multipleAllowed = this.hasAttribute("data-multi-allowed");

--- a/src/pretix/static/pretixpresale/js/ui/main.js
+++ b/src/pretix/static/pretixpresale/js/ui/main.js
@@ -144,13 +144,34 @@ var form_handlers = function (el) {
         ).find("canvas").attr("role", "img").attr("aria-label", this.getAttribute("data-desc"));
     });
 
+    /*
+    - fieldset-max-count (MAX NUMBER PER SECTION)
+    - availability-box input (I vari input)
+    - count-desc (TEXT TO SHOW WHEN MAX IS REACHED)
+    - count-in-cart (If present (hasAttribute), count how many of the items are already in the cart and add them to the count)
+    - max-count
 
-    el.find("fieldset[data-addon-max-count]").each(function() {
+    Per contare:
+    - Per ogni input, predere l'item id e cercarlo nel cart quanti di quell'item id sono già nel carrello
+    - sommare quanti item sono nella selezione
+
+    Se count > max, mantenere logica
+    */
+
+    el.find("fieldset[data-max-count]").each(function() {
         // usually addons are only allowed once one per item
-        var multipleAllowed = this.hasAttribute("data-addon-multi-allowed");
+        var multipleAllowed = this.hasAttribute("data-multi-allowed");
+        var countInCart = this.hasAttribute("data-count-in-cart");
         var $inputs = $(".availability-box input", this);
-        var max = parseInt(this.getAttribute("data-addon-max-count"));
-        var desc = $(".addon-count-desc", this).text().trim();
+        var max = parseInt(this.getAttribute("data-max-count"));
+        var desc = $(".count-desc", this).text().trim();
+
+        var showToolTip = function (element) {
+            $(element).trigger("change").closest(".availability-box").tooltip({
+                "title": desc,
+            }).tooltip('show');
+        }
+
         this.addEventListener("change", function (e) {
             var variations = e.target.closest(".variations");
             if (variations && !multipleAllowed && e.target.checked) {
@@ -158,27 +179,44 @@ var form_handlers = function (el) {
                 $(".availability-box input:checked", variations).not(e.target).prop("checked", false).trigger("change");
             }
 
+            var totalSelected = $inputs.toArray().reduce(function(a, e) {
+                return a + (e.type == "checkbox" ? (e.checked ? parseInt(e.value) : 0) : parseInt(e.value) || 0);
+            }, 0);
+            var totalInCart = countInCart ? $inputs.toArray().reduce(function(a, e) {
+                return a + parseInt(e.getAttribute("already-in-cart") || 0);
+            }, 0) : 0;
+            var total = totalSelected + totalInCart;
             if (max === 1) {
                 if (e.target.checked) {
-                    $inputs.filter(":checked").not(e.target).prop("checked", false).trigger("change");
+                    if (totalInCart > 0) {
+                        e.target.checked = false;
+                        //We don't care destroying this, since the only action that can be done is to remove the element from the cart, 
+                        // which triggers a page reload anyway
+                        showToolTip(e.target);
+                        e.preventDefault();
+                    } else {
+                        $inputs.filter(":checked").not(e.target).prop("checked", false).trigger("change");
+                    }
                 }
                 return;
             }
-            var total = $inputs.toArray().reduce(function(a, e) {
-                return a + (e.type == "checkbox" ? (e.checked ? parseInt(e.value) : 0) : parseInt(e.value) || 0);
-            }, 0);
             if (total > max) {
                 if (e.target.type == "checkbox") {
                     e.target.checked = false;
                 } else {
                     e.target.value = e.target.value - (total - max);
                 }
-                $(e.target).trigger("change").closest(".availability-box").tooltip({
-                    "title": desc,
-                }).tooltip('show');
+                showToolTip(e.target);
                 e.preventDefault();
             } else {
                 $(".availability-box", this).tooltip('destroy')
+            }
+
+            //This MUST be done after the tooltip, otherwise the total calculation would never show it in some cases (IE all other items = 0, this being increased using the + button)
+            var maxSelection = parseInt(e.target.getAttribute("max-selection")) || max;
+            var value = parseInt(e.target.value) || 0;
+            if (value > maxSelection) {
+                e.target.value = maxSelection;
             }
         });
     });


### PR DESCRIPTION
This is a followup of my old PR #4662:
I've generalized the max-item-count frontend checks used in the add-on page and made them work also on the first shop page. This makes the checks for "Maximum number of items per order" work client-side as well and not validated only after an user clicks for adding products to their cart.

Contrary to what I have done in the previous PR, now I don't disable the buttons, but, instead, make a tooltip appear like in the add-on selection. I've also fixed a small bug with that tooltip: Previously if, in a category, all products but one had 0 quantity, multiple selection per add-on category was permitted, the quantity for that single selected product already reached `c.max_count` and the user presses "+", no tooltip was displayed. This has been fixed by setting the upper bound javascript side, and this works also for the first shop page.

This PR changed the name of the attributes used for this checks to a more generalized one, and added a new one, `data-count-in-cart`: If present on a fieldset, it makes the check count as well the number of products from that fieldset already in the cart. 
Finally, it also hides the "+" from the cart's selection if we have already reached the maximum items per order