### PR TITLE
Event Settings: Make contact_url and imprint_url I18nURLField (Z#23238623)

### DIFF
--- a/doc/api/resources/events.rst
+++ b/doc/api/resources/events.rst
@@ -566,7 +566,7 @@ organizer level.
       Content-Type: application/json
 
       {
-        "imprint_url": "https://pretix.eu",
+        "region": "DE",
         …
       }
 
@@ -579,12 +579,14 @@ organizer level.
       Content-Type: application/json
 
       {
-        "imprint_url":
+        "locale":
           {
-            "value": "https://pretix.eu",
-            "label": "Imprint URL",
+            "value": "DE",
+            "label": "Region",
             "readonly": false,
-            "help_text": "This should point e.g. to a part of your website that has your contact details and legal information."
+            "help_text": "Will be used to determine date and time formatting as well as default country for customer
+                          addresses and phone numbers. For formatting, this takes less priority than the language and
+                          is therefore mostly relevant for languages used in different regions globally (like English)."
           }
         },
         …
@@ -620,7 +622,7 @@ organizer level.
       Content-Type: application/json
 
       {
-        "imprint_url": "https://example.org/imprint/"
+        "region": "DE"
       }
 
    **Example response**:
@@ -632,7 +634,7 @@ organizer level.
       Content-Type: application/json
 
       {
-        "imprint_url": "https://example.org/imprint/",
+        "region": "DE",
         …
       }
 

--- a/doc/api/resources/events.rst
+++ b/doc/api/resources/events.rst
@@ -579,7 +579,7 @@ organizer level.
       Content-Type: application/json
 
       {
-        "locale":
+        "region":
           {
             "value": "DE",
             "label": "Region",

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -2303,25 +2303,27 @@ DEFAULTS = {
     },
     'contact_url': {
         'default': None,
-        'type': str,
-        'serializer_class': serializers.URLField,
-        'form_class': forms.URLField,
+        'type': LazyI18nString,
+        'form_class': I18nURLFormField,
         'form_kwargs': dict(
             label=_("Contact URL"),
             help_text=_("If you set this, the footer contact link will point here instead of using the email address above. "
-                        "Please note that you still need to add a contact email address that will be shared with all emails you send.")
-        )
+                        "Please note that you still need to add a contact email address that will be shared with all emails you send."),
+            widget=I18nTextInput,
+        ),
+        'serializer_class': I18nURLField,
     },
     'imprint_url': {
         'default': None,
-        'type': str,
-        'form_class': forms.URLField,
+        'type': LazyI18nString,
+        'form_class': I18nURLFormField,
         'form_kwargs': dict(
             label=_("Imprint URL"),
             help_text=_("This should point e.g. to a part of your website that has your contact details and legal "
                         "information."),
+            widget=I18nTextInput,
         ),
-        'serializer_class': serializers.URLField,
+        'serializer_class': I18nURLField,
     },
     'privacy_url': {
         'default': None,

--- a/src/tests/api/test_events.py
+++ b/src/tests/api/test_events.py
@@ -1434,8 +1434,12 @@ def test_get_event_settings(token_client, organizer, event):
         '/api/v1/organizers/{}/events/{}/settings/'.format(organizer.slug, event.slug),
     )
     assert resp.status_code == 200
-    assert resp.data['imprint_url'] == "https://example.org"
-    assert resp.data['contact_url'] == "https://example.org/contact"
+    assert resp.data['imprint_url'] == {
+        "en": "https://example.org",
+    }
+    assert resp.data['contact_url'] == {
+        "en": "https://example.org/contact",
+    }
     assert resp.data['seating_allow_blocked_seats_for_channel'] == []
 
     resp = token_client.get(
@@ -1443,7 +1447,9 @@ def test_get_event_settings(token_client, organizer, event):
     )
     assert resp.status_code == 200
     assert resp.data['imprint_url'] == {
-        "value": "https://example.org",
+        "value": {
+            "en": "https://example.org",
+        },
         "label": "Imprint URL",
         "help_text": "This should point e.g. to a part of your website that has your contact details and legal "
                      "information.",
@@ -1478,8 +1484,12 @@ def test_patch_event_settings(token_client, organizer, event, team):
         format='json'
     )
     assert resp.status_code == 200
-    assert resp.data['contact_url'] == "https://example.com/contact"
-    assert resp.data['imprint_url'] == "https://example.com"
+    assert resp.data['contact_url'] == {
+        "en": "https://example.com/contact",
+    }
+    assert resp.data['imprint_url'] == {
+        "en": "https://example.com",
+    }
     assert resp.data['seating_allow_blocked_seats_for_channel'] == ['web']
     assert not resp.data['reusable_media_active']
     event.settings.flush()
@@ -1542,8 +1552,12 @@ def test_patch_event_settings(token_client, organizer, event, team):
         format='json'
     )
     assert resp.status_code == 200
-    assert resp.data['contact_url'] == "https://example.org/contact"
-    assert resp.data['imprint_url'] == "https://example.org"
+    assert resp.data['contact_url'] == {
+        "en": "https://example.org/contact",
+    }
+    assert resp.data['imprint_url'] == {
+        "en": "https://example.org",
+    }
     event.settings.flush()
     assert event.settings.contact_url == 'https://example.org/contact'
     assert event.settings.imprint_url == 'https://example.org'

--- a/src/tests/api/test_organizers.py
+++ b/src/tests/api/test_organizers.py
@@ -25,6 +25,8 @@ from datetime import datetime
 import pytest
 from django.core.files.base import ContentFile
 from django_scopes import scopes_disabled
+from i18nfield.strings import LazyI18nString
+
 from tests.const import SAMPLE_PNG
 
 TEST_ORGANIZER_RES = {
@@ -165,9 +167,11 @@ def test_patch_settings(token_client, organizer):
         format='json'
     )
     assert resp.status_code == 200
-    assert resp.data['contact_url'] == 'https://example.org/contact'
+    assert resp.data['contact_url'] == {
+        'en': 'https://example.org/contact',
+    }
     organizer.settings.flush()
-    assert organizer.settings.contact_url == 'https://example.org/contact'
+    assert organizer.settings.contact_url == LazyI18nString('https://example.org/contact')
 
     resp = token_client.patch(
         '/api/v1/organizers/{}/settings/'.format(organizer.slug),

--- a/src/tests/api/test_organizers.py
+++ b/src/tests/api/test_organizers.py
@@ -26,7 +26,6 @@ import pytest
 from django.core.files.base import ContentFile
 from django_scopes import scopes_disabled
 from i18nfield.strings import LazyI18nString
-
 from tests.const import SAMPLE_PNG
 
 TEST_ORGANIZER_RES = {


### PR DESCRIPTION
Also changing the docs to not use the imprint-URL. We could - but then we would need to either explain the whole "Single String in, Dict with default Event lang out" or "Dict in, Dict out"... Both not crazy concepts; but seemed easier to stay with a simple string.

Tests are adjusted to use "String in, Dict out".