### PR TITLE
RRuleForm: allow selecting the fourth occurence of a weekday of a month (Z#23245893)

### DIFF
--- a/src/pretix/control/forms/rrule.py
+++ b/src/pretix/control/forms/rrule.py
@@ -87,6 +87,7 @@ class RRuleForm(forms.Form):
             ('1', pgettext_lazy('rrule', 'first')),
             ('2', pgettext_lazy('rrule', 'second')),
             ('3', pgettext_lazy('rrule', 'third')),
+            ('4', pgettext_lazy('rrule', 'fourth')),
             ('-1', pgettext_lazy('rrule', 'last')),
         ],
         required=False
@@ -134,6 +135,7 @@ class RRuleForm(forms.Form):
             ('1', pgettext_lazy('rrule', 'first')),
             ('2', pgettext_lazy('rrule', 'second')),
             ('3', pgettext_lazy('rrule', 'third')),
+            ('4', pgettext_lazy('rrule', 'fourth')),
             ('-1', pgettext_lazy('rrule', 'last')),
         ],
         required=False


### PR DESCRIPTION
The fourth often is the same as the last, but not always. A weekday can appear five times in a month