### PR TITLE
Questions: set the _required attribute on the ModelMultipleChoiceField (Z#23244968)

### DIFF
--- a/src/pretix/base/forms/questions.py
+++ b/src/pretix/base/forms/questions.py
@@ -899,7 +899,7 @@ class BaseQuestionsForm(forms.Form):
             field.widget.attrs['data-question-dependency-values'] = escapejson_attr(json.dumps(q.dependency_values))
             if q.type != 'M':
                 field.widget.attrs['required'] = q.required and not self.all_optional
-                field._required = q.required and not self.all_optional
+            field._required = q.required and not self.all_optional
             field.required = False
         return field
 


### PR DESCRIPTION
setting _required forces the CheckoutFieldRenderer to add the "required" bit to the label. We only need to remove it from the widget attrs to avoid the html input field validation that would force us to check every single box