### PR TITLE
product image dialog: fix CSS to always fit image to viewport

### DIFF
--- a/src/pretix/static/pretixbase/scss/_dialogs.scss
+++ b/src/pretix/static/pretixbase/scss/_dialogs.scss
@@ -170,13 +170,14 @@ body.has-modal-dialog .container, body.has-modal-dialog #wrapper {
 #lightbox-dialog {
   width: fit-content;
   max-width: 80%;
-  min-width: 24em;
+  min-width: calc(min(24em, 90%));
   .modal-card-content {
     padding: 2.5em;
   }
 
   img {
     max-width: 100%;
+    max-height: calc(100dvh - 60px - 5em - 5em);
   }
 
   button {


### PR DESCRIPTION
Product images had no CSS max-height. On wide screens, the image would take full width and overflow the viewport at the bottom. This PR adds a maximum height so that images always fit into the viewport, regardless of height and width of screen and image.

## Before

<img width="2326" height="1034" alt="Screenshot 2026-09-07 at 14 50 42" src="https://github.com/user-attachments/assets/477064de-27c8-45ef-8409-d02b1b3872c0" />

## After

<img width="2327" height="837" alt="Screenshot 2026-09-07 at 14 51 02" src="https://github.com/user-attachments/assets/92d22f27-6979-4f16-9526-ceb56b0c58e7" />

