### PR TITLE
Add Stripe per-method fee overrides

### DIFF
--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -39,7 +39,7 @@ import urllib.parse
 import zoneinfo
 from collections import OrderedDict
 from datetime import datetime
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from json import JSONDecodeError
 
 import stripe
@@ -75,6 +75,7 @@ from pretix.base.views.redirect import safelink
 from pretix.helpers import OF_SELF
 from pretix.helpers.countries import CachedCountries
 from pretix.helpers.http import get_client_ip
+from pretix.helpers.money import DecimalTextInput
 from pretix.helpers.urls import mainreverse_absolute
 from pretix.multidomain.urlreverse import eventreverse_absolute
 from pretix.plugins.stripe.forms import StripeKeyValidator
@@ -85,6 +86,27 @@ from pretix.plugins.stripe.tasks import (
     get_stripe_account_key, stripe_verify_domain,
 )
 from pretix.presale.views.cart import cart_session
+
+# Must stay in sync with method_* toggles in StripeSettingsHolder.settings_form_fields.
+STRIPE_METHOD_FEE_STEMS = (
+    'card',
+    'ideal',
+    'alipay',
+    'bancontact',
+    'sepa_debit',
+    'eps',
+    'multibanco',
+    'przelewy24',
+    'pay_by_bank',
+    'wechatpay',
+    'revolut_pay',
+    'promptpay',
+    'swish',
+    'twint',
+    'affirm',
+    'klarna',
+    'mobilepay',
+)
 
 logger = logging.getLogger('pretix.plugins.stripe')
 
@@ -231,6 +253,78 @@ class StripeSettingsHolder(BasePaymentProvider):
                   'and to process asynchronous payment methods like SOFORT.'),
                 mainreverse_absolute('plugins:stripe:webhook')
             )
+
+    def _method_has_fee_override(self, stem):
+        return (
+            self.settings.get('method_{}_fee_abs'.format(stem), as_type=Decimal) is not None or
+            self.settings.get('method_{}_fee_percent'.format(stem), as_type=Decimal) is not None
+        )
+
+    def _method_fee_override_fields(self, stem, method_label):
+        places = settings.CURRENCY_PLACES.get(self.event.currency, 2)
+        method_dep = '#id_payment_stripe_method_{}'.format(stem)
+        custom_dep = '#id_payment_stripe_method_{}_fee_custom'.format(stem)
+        nested = 'stripe-method-fee-nested'
+        return [
+            ('method_{}_fee_custom'.format(stem),
+             forms.BooleanField(
+                 label=_('Customize payment fee'),
+                 help_text=_('Override the default Stripe fees below for {method}. Leave individual fields empty to '
+                             'keep the default for that part.').format(method=method_label),
+                 required=False,
+                 initial=self._method_has_fee_override(stem),
+                 widget=forms.CheckboxInput(attrs={
+                     'class': nested,
+                     'data-display-dependency': method_dep,
+                 }),
+             )),
+            ('method_{}_fee_abs'.format(stem),
+             forms.DecimalField(
+                 label=_('Absolute fee'),
+                 help_text=_('Leave empty to use the default absolute fee.'),
+                 localize=True,
+                 required=False,
+                 decimal_places=places,
+                 widget=DecimalTextInput(places=places, attrs={
+                     'class': '{} stripe-method-fee-value'.format(nested),
+                     'data-display-dependency': custom_dep,
+                     'addon_after': self.event.currency,
+                     'placeholder': _('default'),
+                 }),
+             )),
+            ('method_{}_fee_percent'.format(stem),
+             forms.DecimalField(
+                 label=_('Percent fee'),
+                 help_text=_('Leave empty to use the default percent fee.'),
+                 localize=True,
+                 required=False,
+                 widget=forms.TextInput(attrs={
+                     'class': '{} stripe-method-fee-value'.format(nested),
+                     'data-display-dependency': custom_dep,
+                     'addon_after': '%',
+                     'placeholder': _('default'),
+                 }),
+             )),
+        ]
+
+    def settings_form_clean(self, cleaned_data):
+        prefix = self.settings.get_prefix()
+        for stem in STRIPE_METHOD_FEE_STEMS:
+            base = prefix + 'method_' + stem
+            custom_key = base + '_fee_custom'
+            abs_key = base + '_fee_abs'
+            percent_key = base + '_fee_percent'
+            method_on = cleaned_data.get(base)
+            custom_on = cleaned_data.get(custom_key)
+            both_empty = cleaned_data.get(abs_key) is None and cleaned_data.get(percent_key) is None
+            if not method_on or not custom_on or both_empty:
+                # Delete custom bit too so freeze can't pin a lying False
+                cleaned_data[custom_key] = None
+                cleaned_data[abs_key] = None
+                cleaned_data[percent_key] = None
+            else:
+                cleaned_data[custom_key] = True
+        return cleaned_data
 
     @property
     def settings_form_fields(self):
@@ -540,6 +634,25 @@ class StripeSettingsHolder(BasePaymentProvider):
                 #  )),
             ] + extra_fields + list(super().settings_form_fields.items()) + moto_settings
         )
+        d_with_fees = OrderedDict()
+        for key, field in d.items():
+            d_with_fees[key] = field
+            if key.startswith('method_'):
+                stem = key[len('method_'):]
+                if stem in STRIPE_METHOD_FEE_STEMS:
+                    for fee_key, fee_field in self._method_fee_override_fields(stem, field.label):
+                        d_with_fees[fee_key] = fee_field
+        d = d_with_fees
+        if '_fee_abs' in d:
+            d['_fee_abs'].help_text = _(
+                'Absolute value. Default for all Stripe payment methods unless a method-specific fee is customized '
+                'above.'
+            )
+        if '_fee_percent' in d:
+            d['_fee_percent'].help_text = _(
+                'Percentage of the order total. Default for all Stripe payment methods unless a method-specific fee '
+                'is customized above.'
+            )
         if not self.settings.connect_client_id or self.settings.secret_key:
             d['connect_destination'] = forms.CharField(
                 label=_('Destination'),
@@ -563,6 +676,34 @@ class StripeMethod(BasePaymentProvider):
     def __init__(self, event: Event):
         super().__init__(event)
         self.settings = SettingsSandbox('payment', 'stripe', event)
+
+    @property
+    def method_config_key(self) -> str:
+        # Settings stems use identifier (przelewy24/wechatpay), not Stripe API types (p24/wechat_pay).
+        if self.identifier == 'stripe':
+            return 'card'
+        return self.identifier.removeprefix('stripe_')
+
+    def _resolved_fee_value(self, override_key: str, baseline_key: str) -> Decimal:
+        override = self.settings.get(override_key, as_type=Decimal)
+        if override is not None:
+            return override
+        return self.settings.get(baseline_key, as_type=Decimal, default=0)
+
+    def calculate_fee(self, price: Decimal) -> Decimal:
+        stem = self.method_config_key
+        fee_abs = self._resolved_fee_value('method_{}_fee_abs'.format(stem), '_fee_abs')
+        fee_percent = self._resolved_fee_value('method_{}_fee_percent'.format(stem), '_fee_percent')
+        fee_reverse_calc = self.settings.get('_fee_reverse_calc', as_type=bool, default=True)
+        places = settings.CURRENCY_PLACES.get(self.event.currency, 2)
+        if fee_reverse_calc:
+            return ((price + fee_abs) * (1 / (1 - fee_percent / 100)) - price).quantize(
+                Decimal('1') / 10 ** places, ROUND_HALF_UP
+            )
+        else:
+            return (price * fee_percent / 100 + fee_abs).quantize(
+                Decimal('1') / 10 ** places, ROUND_HALF_UP
+            )
 
     @property
     def test_mode_message(self):

--- a/src/pretix/plugins/stripe/signals.py
+++ b/src/pretix/plugins/stripe/signals.py
@@ -26,6 +26,7 @@ from django import forms
 from django.dispatch import receiver
 from django.http import HttpRequest
 from django.template.loader import get_template
+from django.templatetags.static import static
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from paypalhttp import HttpResponse
@@ -36,7 +37,7 @@ from pretix.base.settings import settings_hierarkey
 from pretix.base.signals import (
     logentry_display, register_global_settings, register_payment_providers,
 )
-from pretix.control.signals import nav_organizer
+from pretix.control.signals import html_head as control_html_head, nav_organizer
 from pretix.plugins.stripe.forms import StripeKeyValidator
 from pretix.presale.signals import html_head, process_response
 
@@ -79,6 +80,16 @@ def html_head_presale(sender, request=None, **kwargs):
         return template.render(ctx)
     else:
         return ""
+
+
+@receiver(control_html_head, dispatch_uid="stripe_control_html_head")
+def html_head_control(sender, request=None, **kwargs):
+    url = resolve(request.path_info)
+    if url.url_name == 'event.settings.payment.provider' and url.kwargs.get('provider') == 'stripe_settings':
+        return '<link rel="stylesheet" type="text/css" href="{}">'.format(
+            static('pretixplugins/stripe/control-fees.css')
+        )
+    return ''
 
 
 @receiver(signal=logentry_display, dispatch_uid="stripe_logentry_display")

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/control-fees.css
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/control-fees.css
@@ -1,0 +1,19 @@
+.form-plugins .form-group:has(.stripe-method-fee-nested) {
+    margin-bottom: 10px;
+}
+.form-plugins .form-group:has(.stripe-method-fee-nested) > .control-label {
+    font-weight: normal;
+    color: #555;
+}
+.form-plugins .form-group:has(input.stripe-method-fee-nested[type="checkbox"]) {
+    margin-top: -5px;
+    margin-bottom: 5px;
+}
+.form-plugins .form-group:has(.stripe-method-fee-nested) > .col-md-9,
+.form-plugins .form-group:has(.stripe-method-fee-nested) > [class*="col-"] {
+    padding-left: 40px;
+}
+.form-plugins .form-group:has(input.stripe-method-fee-value) {
+    margin-top: 0;
+    margin-bottom: 8px;
+}

--- a/src/tests/plugins/stripe/test_fees.py
+++ b/src/tests/plugins/stripe/test_fees.py
@@ -1,0 +1,430 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+import datetime
+import re
+from decimal import Decimal
+
+import pytest
+from django.db import transaction
+from django.utils.timezone import now
+from django_scopes import scope, scopes_disabled
+
+from pretix.base.models import (
+    CartPosition, Event, Item, ItemCategory, Order, OrderFee, OrderPosition,
+    Organizer, Quota,
+)
+from pretix.base.services.orders import change_payment_provider
+from pretix.plugins.stripe.payment import (
+    STRIPE_METHOD_FEE_STEMS, StripeCC, StripeKlarna, StripePrzelewy24,
+    StripeSettingsHolder, StripeWeChatPay,
+)
+from pretix.testutils.sessions import add_cart_session, get_cart_session_key
+
+
+@pytest.fixture
+def event():
+    o = Organizer.objects.create(name='Dummy', slug='dummy')
+    event = Event.objects.create(
+        organizer=o, name='Dummy', slug='dummy',
+        date_from=now(),
+        plugins='pretix.plugins.stripe',
+    )
+    with scope(organizer=o):
+        yield event
+
+
+def _set_baseline(event, abs='0.30', percent='2.90', reverse=False):
+    event.settings.set('payment_stripe__fee_abs', Decimal(abs))
+    event.settings.set('payment_stripe__fee_percent', Decimal(percent))
+    event.settings.set('payment_stripe__fee_reverse_calc', reverse)
+
+
+def _prefix(event):
+    return StripeSettingsHolder(event).settings.get_prefix()
+
+
+def _cleaned(event, *, enabled=None, methods=None, fees=None):
+    """Build a cleaned_data dict for settings_form_clean."""
+    prefix = _prefix(event)
+    data = {prefix + '_enabled': True}
+    for stem in STRIPE_METHOD_FEE_STEMS:
+        data[prefix + 'method_' + stem] = False
+        data[prefix + 'method_%s_fee_custom' % stem] = False
+        data[prefix + 'method_%s_fee_abs' % stem] = None
+        data[prefix + 'method_%s_fee_percent' % stem] = None
+    if enabled:
+        for stem in enabled:
+            data[prefix + 'method_' + stem] = True
+    if methods:
+        data.update(methods)
+    if fees:
+        for stem, values in fees.items():
+            if 'custom' in values:
+                data[prefix + 'method_%s_fee_custom' % stem] = values['custom']
+            if 'abs' in values:
+                data[prefix + 'method_%s_fee_abs' % stem] = values['abs']
+            if 'percent' in values:
+                data[prefix + 'method_%s_fee_percent' % stem] = values['percent']
+    return data
+
+
+def _apply_clean(event, cleaned):
+    cleaned = StripeSettingsHolder(event).settings_form_clean(cleaned)
+    for key, value in cleaned.items():
+        if value is None:
+            try:
+                del event.settings[key]
+            except KeyError:
+                pass
+        else:
+            event.settings.set(key, value)
+    return cleaned
+
+
+# --- calculate_fee ---
+
+@pytest.mark.django_db
+def test_baseline_shared_forward(event):
+    _set_baseline(event)
+    assert StripeCC(event).calculate_fee(Decimal('100.00')) == Decimal('3.20')
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('3.20')
+
+
+@pytest.mark.django_db
+def test_baseline_shared_reverse(event):
+    _set_baseline(event, reverse=True)
+    assert StripeCC(event).calculate_fee(Decimal('100.00')) == Decimal('3.30')
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('3.30')
+
+
+@pytest.mark.django_db
+def test_card_stem_override(event):
+    _set_baseline(event)
+    event.settings.set('payment_stripe_method_card_fee_percent', Decimal('10.00'))
+    assert StripeCC(event).method_config_key == 'card'
+    assert StripeCC(event).calculate_fee(Decimal('100.00')) == Decimal('10.30')
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('3.20')
+
+
+@pytest.mark.django_db
+def test_klarna_percent_override_inherits_abs(event):
+    _set_baseline(event)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('5.00'))
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('5.30')
+    assert StripeCC(event).calculate_fee(Decimal('100.00')) == Decimal('3.20')
+
+
+@pytest.mark.django_db
+def test_klarna_abs_override_inherits_percent(event):
+    _set_baseline(event)
+    event.settings.set('payment_stripe_method_klarna_fee_abs', Decimal('1.50'))
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('4.40')
+
+
+@pytest.mark.django_db
+def test_explicit_zero_abs_override(event):
+    _set_baseline(event)
+    event.settings.set('payment_stripe_method_klarna_fee_abs', Decimal('0.00'))
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('2.90')
+
+
+@pytest.mark.django_db
+def test_explicit_zero_percent_override(event):
+    _set_baseline(event)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('0.00'))
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('0.30')
+
+
+@pytest.mark.django_db
+def test_reverse_with_percent_only_override(event):
+    _set_baseline(event, abs='0.30', percent='2.90', reverse=True)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('5.00'))
+    # reverse: (100 + 0.30) / (1 - 0.05) - 100 = 100.30/0.95 - 100 = 5.578... → 5.58
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('5.58')
+    assert StripeCC(event).calculate_fee(Decimal('100.00')) == Decimal('3.30')
+
+
+@pytest.mark.django_db
+def test_reverse_with_abs_only_override(event):
+    _set_baseline(event, abs='0.30', percent='2.90', reverse=True)
+    event.settings.set('payment_stripe_method_klarna_fee_abs', Decimal('1.00'))
+    # reverse: (100 + 1) / (1 - 0.029) - 100 = 101/0.971 - 100 ≈ 4.02
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('4.02')
+
+
+@pytest.mark.django_db
+def test_both_overrides_with_baseline_reverse(event):
+    _set_baseline(event, abs='0.30', percent='2.90', reverse=False)
+    event.settings.set('payment_stripe_method_klarna_fee_abs', Decimal('1.00'))
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('10.00'))
+    event.settings.set('payment_stripe__fee_reverse_calc', True)
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('12.22')
+
+
+@pytest.mark.django_db
+def test_stem_przelewy24_and_wechatpay(event):
+    _set_baseline(event, abs='0.00', percent='1.00', reverse=False)
+    event.settings.set('payment_stripe_method_przelewy24_fee_percent', Decimal('3.00'))
+    event.settings.set('payment_stripe_method_wechatpay_fee_percent', Decimal('4.00'))
+    event.settings.set('payment_stripe_method_p24_fee_percent', Decimal('9.00'))
+    event.settings.set('payment_stripe_method_wechat_pay_fee_percent', Decimal('9.00'))
+
+    p24 = StripePrzelewy24(event)
+    wechat = StripeWeChatPay(event)
+    assert p24.method_config_key == 'przelewy24'
+    assert wechat.method_config_key == 'wechatpay'
+    assert p24.calculate_fee(Decimal('100.00')) == Decimal('3.00')
+    assert wechat.calculate_fee(Decimal('100.00')) == Decimal('4.00')
+
+
+@pytest.mark.django_db
+def test_fee_custom_not_read_at_runtime(event):
+    """fee_custom is a form latch; calculate_fee only looks at abs/percent keys."""
+    _set_baseline(event)
+    event.settings.set('payment_stripe_method_klarna_fee_custom', False)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('5.00'))
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == Decimal('5.30')
+
+
+# --- settings form ---
+
+@pytest.mark.django_db
+def test_form_exposes_fee_fields_for_all_stems(event):
+    fields = StripeSettingsHolder(event).settings_form_fields
+    keys = list(fields.keys())
+    for stem in STRIPE_METHOD_FEE_STEMS:
+        assert 'method_%s' % stem in fields
+        assert 'method_%s_fee_custom' % stem in fields
+        assert 'method_%s_fee_abs' % stem in fields
+        assert 'method_%s_fee_percent' % stem in fields
+        # Fee fields sit immediately after the method toggle
+        i = keys.index('method_%s' % stem)
+        assert keys[i + 1] == 'method_%s_fee_custom' % stem
+        assert keys[i + 2] == 'method_%s_fee_abs' % stem
+        assert keys[i + 3] == 'method_%s_fee_percent' % stem
+
+
+@pytest.mark.django_db
+def test_form_field_wiring(event):
+    fields = StripeSettingsHolder(event).settings_form_fields
+    custom = fields['method_klarna_fee_custom']
+    abs_f = fields['method_klarna_fee_abs']
+    pct_f = fields['method_klarna_fee_percent']
+    assert custom.widget.attrs['data-display-dependency'] == '#id_payment_stripe_method_klarna'
+    assert abs_f.widget.attrs['data-display-dependency'] == '#id_payment_stripe_method_klarna_fee_custom'
+    assert pct_f.widget.attrs['data-display-dependency'] == '#id_payment_stripe_method_klarna_fee_custom'
+    assert abs_f.widget.attrs['addon_after'] == event.currency
+    assert pct_f.widget.attrs['addon_after'] == '%'
+    assert 'customized' in str(fields['_fee_abs'].help_text).lower()
+    assert 'customized' in str(fields['_fee_percent'].help_text).lower()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('key,value', [
+    ('payment_stripe_method_klarna_fee_percent', Decimal('5.00')),
+    ('payment_stripe_method_klarna_fee_abs', Decimal('1.00')),
+])
+def test_fee_custom_initial_from_existing_override(event, key, value):
+    event.settings.set(key, value)
+    fields = StripeSettingsHolder(event).settings_form_fields
+    assert fields['method_klarna_fee_custom'].initial is True
+    assert fields['method_card_fee_custom'].initial is False
+
+
+@pytest.mark.django_db
+def test_clean_keeps_overrides_when_customized(event):
+    cleaned = _cleaned(
+        event,
+        enabled=['klarna'],
+        fees={'klarna': {'custom': True, 'abs': Decimal('1.00'), 'percent': Decimal('5.00')}},
+    )
+    cleaned = StripeSettingsHolder(event).settings_form_clean(cleaned)
+    prefix = _prefix(event)
+    assert cleaned[prefix + 'method_klarna_fee_custom'] is True
+    assert cleaned[prefix + 'method_klarna_fee_abs'] == Decimal('1.00')
+    assert cleaned[prefix + 'method_klarna_fee_percent'] == Decimal('5.00')
+
+
+@pytest.mark.django_db
+def test_clean_clears_when_method_disabled(event):
+    cleaned = _cleaned(
+        event,
+        enabled=['card'],
+        fees={
+            'klarna': {'custom': True, 'abs': Decimal('1.00'), 'percent': Decimal('5.00')},
+            'card': {'custom': True, 'percent': Decimal('2.00')},
+        },
+    )
+    # klarna method off (default in helper)
+    cleaned = StripeSettingsHolder(event).settings_form_clean(cleaned)
+    prefix = _prefix(event)
+    assert cleaned[prefix + 'method_klarna_fee_custom'] is None
+    assert cleaned[prefix + 'method_klarna_fee_abs'] is None
+    assert cleaned[prefix + 'method_klarna_fee_percent'] is None
+    assert cleaned[prefix + 'method_card_fee_custom'] is True
+    assert cleaned[prefix + 'method_card_fee_percent'] == Decimal('2.00')
+
+
+@pytest.mark.django_db
+def test_clean_clears_when_custom_unchecked(event):
+    cleaned = _cleaned(
+        event,
+        enabled=['klarna'],
+        fees={'klarna': {'custom': False, 'abs': Decimal('1.00'), 'percent': Decimal('5.00')}},
+    )
+    cleaned = StripeSettingsHolder(event).settings_form_clean(cleaned)
+    prefix = _prefix(event)
+    assert cleaned[prefix + 'method_klarna_fee_custom'] is None
+    assert cleaned[prefix + 'method_klarna_fee_abs'] is None
+    assert cleaned[prefix + 'method_klarna_fee_percent'] is None
+
+
+@pytest.mark.django_db
+def test_clean_clears_empty_customization(event):
+    cleaned = _cleaned(
+        event,
+        enabled=['klarna'],
+        fees={'klarna': {'custom': True, 'abs': None, 'percent': None}},
+    )
+    cleaned = StripeSettingsHolder(event).settings_form_clean(cleaned)
+    prefix = _prefix(event)
+    assert cleaned[prefix + 'method_klarna_fee_custom'] is None
+    assert cleaned[prefix + 'method_klarna_fee_abs'] is None
+    assert cleaned[prefix + 'method_klarna_fee_percent'] is None
+
+
+@pytest.mark.django_db
+def test_disabling_method_deletes_stored_overrides(event):
+    event.settings.set('payment_stripe_method_klarna', True)
+    event.settings.set('payment_stripe_method_klarna_fee_custom', True)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('5.00'))
+    event.settings.set('payment_stripe_method_klarna_fee_abs', Decimal('1.00'))
+
+    cleaned = _cleaned(
+        event,
+        enabled=['card'],
+        fees={'klarna': {'custom': True, 'abs': Decimal('1.00'), 'percent': Decimal('5.00')}},
+    )
+    _apply_clean(event, cleaned)
+
+    assert event.settings.get('payment_stripe_method_klarna_fee_abs', as_type=Decimal) is None
+    assert event.settings.get('payment_stripe_method_klarna_fee_percent', as_type=Decimal) is None
+    assert event.settings.get('payment_stripe_method_klarna_fee_custom', as_type=bool) is None
+    assert StripeKlarna(event).calculate_fee(Decimal('100.00')) == StripeCC(event).calculate_fee(Decimal('100.00'))
+
+
+# --- checkout / payment change ---
+
+@pytest.mark.django_db
+def test_checkout_shows_different_fees_per_method(client, monkeypatch):
+    class MockedAppleDomain:
+        livemode = True
+
+    monkeypatch.setattr("stripe.ApplePayDomain.create", lambda **kwargs: MockedAppleDomain())
+
+    orga = Organizer.objects.create(name='CCC', slug='ccc')
+    event = Event.objects.create(
+        organizer=orga, name='30C3', slug='30c3',
+        date_from=datetime.datetime(now().year + 1, 12, 26, tzinfo=datetime.timezone.utc),
+        plugins='pretix.plugins.stripe',
+        live=True,
+    )
+    category = ItemCategory.objects.create(event=event, name="Everything", position=0)
+    quota = Quota.objects.create(event=event, name='Tickets', size=5)
+    ticket = Item.objects.create(
+        event=event, name='Early-bird ticket', category=category, default_price=23, admission=True,
+    )
+    quota.items.add(ticket)
+    event.settings.set('attendee_names_asked', False)
+    event.settings.set('payment_stripe__enabled', True)
+    event.settings.set('payment_stripe_method_card', True)
+    event.settings.set('payment_stripe_method_klarna', True)
+    event.settings.set('payment_stripe_publishable_key', 'pk_test_dummy')
+    event.settings.set('payment_stripe_secret_key', 'sk_test_dummy')
+    event.settings.set('payment_stripe_merchant_country', 'DE')
+    _set_baseline(event, abs='1.00', percent='2.00', reverse=False)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('5.00'))
+
+    add_cart_session(client, event, {'email': 'admin@localhost'})
+    CartPosition.objects.create(
+        event=event, cart_id=get_cart_session_key(client, event), item=ticket,
+        price=23, expires=now() + datetime.timedelta(minutes=10),
+    )
+    client.post('/%s/%s/checkout/questions/' % (event.organizer.slug, event.slug), {
+        'email': 'admin@localhost',
+    }, follow=True)
+    response = client.get('/%s/%s/checkout/payment/' % (event.organizer.slug, event.slug), follow=True)
+    content = response.rendered_content
+
+    # card: 23*2%+1 = 1.46; klarna: 23*5%+1 = 2.15 — fee sits in the same panel heading as the radio
+    assert 'value="stripe"' in content
+    assert 'value="stripe_klarna"' in content
+    for provider, amount in (('stripe', '€1.46'), ('stripe_klarna', '€2.15')):
+        panel = re.search(
+            r'<fieldset[^>]*>.*?value="%s".*?</fieldset>' % re.escape(provider),
+            content,
+            re.DOTALL,
+        )
+        assert panel, 'missing payment panel for %s' % provider
+        assert amount in panel.group(0)
+
+
+@pytest.mark.django_db
+def test_change_payment_provider_applies_and_reverts_override(event):
+    with scopes_disabled():
+        ticket = Item.objects.create(event=event, name='Ticket', default_price=23, admission=True)
+        order = Order.objects.create(
+            code='FOOBAR', event=event, email='dummy@dummy.test',
+            status=Order.STATUS_PENDING,
+            datetime=now(), expires=now() + datetime.timedelta(days=10),
+            total=Decimal('23.00'),
+            sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        )
+        OrderPosition.objects.create(
+            order=order, item=ticket, variation=None, price=Decimal('23.00'),
+            attendee_name_parts={}, positionid=1,
+        )
+
+    _set_baseline(event, abs='1.00', percent='2.00', reverse=False)
+    event.settings.set('payment_stripe__enabled', True)
+    event.settings.set('payment_stripe_method_klarna', True)
+    event.settings.set('payment_stripe_method_card', True)
+    event.settings.set('payment_stripe_method_klarna_fee_percent', Decimal('5.00'))
+
+    with scope(organizer=event.organizer):
+        with transaction.atomic():
+            change_payment_provider(order, StripeKlarna(event))
+        order.refresh_from_db()
+        with scopes_disabled():
+            fee = order.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT)
+            assert fee.value == Decimal('2.15')
+            assert fee.internal_type == 'stripe_klarna'
+            assert order.total == Decimal('25.15')
+
+        with transaction.atomic():
+            change_payment_provider(order, StripeCC(event))
+        order.refresh_from_db()
+        with scopes_disabled():
+            fee = order.fees.get(fee_type=OrderFee.FEE_TYPE_PAYMENT)
+            assert fee.value == Decimal('1.46')
+            assert fee.internal_type == 'stripe'
+            assert order.total == Decimal('24.46')


### PR DESCRIPTION
This PR proposes adding support for overriding the base and variable fee for every Stripe method to account for more expensive methods such as Klarna.

Use case: we want incentivize credit card payments, but cannot individually customize fees for methods.

This is deliberately still phrased as a draft, as I'd love to figure out whether this is viable before adding e.g. translations, further tests, etc.

I tried to keep the edits minimal and chose not to abstract the fees logic away into it's own module, if the changes bloat the payment.py too much, I'd be happy to refactor it. 

AI declaration: the test file is entirely AI generated and wasn't checked thoroughly - obviously needs a manual rewrite if viable. I used Cursor with Gemini Pro 3.1 (Thinking) for sketching out the viability and fully reviewed and customized the output. Will further manually rewrite if proven viable, of course. I'm not unfamiliar with the plugin codebase so this should hopefully not smell 😅 

Thank you for taking the time to review the proposal :) 