### PR TITLE
Event header: Remove date directly above other date (Z#23245589)

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -135,9 +135,6 @@
         {% if event_logo and event_logo_show_title %}
             <h2 class="content-header">
                 {{ event.name }}
-                {% if request.event.settings.show_dates_on_frontpage %}
-                    <small>{{ event.get_date_range_display_as_html }}</small>
-                {% endif %}
             </h2>
         {% endif %}
         {% if frontpage_text %}

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -75,6 +75,9 @@ h3, .h3 {
 
 h2.content-header {
   margin-top: 0;
+  small {
+    white-space: nowrap;
+  }
 }
 
 @media (max-width: $screen-xs-max) {
@@ -85,6 +88,7 @@ h2.content-header {
   }
   h2.content-header small {
     display: block;
+    white-space: normal;
   }
 }
 @media (min-width: $screen-sm-min) {

--- a/src/pretix/static/pretixpresale/scss/_theme.scss
+++ b/src/pretix/static/pretixpresale/scss/_theme.scss
@@ -75,9 +75,6 @@ h3, .h3 {
 
 h2.content-header {
   margin-top: 0;
-  small {
-    white-space: nowrap;
-  }
 }
 
 @media (max-width: $screen-xs-max) {
@@ -88,7 +85,6 @@ h2.content-header {
   }
   h2.content-header small {
     display: block;
-    white-space: normal;
   }
 }
 @media (min-width: $screen-sm-min) {


### PR DESCRIPTION
This removes the date from the h2 option used when a header image is uploaded and the header should still be shown. Rendering the date here makes little sense, since the infobox with the date is always just a few lines below. It still makes sense for the h1 option where it becomes part of the site header.
