### PR TITLE
Paypal2: handle incomming capture webhooks (Z#23240966)

### DIFF
--- a/src/pretix/plugins/paypal2/payment.py
+++ b/src/pretix/plugins/paypal2/payment.py
@@ -677,6 +677,8 @@ class PaypalMethod(BasePaymentProvider):
                 raise PaymentException(_('We had trouble communicating with PayPal'))
             else:
                 pp_captured_order = response.result
+                payment.info = json.dumps(pp_captured_order.dict())
+                payment.save()
 
             try:
                 ReferencedPayPalObject.objects.get_or_create(order=payment.order, payment=payment, reference=pp_captured_order.id)

--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -361,10 +361,13 @@ def webhook(request, *args, **kwargs):
         return HttpResponse("Not interested in this resource type", status=200)
 
     # Retrieve the Charge ID of the refunded payment
-    if event_json['resource_type'] == 'refund':
+    if event_json['resource_type'] == 'checkout-order':
+        payloadid = event_json['resource']['id']
+    elif event_json['resource_type'] == 'refund' or event_json['resource_type'] == 'capture':
         payloadid = get_link(event_json['resource']['links'], 'up')['href'].split('/')[-1]
     else:
-        payloadid = event_json['resource']['id']
+        logger.exception('Unknown webhook ressource received. Event data: %s' % str(event_json))
+        return HttpResponse("Unable to handle ressource", status=200)
 
     refs = [payloadid]
     if event_json['resource'].get('supplementary_data', {}).get('related_ids', {}).get('order_id'):

--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -357,17 +357,13 @@ def webhook(request, *args, **kwargs):
     if 'resource_type' not in event_json:
         return HttpResponse("Invalid body, no resource_type given", status=400)
 
-    if event_json['resource_type'] not in ["checkout-order", "refund", "capture"]:
-        return HttpResponse("Not interested in this resource type", status=200)
-
     # Retrieve the Charge ID of the refunded payment
     if event_json['resource_type'] == 'checkout-order':
         payloadid = event_json['resource']['id']
     elif event_json['resource_type'] == 'refund' or event_json['resource_type'] == 'capture':
         payloadid = get_link(event_json['resource']['links'], 'up')['href'].split('/')[-1]
     else:
-        logger.exception('Unknown webhook resource received. Event data: %s' % str(event_json))
-        return HttpResponse("Unable to handle resource", status=200)
+        return HttpResponse("Not interested in this resource type", status=200)
 
     refs = [payloadid]
     if event_json['resource'].get('supplementary_data', {}).get('related_ids', {}).get('order_id'):

--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -366,8 +366,8 @@ def webhook(request, *args, **kwargs):
     elif event_json['resource_type'] == 'refund' or event_json['resource_type'] == 'capture':
         payloadid = get_link(event_json['resource']['links'], 'up')['href'].split('/')[-1]
     else:
-        logger.exception('Unknown webhook ressource received. Event data: %s' % str(event_json))
-        return HttpResponse("Unable to handle ressource", status=200)
+        logger.exception('Unknown webhook resource received. Event data: %s' % str(event_json))
+        return HttpResponse("Unable to handle resource", status=200)
 
     refs = [payloadid]
     if event_json['resource'].get('supplementary_data', {}).get('related_ids', {}).get('order_id'):

--- a/src/pretix/plugins/paypal2/views.py
+++ b/src/pretix/plugins/paypal2/views.py
@@ -424,6 +424,8 @@ def webhook(request, *args, **kwargs):
         **event_json,
         '_order_state': sale.dict(),
     })
+    payment.info = json.dumps(sale.dict())
+    payment.save()
 
     if payment.state == OrderPayment.PAYMENT_STATE_CONFIRMED and sale['status'] in ('PARTIALLY_REFUNDED', 'REFUNDED', 'COMPLETED'):
         if event_json['resource_type'] == 'refund':

--- a/src/tests/plugins/paypal2/test_webhook.py
+++ b/src/tests/plugins/paypal2/test_webhook.py
@@ -22,6 +22,7 @@
 import json
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pytest
 from django.utils.timezone import now
@@ -409,7 +410,8 @@ def test_webhook_mark_paid(env, client, monkeypatch):
         order.payments.update(state=OrderPayment.PAYMENT_STATE_PENDING)
 
     pp_order = Result(get_test_order())
-    monkeypatch.setattr("paypalcheckoutsdk.orders.OrdersGetRequest", lambda *args: pp_order)
+    mock_orders_get_request = MagicMock(return_value=pp_order)
+    monkeypatch.setattr("paypalcheckoutsdk.orders.OrdersGetRequest", mock_orders_get_request)
     monkeypatch.setattr("pretix.plugins.paypal2.payment.PaypalMethod.init_api", init_api)
     with scopes_disabled():
         ReferencedPayPalObject.objects.create(order=order, payment=order.payments.first(),
@@ -497,7 +499,7 @@ def test_webhook_mark_paid(env, client, monkeypatch):
             "resource_version": "2.0"
         }
     ), content_type='application_json')
-
+    mock_orders_get_request.assert_called_once_with('806440346Y391300T')
     order.refresh_from_db()
     assert order.status == Order.STATUS_PAID
 


### PR DESCRIPTION
We have to handle webhooks differently depending on the incoming resource type.
In this case "capture" has its own id. We need to pry out the checkout-order id in order to look up the order object.

Additionally we store the payment info asap 