### PR TITLE
Sendmail: Fix performance issues (Z#23244045)

### DIFF
--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -367,50 +367,41 @@ class OrderSendView(BaseSenderView):
         )
 
         if form.cleaned_data.get('filter_checkins'):
-            ql = []
+            ci_filter = Q(pk__in=[])  # return nothing
 
             if form.cleaned_data.get('not_checked_in'):
                 opq = opq.alias(
                     any_checkins=Exists(
-                        Checkin.all.filter(
+                        Checkin.objects.filter(
                             position_id=OuterRef('pk'),
-                            successful=True,
                             list__consider_tickets_used=True,
                         )
                     ) | Exists(
-                        Checkin.all.filter(
+                        Checkin.objects.filter(
                             position__addon_to_id=OuterRef('pk'),
-                            successful=True,
                             list__consider_tickets_used=True,
                         )
                     )
                 )
-                ql.append(Q(any_checkins=False))
+                ci_filter |= Q(any_checkins=False)
 
             if form.cleaned_data.get('checkin_lists'):
                 opq = opq.alias(
                     matching_checkins=Exists(
-                        Checkin.all.filter(
+                        Checkin.objects.filter(
                             position_id=OuterRef('pk'),
                             list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
-                            successful=True
                         )
                     ) | Exists(
-                        Checkin.all.filter(
+                        Checkin.objects.filter(
                             position__addon_to_id=OuterRef('pk'),
                             list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
-                            successful=True
                         )
                     )
                 )
-                ql.append(Q(matching_checkins=True))
+                ci_filter |= Q(matching_checkins=True)
 
-            if len(ql) == 2:
-                opq = opq.filter(ql[0] | ql[1])
-            elif ql:
-                opq = opq.filter(ql[0])
-            else:
-                opq = opq.none()
+            opq = opq.filter(ci_filter)
 
         if form.cleaned_data.get('subevent'):
             opq = opq.filter(subevent=form.cleaned_data.get('subevent'))

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -373,24 +373,38 @@ class OrderSendView(BaseSenderView):
                 opq = opq.alias(
                     any_checkins=Exists(
                         Checkin.all.filter(
-                            Q(position_id=OuterRef('pk')) | Q(position__addon_to_id=OuterRef('pk')),
+                            position_id=OuterRef('pk'),
+                            successful=True,
+                            list__consider_tickets_used=True,
+                        )
+                    ) | Exists(
+                        Checkin.all.filter(
+                            position__addon_to_id=OuterRef('pk'),
                             successful=True,
                             list__consider_tickets_used=True,
                         )
                     )
                 )
                 ql.append(Q(any_checkins=False))
+
             if form.cleaned_data.get('checkin_lists'):
                 opq = opq.alias(
                     matching_checkins=Exists(
                         Checkin.all.filter(
-                            Q(position_id=OuterRef('pk')) | Q(position__addon_to_id=OuterRef('pk')),
+                            position_id=OuterRef('pk'),
+                            list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
+                            successful=True
+                        )
+                    ) | Exists(
+                        Checkin.all.filter(
+                            position__addon_to_id=OuterRef('pk'),
                             list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
                             successful=True
                         )
                     )
                 )
                 ql.append(Q(matching_checkins=True))
+
             if len(ql) == 2:
                 opq = opq.filter(ql[0] | ql[1])
             elif ql:

--- a/src/pretix/plugins/sendmail/views.py
+++ b/src/pretix/plugins/sendmail/views.py
@@ -370,16 +370,18 @@ class OrderSendView(BaseSenderView):
             ci_filter = Q(pk__in=[])  # return nothing
 
             if form.cleaned_data.get('not_checked_in'):
+                consider_tickets_used_lists = list(self.request.event.checkin_lists.filter(consider_tickets_used=True).values_list("id", flat=True))
+
                 opq = opq.alias(
                     any_checkins=Exists(
-                        Checkin.objects.filter(
+                        Checkin.objects.with_scopes_disabled().filter(
                             position_id=OuterRef('pk'),
-                            list__consider_tickets_used=True,
+                            list_id__in=consider_tickets_used_lists,
                         )
                     ) | Exists(
-                        Checkin.objects.filter(
+                        Checkin.objects.with_scopes_disabled().filter(
                             position__addon_to_id=OuterRef('pk'),
-                            list__consider_tickets_used=True,
+                            list_id__in=consider_tickets_used_lists,
                         )
                     )
                 )
@@ -388,12 +390,12 @@ class OrderSendView(BaseSenderView):
             if form.cleaned_data.get('checkin_lists'):
                 opq = opq.alias(
                     matching_checkins=Exists(
-                        Checkin.objects.filter(
+                        Checkin.objects.with_scopes_disabled().filter(
                             position_id=OuterRef('pk'),
                             list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
                         )
                     ) | Exists(
-                        Checkin.objects.filter(
+                        Checkin.objects.with_scopes_disabled().filter(
                             position__addon_to_id=OuterRef('pk'),
                             list_id__in=[i.pk for i in form.cleaned_data.get('checkin_lists', [])],
                         )


### PR DESCRIPTION
when doing `Q(position_id=OuterRef('pk')) | Q(position__addon_to_id=OuterRef('pk'))` the database ignores the `pretixdroid_checkin_position_id` and `pretixbase_orderposition.addon_to_id` indices, instead doing an expensive sequential scan over the orderposition-table for every checkin. Splitting this up into two `Exists` fixes this.

This also adds a small optimization that pre-calculates the checkin-lists that `consider_tickets_used`, as this is usually a very small list that is otherwise recalculated by the database for every checkin considered.