### PR TITLE
Payment step: Allow to postpone payment choice on some sales channels

### DIFF
--- a/src/pretix/base/models/orders.py
+++ b/src/pretix/base/models/orders.py
@@ -626,47 +626,14 @@ class Order(LockModel, LoggedModel):
         self.save(update_fields=['last_modified'])
 
     def set_expires(self, now_dt=None, subevents=None):
-        now_dt = now_dt or now()
-        tz = ZoneInfo(self.event.settings.timezone)
+        from pretix.base.services.payment import compute_payment_deadline
 
-        sales_channel_suffix = "_" + self.sales_channel.identifier.replace(".", "_")
-        if not (mode := self.event.settings.get(f'payment_term_mode{sales_channel_suffix}')):
-            mode = self.event.settings.get('payment_term_mode')
-            sales_channel_suffix = ""
-
-        if mode == 'days':
-            exp_by_date = now_dt.astimezone(tz) + timedelta(days=self.event.settings.get(f'payment_term_days{sales_channel_suffix}', as_type=int))
-            exp_by_date = exp_by_date.astimezone(tz).replace(hour=23, minute=59, second=59, microsecond=0)
-            if self.event.settings.get('payment_term_weekdays'):
-                if exp_by_date.weekday() == 5:
-                    exp_by_date += timedelta(days=2)
-                elif exp_by_date.weekday() == 6:
-                    exp_by_date += timedelta(days=1)
-        elif mode == 'minutes':
-            exp_by_date = now_dt.astimezone(tz) + timedelta(minutes=self.event.settings.get(f'payment_term_minutes{sales_channel_suffix}', as_type=int))
-        else:
-            raise ValueError("'payment_term_mode' has an invalid value '{}'.".format(mode))
-
-        self.expires = exp_by_date
-
-        term_last = self.event.settings.get('payment_term_last', as_type=RelativeDateWrapper)
-        if term_last:
-            if self.event.has_subevents and subevents:
-                terms = [
-                    term_last.datetime(se).date()
-                    for se in subevents
-                ]
-                if not terms:
-                    return
-                term_last = min(terms)
-            else:
-                term_last = term_last.datetime(self.event).date()
-            term_last = make_aware(datetime.combine(
-                term_last,
-                time(hour=23, minute=59, second=59)
-            ), tz)
-            if term_last < self.expires:
-                self.expires = term_last
+        self.expires = compute_payment_deadline(
+            event=self.event,
+            sales_channel=self.sales_channel,
+            now_dt=now_dt,
+            subevents=subevents,
+        )
 
     @cached_property
     def tax_total(self):

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -1605,6 +1605,7 @@ def add_payment_to_cart_session(cart_session, provider, min_value: Decimal=None,
         'max_value': str(max_value) if max_value is not None else None,
         'info_data': info_data or {},
     })
+    cart_session['payments_postpone'] = False
 
 
 def add_payment_to_cart(request, provider, min_value: Decimal=None, max_value: Decimal=None, info_data: dict=None):

--- a/src/pretix/base/services/orders.py
+++ b/src/pretix/base/services/orders.py
@@ -961,7 +961,7 @@ def _check_positions(event: Event, now_dt: datetime, time_machine_now_dt: dateti
 
 
 def _apply_rounding_and_fees(positions: List[CartPosition], payment_requests: List[dict], address: InvoiceAddress,
-                             meta_info: dict, event: Event, require_approval=False):
+                             meta_info: dict, event: Event, sales_channel: SalesChannel, require_approval=False):
     fees = []
     # Pre-rounding, pre-fee total is used for fee calculation
     total = sum([c.gross_price_before_rounding for c in positions])
@@ -1021,7 +1021,14 @@ def _apply_rounding_and_fees(positions: List[CartPosition], payment_requests: Li
         payments_assigned += to_pay
         p['payment_amount'] = to_pay
 
-    if total != payments_assigned and not require_approval:
+    allow_postponed_payment = (
+        require_approval or
+        (
+            sales_channel.identifier in event.settings.payment_choice_postpone_allowed_channels and not payment_requests
+        )
+    )
+
+    if total != payments_assigned and not allow_postponed_payment:
         raise OrderError(_("The selected payment methods do not cover the total balance."))
 
     return fees
@@ -1043,7 +1050,15 @@ def _create_order(event: Event, *, email: str, positions: List[CartPosition], no
 
     # Final calculation of fees, also performs final rounding
     try:
-        fees = _apply_rounding_and_fees(positions, payment_requests, address, meta_info, event, require_approval=require_approval)
+        fees = _apply_rounding_and_fees(
+            positions,
+            payment_requests,
+            address,
+            meta_info,
+            event,
+            sales_channel=sales_channel,
+            require_approval=require_approval
+        )
     except TaxRule.SaleNotAllowed:
         raise OrderError(error_messages['country_blocked'])
 

--- a/src/pretix/base/services/payment.py
+++ b/src/pretix/base/services/payment.py
@@ -1,0 +1,76 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from django.utils.timezone import make_aware, now
+
+from pretix.base.models import Event, SalesChannel
+from pretix.base.reldate import RelativeDateWrapper
+
+
+def compute_payment_deadline(event: Event, sales_channel: SalesChannel, now_dt=None, subevents=None) -> datetime:
+    now_dt = now_dt or now()
+    tz = ZoneInfo(event.settings.timezone)
+
+    sales_channel_suffix = "_" + sales_channel.identifier.replace(".", "_")
+    if not (mode := event.settings.get(f'payment_term_mode{sales_channel_suffix}')):
+        mode = event.settings.get('payment_term_mode')
+        sales_channel_suffix = ""
+
+    if mode == 'days':
+        exp_by_date = now_dt.astimezone(tz) + timedelta(
+            days=event.settings.get(f'payment_term_days{sales_channel_suffix}', as_type=int))
+        exp_by_date = exp_by_date.astimezone(tz).replace(hour=23, minute=59, second=59, microsecond=0)
+        if event.settings.get('payment_term_weekdays'):
+            if exp_by_date.weekday() == 5:
+                exp_by_date += timedelta(days=2)
+            elif exp_by_date.weekday() == 6:
+                exp_by_date += timedelta(days=1)
+    elif mode == 'minutes':
+        exp_by_date = now_dt.astimezone(tz) + timedelta(
+            minutes=event.settings.get(f'payment_term_minutes{sales_channel_suffix}', as_type=int))
+    else:
+        raise ValueError("'payment_term_mode' has an invalid value '{}'.".format(mode))
+
+    expires = exp_by_date
+
+    term_last = event.settings.get('payment_term_last', as_type=RelativeDateWrapper)
+    if term_last:
+        if event.has_subevents and subevents:
+            terms = [
+                term_last.datetime(se).date()
+                for se in subevents
+            ]
+            if not terms:
+                return expires
+            term_last = min(terms)
+        else:
+            term_last = term_last.datetime(event).date()
+        term_last = make_aware(datetime.combine(
+            term_last,
+            time(hour=23, minute=59, second=59)
+        ), tz)
+        if term_last < expires:
+            return term_last
+
+    return expires

--- a/src/pretix/base/settings.py
+++ b/src/pretix/base/settings.py
@@ -1159,6 +1159,19 @@ DEFAULTS = {
                         "configured above."),
         )
     },
+    'payment_choice_postpone_allowed_channels': {
+        'default': [],
+        'type': list,
+        'form_class': forms.MultipleChoiceField,
+        'form_kwargs': dict(
+            label=_('Allow postponed payment choice for sales channels'),
+            help_text=_("If postponed payment is allowed on a sales channel, customers can complete their order without "
+                        "selecting a payment method. This is useful whenever orders are not created by the same "
+                        "person who is making the payment."),
+            widget=forms.CheckboxSelectMultiple,
+            choices=[],
+        )
+    },
     'presale_start_show_date': {
         'default': 'True',
         'type': bool,

--- a/src/pretix/control/forms/event.py
+++ b/src/pretix/control/forms/event.py
@@ -855,14 +855,21 @@ class PaymentSettingsForm(EventSettingsValidationMixin, SettingsForm):
         'payment_term_accept_late',
         'payment_pending_hidden',
         'payment_explanation',
+        'payment_choice_postpone_allowed_channels',
         'tax_rule_payment',
     ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        channels = list(self.obj.organizer.sales_channels.all())
+        self.fields['payment_choice_postpone_allowed_channels'].choices = [
+            (c.identifier, c.label) for c in channels
+            if c.type_instance.payment_restrictions_supported
+        ]
+
         self.term_channel_fields = {}
-        for c in self.obj.organizer.sales_channels.all():
+        for c in channels:
             if c.type_instance.payment_restrictions_supported and c.identifier != "web":
                 # At the moment, it seems sufficient to allow this for the same channel types as other payment settings
                 # We can always introduce more flags later if needed

--- a/src/pretix/control/templates/pretixcontrol/event/payment.html
+++ b/src/pretix/control/templates/pretixcontrol/event/payment.html
@@ -109,6 +109,7 @@
                 {% bootstrap_form_errors form layout="control" %}
                 {% bootstrap_field form.tax_rule_payment layout="control" %}
                 {% bootstrap_field form.payment_explanation layout="control" %}
+                {% bootstrap_field form.payment_choice_postpone_allowed_channels layout="control" %}
             </fieldset>
         </div>
         {% if "event.settings.payment:write" in request.eventpermset %}

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -35,6 +35,7 @@ import copy
 import inspect
 import uuid
 from collections import defaultdict
+from datetime import time
 from decimal import Decimal
 
 from django import forms
@@ -52,6 +53,7 @@ from django.shortcuts import redirect
 from django.utils import translation
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape
+from django.utils.timezone import now
 from django.utils.translation import (
     get_language, gettext_lazy as _, pgettext_lazy,
 )
@@ -71,6 +73,7 @@ from pretix.base.services.cart import (
 from pretix.base.services.cross_selling import CrossSellingService
 from pretix.base.services.memberships import validate_memberships_in_order
 from pretix.base.services.orders import perform_order
+from pretix.base.services.payment import compute_payment_deadline
 from pretix.base.services.pricing import get_price
 from pretix.base.services.tasks import EventTask
 from pretix.base.settings import PERSON_NAME_SCHEMES
@@ -1344,6 +1347,11 @@ class PaymentStep(CartMixin, TemplateFlowStep):
         self.request = request
         self.request.pci_dss_payment_page = True
 
+        if "postpone" in request.POST and self._allow_postpone:
+            self.cart_session['payments_postpone'] = True
+            self.cart_session['payments'] = []
+            return redirect_to_url(self.get_next_url(request))
+
         if "remove_payment" in request.POST:
             self._remove_payment(request.POST["remove_payment"])
             return redirect_to_url(self.get_step_url(request))
@@ -1440,12 +1448,31 @@ class PaymentStep(CartMixin, TemplateFlowStep):
             ctx['selected'] = self.single_use_payment['provider']
         else:
             ctx['selected'] = ''
+
+        ctx['allow_postpone'] = self._allow_postpone
+        if self._allow_postpone:
+            now_dt = now()
+            ctx['payment_deadline'] = compute_payment_deadline(
+                event=self.request.event,
+                sales_channel=self.request.sales_channel,
+                subevents={p.subevent for p in ctx['cart']['raw']},
+                now_dt=now_dt,
+            )
+            if ctx['payment_deadline'].time() != time(hour=23, minute=59, second=59):
+                ctx['payment_deadline_minutes'] = int((ctx['payment_deadline'] - now_dt).total_seconds() // 60)
         return ctx
+
+    @cached_property
+    def _allow_postpone(self):
+        return self.request.sales_channel.identifier in self.request.event.settings.payment_choice_postpone_allowed_channels
 
     def _is_allowed(self, prov, request):
         return prov.is_allowed(request, total=self._total_order_value)
 
     def is_completed(self, request, warn=False):
+        if self.cart_session.get('payments_postpone') and self._allow_postpone:
+            return True
+
         if not self.cart_session.get('payments'):
             if warn:
                 messages.error(request, _('Please select a payment method to proceed.'))

--- a/src/pretix/presale/checkoutflow.py
+++ b/src/pretix/presale/checkoutflow.py
@@ -1440,10 +1440,12 @@ class PaymentStep(CartMixin, TemplateFlowStep):
         ctx['providers'] = self.provider_forms
         ctx['show_fees'] = any(p['fee'] for p in self.provider_forms)
 
-        if len(self.provider_forms) == 1:
-            ctx['selected'] = self.provider_forms[0]['provider'].identifier
-        elif 'payment' in self.request.POST:
+        if 'payment' in self.request.POST:
             ctx['selected'] = self.request.POST['payment']
+        elif self.cart_session.get('payments_postpone') and self._allow_postpone:
+            ctx['selected'] = ''
+        elif len(self.provider_forms) == 1:
+            ctx['selected'] = self.provider_forms[0]['provider'].identifier
         elif self.single_use_payment:
             ctx['selected'] = self.single_use_payment['provider']
         else:

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
@@ -128,6 +128,32 @@
                 {% endif %}
             </div>
         {% endif %}
+        {% if allow_postpone %}
+            <div class="panel panel-default">
+                <div class="panel-body row">
+                    <div class="col-md-9 col-xs-12">
+                        {% trans "Not sure yet? You can complete your order first and then select a payment method later." %}
+                        <br>
+                        <span class="text-muted">
+                            {% if payment_deadline_minutes %}
+                                {% blocktrans trimmed with minutes=payment_deadline_minutes %}
+                                    Your payment needs to be completed within {{ minutes }} minutes.
+                                {% endblocktrans %}
+                            {% else %}
+                                {% blocktrans trimmed with deadline=payment_deadline|date:"SHORT_DATE_FORMAT" %}
+                                    Your payment needs to be completed by {{ deadline }}.
+                                {% endblocktrans %}
+                            {% endif %}
+                        </span>
+                    </div>
+                    <div class="col-md-3 col-xs-12 text-right flip">
+                        <button name="postpone" value="on" class="btn btn-primary">
+                            {% trans "Proceed without selection" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
         <div class="row checkout-button-row">
             <div class="col-md-4 col-sm-6">
                 <a class="btn btn-block btn-default btn-lg"

--- a/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
+++ b/src/pretix/presale/templates/pretixpresale/event/checkout_payment.html
@@ -135,7 +135,9 @@
                         {% trans "Not sure yet? You can complete your order first and then select a payment method later." %}
                         <br>
                         <span class="text-muted">
-                            {% if payment_deadline_minutes %}
+                            {% if current_payments %}
+                                {% trans "To do so, please first remove the payment methods you already selected above." %}
+                            {% elif payment_deadline_minutes %}
                                 {% blocktrans trimmed with minutes=payment_deadline_minutes %}
                                     Your payment needs to be completed within {{ minutes }} minutes.
                                 {% endblocktrans %}
@@ -147,7 +149,8 @@
                         </span>
                     </div>
                     <div class="col-md-3 col-xs-12 text-right flip">
-                        <button name="postpone" value="on" class="btn btn-primary">
+                        <button name="postpone" value="on" class="btn btn-primary"
+                                {% if current_payments %}disabled{% endif %}>
                             {% trans "Proceed without selection" %}
                         </button>
                     </div>

--- a/src/tests/presale/test_checkout.py
+++ b/src/tests/presale/test_checkout.py
@@ -2372,6 +2372,39 @@ class CheckoutTestCase(BaseCheckoutTestCase, TimemachineTestMixin, TestCase):
             assert p2.fee.value == Decimal("0.46")
             assert o.total == Decimal("25.76")
 
+    def test_payment_postpone_not_allowed(self):
+        self.event.settings.set('payment_banktransfer__enabled', True)
+        with scopes_disabled():
+            CartPosition.objects.create(
+                event=self.event, cart_id=self.session_key, item=self.ticket,
+                price=23, expires=now() + timedelta(minutes=10)
+            )
+        response = self.client.post('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), {
+            'postpone': 'on',
+        }, follow=False)
+        assert 'Please select' in response.content.decode()
+
+    def test_payment_postpone_allowed(self):
+        self.event.settings.set('payment_banktransfer__enabled', True)
+        self.event.settings.payment_choice_postpone_allowed_channels = ['web']
+        with scopes_disabled():
+            CartPosition.objects.create(
+                event=self.event, cart_id=self.session_key, item=self.ticket,
+                price=23, expires=now() + timedelta(minutes=10)
+            )
+        response = self.client.post('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), {
+            'postpone': 'on',
+        }, follow=True)
+        self.assertRedirects(response, '/%s/%s/checkout/confirm/' % (self.orga.slug, self.event.slug),
+                             target_status_code=200)
+
+        response = self.client.post('/%s/%s/checkout/confirm/' % (self.orga.slug, self.event.slug), follow=True)
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        self.assertEqual(len(doc.select(".thank-you")), 1)
+        with scopes_disabled():
+            o = Order.objects.last()
+            assert not o.payments.exists()
+
     def test_premature_confirm(self):
         response = self.client.get('/%s/%s/checkout/confirm/' % (self.orga.slug, self.event.slug), follow=True)
         self.assertRedirects(response, '/%s/%s/?require_cookie=true' % (self.orga.slug, self.event.slug),

--- a/src/tests/presale/test_checkout.py
+++ b/src/tests/presale/test_checkout.py
@@ -2405,6 +2405,64 @@ class CheckoutTestCase(BaseCheckoutTestCase, TimemachineTestMixin, TestCase):
             o = Order.objects.last()
             assert not o.payments.exists()
 
+    def test_payment_postpone_cleared_on_selection(self):
+        self.event.settings.set('payment_banktransfer__enabled', True)
+        self.event.settings.payment_choice_postpone_allowed_channels = ['web']
+        with scopes_disabled():
+            CartPosition.objects.create(
+                event=self.event, cart_id=self.session_key, item=self.ticket,
+                price=23, expires=now() + timedelta(minutes=10)
+            )
+
+        response = self.client.post('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), {
+            'postpone': 'on',
+        }, follow=False)
+        self.assertRedirects(response, '/%s/%s/checkout/confirm/' % (self.orga.slug, self.event.slug),
+                             target_status_code=200)
+        assert self.client.session['carts'][self.session_key].get('payments_postpone')
+
+        # The only available provider must not be preselected while the choice is postponed
+        response = self.client.get('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), follow=True)
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        self.assertEqual(len(doc.select('input[name="payment"]')), 1)
+        self.assertEqual(len(doc.select('input[name="payment"][checked]')), 0)
+
+        # Selecting a payment method takes the order out of the postponed state again
+        response = self.client.post('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), {
+            'payment': 'banktransfer',
+        }, follow=False)
+        self.assertRedirects(response, '/%s/%s/checkout/confirm/' % (self.orga.slug, self.event.slug),
+                             target_status_code=200)
+        assert not self.client.session['carts'][self.session_key].get('payments_postpone')
+
+    def test_payment_postpone_disabled_with_partial_payment(self):
+        self.event.settings.set('payment_banktransfer__enabled', True)
+        self.event.settings.payment_choice_postpone_allowed_channels = ['web']
+        gc = self.orga.issued_gift_cards.create(currency="EUR")
+        gc.transactions.create(value=20, acceptor=self.orga)
+        with scopes_disabled():
+            CartPosition.objects.create(
+                event=self.event, cart_id=self.session_key, item=self.ticket,
+                price=23, expires=now() + timedelta(minutes=10)
+            )
+
+        response = self.client.get('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), follow=True)
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        self.assertEqual(len(doc.select('button[name="postpone"]')), 1)
+        self.assertEqual(len(doc.select('button[name="postpone"][disabled]')), 0)
+
+        # Apply a gift card that only covers part of the total
+        response = self.client.post('/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug), {
+            'payment': 'giftcard',
+            'payment_giftcard-code': gc.secret,
+        }, follow=True)
+        self.assertRedirects(response, '/%s/%s/checkout/payment/' % (self.orga.slug, self.event.slug),
+                             target_status_code=200)
+
+        # Postponing would silently drop the gift card, so it is no longer offered
+        doc = BeautifulSoup(response.content.decode(), "lxml")
+        self.assertEqual(len(doc.select('button[name="postpone"][disabled]')), 1)
+
     def test_premature_confirm(self):
         response = self.client.get('/%s/%s/checkout/confirm/' % (self.orga.slug, self.event.slug), follow=True)
         self.assertRedirects(response, '/%s/%s/?require_cookie=true' % (self.orga.slug, self.event.slug),


### PR DESCRIPTION
<img width="1170" height="698" alt="image" src="https://github.com/user-attachments/assets/67ad3a2d-de5e-4b2b-bc8e-e9f43792066e" />

Use case 1: pretix-resellers being used for telephone order or mail order and customer should receive a link without any started payment.

Use case 2: Target audience where usually the person who orders cannot make the payment decision but needs to forward the link internally.